### PR TITLE
feat: add anti-bot HEAD→GET fallback to check_links.py

### DIFF
--- a/check_links.py
+++ b/check_links.py
@@ -2,19 +2,87 @@
 
 Extracts and validates HTTP/HTTPS URLs from files, reporting status
 via structured logging. See LLD #11 for design rationale.
+Anti-bot fallback via network.py integration per LLD #1.
 """
 
-import http.client
 import re
-import ssl
-import time
-import urllib.error
-import urllib.request
+from typing import TypedDict
 
+from gh_link_auditor.network import check_url as network_check_url
+from gh_link_auditor.network import create_backoff_config, create_request_config, should_retry
 from src.logging_config import setup_logging
 
 # LLD §2.5 step 3.2: Module-level logger
 logger = setup_logging("check_links")
+
+
+# ---------------------------------------------------------------------------
+# LLD #1 — Anti-bot fallback data structures and helpers
+# ---------------------------------------------------------------------------
+
+
+class LinkCheckResult(TypedDict):
+    """Result of a link check with fallback metadata."""
+
+    url: str
+    status_code: int | None
+    method_used: str
+    fallback_used: bool
+    error: str | None
+
+
+def should_fallback_to_get(status_code: int) -> bool:
+    """Check if a HEAD response should trigger a GET fallback.
+
+    Delegates to ``network.should_retry`` and returns the ``try_get_fallback`` flag.
+
+    Args:
+        status_code: HTTP status code from a HEAD request.
+
+    Returns:
+        ``True`` if the status code warrants a GET fallback (e.g. 403, 405).
+    """
+    _retry, try_get = should_retry(status_code, None)
+    return try_get
+
+
+def log_fallback_attempt(url: str, head_status: int) -> None:
+    """Log that a GET fallback is being attempted for a URL.
+
+    Args:
+        url: The URL being checked.
+        head_status: The HTTP status code received from the HEAD request.
+    """
+    logger.info("HEAD returned %d for %s — falling back to GET", head_status, url)
+
+
+def check_link_with_fallback(url: str, timeout: int = 10) -> LinkCheckResult:
+    """Check a URL using network.check_url with HEAD→GET fallback.
+
+    Creates a ``RequestConfig`` with ``verify_ssl=False`` (matching the original
+    ``check_links`` behaviour) and delegates to ``network.check_url``.
+
+    Args:
+        url: The URL to check.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        A ``LinkCheckResult`` with status and fallback metadata.
+    """
+    req_cfg = create_request_config(timeout=float(timeout), verify_ssl=False)
+    result = network_check_url(url, request_config=req_cfg)
+
+    fallback_used = result["method"] == "GET"
+    if fallback_used:
+        log_fallback_attempt(url, 0)
+
+    return LinkCheckResult(
+        url=result["url"],
+        status_code=result["status_code"],
+        method_used=result["method"],
+        fallback_used=fallback_used,
+        error=result["error"],
+    )
 
 
 def find_urls(filepath: str) -> list[str]:
@@ -38,53 +106,39 @@ def find_urls(filepath: str) -> list[str]:
 
 
 def check_url(url: str, retries: int = 2) -> str:
+    """Check a single URL and return a human-readable status string.
+
+    Delegates to :func:`check_link_with_fallback` (which uses ``network.check_url``
+    with HEAD→GET fallback) and formats the result to match the original output.
+
+    Args:
+        url: The URL to validate.
+        retries: Maximum number of retries (maps to ``backoff_config.max_retries``).
+
+    Returns:
+        A formatted status string (e.g. ``"[  OK  ] (Code: 200) - https://…"``).
     """
-    Checks a single URL. Returns a status string.
-    Uses a standard User-Agent to avoid 403 Forbidden errors.
-    """
-    # Create a default SSL context that does not verify certs
-    # This helps avoid SSL certificate verification errors, which are common
-    # but don't necessarily mean the link is "broken" for our purposes.
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
+    req_cfg = create_request_config(timeout=10.0, verify_ssl=False)
+    backoff_cfg = create_backoff_config(max_retries=retries)
+    result = network_check_url(url, request_config=req_cfg, backoff_config=backoff_cfg)
 
-    headers = {
-        "User-Agent": (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/58.0.3029.110 Safari/537.36"
-        )
-    }
+    if result["method"] == "GET":
+        log_fallback_attempt(url, 0)
 
-    req = urllib.request.Request(url, headers=headers, method="HEAD")
+    status = result["status"]
+    code = result["status_code"]
 
-    for attempt in range(retries):
-        try:
-            # Set a 10-second timeout
-            with urllib.request.urlopen(req, timeout=10, context=ctx) as response:
-                return f"[  OK  ] (Code: {response.status}) - {url}"
-        except urllib.error.HTTPError as e:
-            # Server responded, but with an error code (404, 403, 500, etc.)
-            return f"[ ERROR ] (Code: {e.code}) - {url}"
-        except urllib.error.URLError as e:
-            # URL-related error (e.g., DNS failure, timeout)
-            if "timed out" in str(e.reason):
-                if attempt < retries - 1:
-                    time.sleep(1)  # Wait before retry
-                    continue  # Try again
-                return f"[ TIMEOUT ] - {url}"
-            return f"[ FAILED ] (Reason: {e.reason}) - {url}"
-        except (http.client.RemoteDisconnected, ConnectionResetError):
-            if attempt < retries - 1:
-                time.sleep(1)
-                continue
-            return f"[ DISCONNECTED ] - {url}"
-        except Exception as e:
-            # Catch-all for other issues (e.g., invalid URL format)
-            return f"[ INVALID ] (Error: {type(e).__name__}) - {url}"
-
-    return f"[ FAILED ] (All retries) - {url}"
+    if status == "ok":
+        return f"[  OK  ] (Code: {code}) - {url}"
+    if status == "timeout":
+        return f"[ TIMEOUT ] - {url}"
+    if status == "disconnected":
+        return f"[ DISCONNECTED ] - {url}"
+    if status == "error":
+        return f"[ ERROR ] (Code: {code}) - {url}"
+    if status == "failed":
+        return f"[ FAILED ] (Reason: {result['error']}) - {url}"
+    return f"[ INVALID ] (Error: {result['error']}) - {url}"
 
 
 def main():

--- a/tests/unit/test_check_links_fallback.py
+++ b/tests/unit/test_check_links_fallback.py
@@ -1,0 +1,133 @@
+"""Unit tests for check_links anti-bot fallback (LLD #1, §10.0).
+
+Tests the HEAD→GET fallback integration between check_links.py and network.py.
+Mock target: ``check_links.network_check_url`` (the imported alias).
+"""
+
+import logging
+from unittest.mock import patch
+
+from check_links import (
+    check_link_with_fallback,
+    check_url,
+    should_fallback_to_get,
+)
+from gh_link_auditor.network import RequestResult
+
+
+def _make_result(**overrides) -> RequestResult:
+    """Helper to build a ``RequestResult`` with sensible defaults."""
+    base: RequestResult = {
+        "url": "https://example.com",
+        "status": "ok",
+        "status_code": 200,
+        "method": "HEAD",
+        "response_time_ms": 42,
+        "retries": 0,
+        "error": None,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCheckLinksWithFallback:
+    """Tests T010–T050: check_link_with_fallback behaviour."""
+
+    # T010 — HEAD success → no fallback
+    def test_head_success_no_fallback(self):
+        result_from_network = _make_result(status="ok", status_code=200, method="HEAD")
+        with patch("check_links.network_check_url", return_value=result_from_network):
+            result = check_link_with_fallback("https://example.com")
+
+        assert result["status_code"] == 200
+        assert result["method_used"] == "HEAD"
+        assert result["fallback_used"] is False
+        assert result["error"] is None
+
+    # T020 — HEAD 403 → GET fallback succeeds
+    def test_head_403_triggers_get_fallback(self):
+        result_from_network = _make_result(status="ok", status_code=200, method="GET")
+        with patch("check_links.network_check_url", return_value=result_from_network):
+            result = check_link_with_fallback("https://example.com")
+
+        assert result["method_used"] == "GET"
+        assert result["fallback_used"] is True
+        assert result["status_code"] == 200
+
+    # T030 — HEAD 405 → GET fallback succeeds
+    def test_head_405_triggers_get_fallback(self):
+        result_from_network = _make_result(status="ok", status_code=200, method="GET")
+        with patch("check_links.network_check_url", return_value=result_from_network):
+            result = check_link_with_fallback("https://example.com")
+
+        assert result["method_used"] == "GET"
+        assert result["fallback_used"] is True
+
+    # T040 — HEAD 404 → no fallback, error returned
+    def test_head_404_no_fallback(self):
+        result_from_network = _make_result(
+            status="error", status_code=404, method="HEAD", error="HTTP 404",
+        )
+        with patch("check_links.network_check_url", return_value=result_from_network):
+            result = check_link_with_fallback("https://example.com")
+
+        assert result["status_code"] == 404
+        assert result["method_used"] == "HEAD"
+        assert result["fallback_used"] is False
+        assert result["error"] == "HTTP 404"
+
+    # T050 — GET fallback returns actual GET status code
+    def test_get_fallback_returns_get_status_code(self):
+        result_from_network = _make_result(
+            status="error", status_code=503, method="GET", error="HTTP 503",
+        )
+        with patch("check_links.network_check_url", return_value=result_from_network):
+            result = check_link_with_fallback("https://example.com")
+
+        assert result["status_code"] == 503
+        assert result["method_used"] == "GET"
+
+
+class TestShouldFallbackToGet:
+    """Tests T060–T080: should_fallback_to_get predicate."""
+
+    # T060 — 403 → True
+    def test_403_triggers_fallback(self):
+        assert should_fallback_to_get(403) is True
+
+    # T070 — 405 → True
+    def test_405_triggers_fallback(self):
+        assert should_fallback_to_get(405) is True
+
+    # T080 — 404 → False
+    def test_404_does_not_trigger_fallback(self):
+        assert should_fallback_to_get(404) is False
+
+
+class TestFallbackLogging:
+    """Test T090: fallback attempts are logged."""
+
+    # T090 — Fallback is logged
+    def test_fallback_is_logged(self, caplog):
+        result_from_network = _make_result(status="ok", status_code=200, method="GET")
+        with (
+            patch("check_links.network_check_url", return_value=result_from_network),
+            caplog.at_level(logging.INFO),
+        ):
+            check_link_with_fallback("https://example.com")
+
+        assert any("falling back to GET" in msg for msg in caplog.messages)
+
+
+class TestCheckUrlInterface:
+    """Test T100: check_url() output format unchanged."""
+
+    # T100 — Interface unchanged: string output format preserved
+    def test_check_url_returns_formatted_string(self):
+        result_from_network = _make_result(status="ok", status_code=200, method="HEAD")
+        with patch("check_links.network_check_url", return_value=result_from_network):
+            output = check_url("https://example.com")
+
+        assert "[  OK  ]" in output
+        assert "(Code: 200)" in output
+        assert "https://example.com" in output

--- a/tests/unit/test_check_url.py
+++ b/tests/unit/test_check_url.py
@@ -1,38 +1,58 @@
-"""Unit tests for URL checking logic."""
+"""Unit tests for URL checking logic.
 
-import urllib.error
-from unittest.mock import MagicMock, patch
+Updated to mock ``check_links.network_check_url`` after the refactor to
+delegate to ``network.check_url`` (LLD #1).
+"""
+
+from unittest.mock import patch
 
 from check_links import check_url
+from gh_link_auditor.network import RequestResult
+
+
+def _make_result(**overrides) -> RequestResult:
+    """Helper to build a ``RequestResult`` with sensible defaults."""
+    base: RequestResult = {
+        "url": "https://example.com",
+        "status": "ok",
+        "status_code": 200,
+        "method": "HEAD",
+        "response_time_ms": 42,
+        "retries": 0,
+        "error": None,
+    }
+    base.update(overrides)
+    return base
 
 
 class TestCheckUrl:
     def test_ok_returns_ok_status(self):
-        mock_response = MagicMock()
-        mock_response.status = 200
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch("check_links.urllib.request.urlopen", return_value=mock_response):
+        result_from_network = _make_result(status="ok", status_code=200, method="HEAD")
+        with patch("check_links.network_check_url", return_value=result_from_network):
             result = check_url("https://example.com")
         assert "[  OK  ]" in result
 
     def test_404_returns_error(self):
-        error = urllib.error.HTTPError(url="https://example.com", code=404, msg="Not Found", hdrs=None, fp=None)
-        with patch("check_links.urllib.request.urlopen", side_effect=error):
+        result_from_network = _make_result(
+            status="error", status_code=404, method="HEAD", error="HTTP 404",
+        )
+        with patch("check_links.network_check_url", return_value=result_from_network):
             result = check_url("https://example.com")
         assert "[ ERROR ]" in result
         assert "404" in result
 
     def test_timeout_returns_timeout_after_retries(self):
-        error = urllib.error.URLError(reason="timed out")
-        with patch("check_links.urllib.request.urlopen", side_effect=error):
-            with patch("check_links.time.sleep"):
-                result = check_url("https://example.com", retries=2)
+        result_from_network = _make_result(
+            status="timeout", status_code=None, method="HEAD", error="Request timed out",
+        )
+        with patch("check_links.network_check_url", return_value=result_from_network):
+            result = check_url("https://example.com", retries=2)
         assert "[ TIMEOUT ]" in result
 
     def test_dns_failure_returns_failed(self):
-        error = urllib.error.URLError(reason="Name or service not known")
-        with patch("check_links.urllib.request.urlopen", side_effect=error):
+        result_from_network = _make_result(
+            status="failed", status_code=None, method="HEAD", error="DNS resolution failed",
+        )
+        with patch("check_links.network_check_url", return_value=result_from_network):
             result = check_url("https://nonexistent.invalid")
         assert "[ FAILED ]" in result


### PR DESCRIPTION
## Summary

- Refactors `check_links.py` to delegate to `network.check_url()` instead of inline urllib logic, gaining HEAD→GET fallback on 403/405 responses with exponential backoff
- Adds LLD-specified API: `LinkCheckResult`, `should_fallback_to_get()`, `log_fallback_attempt()`, `check_link_with_fallback()`
- Preserves existing `check_url()` interface and output format; updates existing test mocks to match new delegation

## Test plan

- [x] 10 new tests in `test_check_links_fallback.py` (T010–T100 per LLD §10.0)
- [x] 4 existing tests in `test_check_url.py` updated and passing
- [x] All 144 tests pass (`poetry run pytest tests/ -v`)
- [x] Ruff lint clean on changed files

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)