### PR TITLE
feat: add maintainer policy checker module

### DIFF
--- a/src/gh_link_auditor/policy_checker.py
+++ b/src/gh_link_auditor/policy_checker.py
@@ -1,0 +1,245 @@
+"""Maintainer policy checker for gh-link-auditor.
+
+Checks repository CONTRIBUTING.md files for policy keywords that indicate
+whether automated PRs are welcome. See LLD #4 for design rationale.
+
+Deviations from LLD-004:
+- Synchronous (not async) to match the rest of the codebase.
+- Data structures kept in this module (not split into models/policy.py
+  and constants.py) to avoid over-engineering for a small module.
+"""
+
+from __future__ import annotations
+
+import re
+import urllib.error
+import urllib.request
+from enum import Enum
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from gh_link_auditor.state_db import StateDatabase
+
+from src.logging_config import setup_logging
+
+logger = setup_logging("policy_checker")
+
+
+# ---------------------------------------------------------------------------
+# Data structures (LLD §2.3)
+# ---------------------------------------------------------------------------
+
+
+class PolicyKeyword(Enum):
+    """Keywords recognised in CONTRIBUTING.md files."""
+
+    NO_BOT = "no-bot"
+    NO_PR = "no-pr"
+    TYPOS_WELCOME = "typos-welcome"
+    SKIP_DOC_PRS = "skip-doc-prs"
+    CONTACT_FIRST = "contact-first"
+
+
+class PolicyStatus(Enum):
+    """Outcome of a policy check."""
+
+    ALLOWED = "allowed"
+    BLOCKED = "policy-blacklisted"
+    UNKNOWN = "unknown"
+
+
+class PolicyCheckResult(TypedDict):
+    """Result of checking a repository's contribution policy."""
+
+    repo_url: str
+    contributing_found: bool
+    contributing_path: str | None
+    keywords_found: list[PolicyKeyword]
+    is_blocked: bool
+    block_reason: str | None
+    status: PolicyStatus
+
+
+# Keywords that cause a repository to be blocked.
+_BLOCKING_KEYWORDS = frozenset({
+    PolicyKeyword.NO_BOT,
+    PolicyKeyword.NO_PR,
+    PolicyKeyword.SKIP_DOC_PRS,
+    PolicyKeyword.CONTACT_FIRST,
+})
+
+# Locations to check for CONTRIBUTING.md (in priority order).
+_CONTRIBUTING_PATHS = [
+    "CONTRIBUTING.md",
+    ".github/CONTRIBUTING.md",
+    "docs/CONTRIBUTING.md",
+]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_raw_url(url: str) -> str | None:
+    """Fetch raw text content from a URL.
+
+    Returns the content as a string, or ``None`` if the URL returns
+    a non-2xx status or a network error occurs.
+    """
+    try:
+        req = urllib.request.Request(url, method="GET", headers={
+            "User-Agent": "gh-link-auditor/0.1 policy-checker",
+        })
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            if 200 <= resp.status < 400:
+                return resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError):
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API (LLD §2.4)
+# ---------------------------------------------------------------------------
+
+
+def parse_policy_keywords(content: str) -> list[PolicyKeyword]:
+    """Parse CONTRIBUTING.md content for policy keywords.
+
+    Uses case-insensitive matching for all defined keywords.
+
+    Args:
+        content: Raw text content of a CONTRIBUTING.md file.
+
+    Returns:
+        List of matched ``PolicyKeyword`` values (may be empty).
+    """
+    found: list[PolicyKeyword] = []
+    lower = content.lower()
+    for kw in PolicyKeyword:
+        if re.search(re.escape(kw.value), lower):
+            found.append(kw)
+    return found
+
+
+def determine_block_status(
+    keywords: list[PolicyKeyword],
+) -> tuple[bool, str | None]:
+    """Determine if a repository should be blocked based on keywords found.
+
+    Blocking keywords take precedence over welcoming keywords.
+
+    Args:
+        keywords: List of keywords found in CONTRIBUTING.md.
+
+    Returns:
+        Tuple of ``(is_blocked, reason)``. ``reason`` is ``None`` when
+        not blocked.
+    """
+    for kw in keywords:
+        if kw in _BLOCKING_KEYWORDS:
+            return True, f"{kw.value} policy"
+    return False, None
+
+
+def fetch_contributing_content(repo_url: str) -> str | None:
+    """Fetch CONTRIBUTING.md content from a GitHub repository.
+
+    Tries multiple standard locations (root, ``.github/``, ``docs/``).
+    Returns content from the first location found, or ``None`` if the
+    file does not exist in any location.
+
+    Args:
+        repo_url: GitHub repository URL (e.g. ``https://github.com/org/repo``).
+
+    Returns:
+        File content as a string, or ``None`` if not found.
+    """
+    # Normalise repo URL: strip trailing slash, extract owner/repo
+    repo_url = repo_url.rstrip("/")
+    # Convert https://github.com/org/repo to raw content base URL
+    parts = repo_url.replace("https://github.com/", "").split("/")
+    if len(parts) < 2:
+        logger.warning("Invalid repo URL format: %s", repo_url)
+        return None
+    owner, repo = parts[0], parts[1]
+    base = f"https://raw.githubusercontent.com/{owner}/{repo}/HEAD"
+
+    for path in _CONTRIBUTING_PATHS:
+        url = f"{base}/{path}"
+        content = _fetch_raw_url(url)
+        if content is not None:
+            logger.info("Found %s for %s/%s", path, owner, repo)
+            return content
+
+    logger.info("No CONTRIBUTING.md found for %s/%s", owner, repo)
+    return None
+
+
+def check_repository_policy(repo_url: str) -> PolicyCheckResult:
+    """Check a repository's contribution policy before scanning.
+
+    Fetches CONTRIBUTING.md, parses for policy keywords, and returns
+    a structured result indicating whether the bot should proceed.
+
+    Args:
+        repo_url: GitHub repository URL.
+
+    Returns:
+        A ``PolicyCheckResult`` with block status and metadata.
+    """
+    content = fetch_contributing_content(repo_url)
+
+    if content is None:
+        return PolicyCheckResult(
+            repo_url=repo_url,
+            contributing_found=False,
+            contributing_path=None,
+            keywords_found=[],
+            is_blocked=False,
+            block_reason=None,
+            status=PolicyStatus.UNKNOWN,
+        )
+
+    keywords = parse_policy_keywords(content)
+    is_blocked, reason = determine_block_status(keywords)
+
+    if is_blocked:
+        status = PolicyStatus.BLOCKED
+    else:
+        status = PolicyStatus.ALLOWED
+
+    return PolicyCheckResult(
+        repo_url=repo_url,
+        contributing_found=True,
+        contributing_path="CONTRIBUTING.md",
+        keywords_found=keywords,
+        is_blocked=is_blocked,
+        block_reason=reason,
+        status=status,
+    )
+
+
+def log_policy_result(result: PolicyCheckResult, db: StateDatabase) -> None:
+    """Log a policy check result to the state database.
+
+    If the repository is blocked, adds it to the blacklist with reason
+    ``"policy-blacklisted"``.
+
+    Args:
+        result: The policy check result to log.
+        db: State database instance.
+    """
+    if result["is_blocked"]:
+        reason = result["block_reason"] or "policy-blacklisted"
+        db.add_to_blacklist(repo_url=result["repo_url"], reason=reason)
+        logger.info(
+            "Blacklisted %s: %s", result["repo_url"], reason,
+        )
+    else:
+        logger.info(
+            "Policy check passed for %s (status: %s)",
+            result["repo_url"],
+            result["status"].value,
+        )

--- a/tests/fixtures/contributing_samples/contributing_clean.md
+++ b/tests/fixtures/contributing_samples/contributing_clean.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Thank you for considering contributing to this project!
+
+## How to Contribute
+
+1. Fork the repository
+2. Create your feature branch
+3. Commit your changes
+4. Push to the branch
+5. Open a Pull Request
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions.

--- a/tests/fixtures/contributing_samples/contributing_contact.md
+++ b/tests/fixtures/contributing_samples/contributing_contact.md
@@ -1,0 +1,11 @@
+# Contributing to This Project
+
+We're happy to receive contributions, but please reach out first.
+
+**contact-first** — open an issue to discuss before submitting a PR.
+
+## Process
+
+1. Open an issue describing your proposed change
+2. Wait for maintainer feedback
+3. Submit a PR once approved

--- a/tests/fixtures/contributing_samples/contributing_mixed.md
+++ b/tests/fixtures/contributing_samples/contributing_mixed.md
@@ -1,0 +1,8 @@
+# Contributing
+
+We welcome documentation fixes! **typos-welcome**
+
+However, please be aware of the following policy:
+**no-bot** — automated pull requests are not accepted.
+
+If you have questions, please open an issue first.

--- a/tests/fixtures/contributing_samples/contributing_no_bot.md
+++ b/tests/fixtures/contributing_samples/contributing_no_bot.md
@@ -1,0 +1,11 @@
+# Contributing
+
+We welcome contributions from human developers!
+
+Please note: **no-bot** — we do not accept automated pull requests.
+
+## How to Contribute
+
+1. Fork the repository
+2. Create a feature branch
+3. Submit a pull request

--- a/tests/fixtures/contributing_samples/contributing_welcome.md
+++ b/tests/fixtures/contributing_samples/contributing_welcome.md
@@ -1,0 +1,11 @@
+# Contributing
+
+Thanks for your interest in contributing!
+
+We appreciate all kinds of contributions, including automated fixes.
+**typos-welcome** — we love it when bots fix our typos.
+
+## Guidelines
+
+- Keep PRs small and focused
+- Follow existing code style

--- a/tests/unit/test_policy_checker.py
+++ b/tests/unit/test_policy_checker.py
@@ -1,0 +1,259 @@
+"""Unit tests for maintainer policy checker (LLD #4, §10.0).
+
+TDD: Tests written BEFORE implementation. All tests should be RED until
+policy_checker.py is implemented.
+
+Mock target for HTTP fetching: ``policy_checker.network_check_url``
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from gh_link_auditor.policy_checker import (
+    PolicyCheckResult,
+    PolicyKeyword,
+    PolicyStatus,
+    check_repository_policy,
+    determine_block_status,
+    fetch_contributing_content,
+    parse_policy_keywords,
+)
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "contributing_samples"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_fixture(name: str) -> str:
+    """Read a fixture file and return its content."""
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _mock_fetch_result(content: str | None, status_code: int = 200):
+    """Build a network RequestResult for mocking fetch_contributing_content."""
+    from gh_link_auditor.network import RequestResult
+
+    if content is None:
+        return RequestResult(
+            url="https://raw.githubusercontent.com/org/repo/HEAD/CONTRIBUTING.md",
+            status="error",
+            status_code=404,
+            method="GET",
+            response_time_ms=50,
+            retries=0,
+            error="HTTP 404",
+        )
+    return RequestResult(
+        url="https://raw.githubusercontent.com/org/repo/HEAD/CONTRIBUTING.md",
+        status="ok",
+        status_code=status_code,
+        method="GET",
+        response_time_ms=50,
+        retries=0,
+        error=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# T010: Check CONTRIBUTING.md exists before scanning (REQ-1)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchContributing:
+    # T010
+    def test_check_contributing_file_exists(self):
+        """Verifies that fetch_contributing_content returns content when file exists."""
+        content = _read_fixture("contributing_clean.md")
+        with patch(
+            "gh_link_auditor.policy_checker._fetch_raw_url",
+            return_value=content,
+        ):
+            result = fetch_contributing_content("https://github.com/org/repo")
+        assert result is not None
+        assert "Contributing" in result
+
+    # T100: Fetch when file missing proceeds with scan (REQ-6)
+    def test_fetch_contributing_not_found_proceeds(self):
+        """Returns None and allows scan when CONTRIBUTING.md missing."""
+        with patch(
+            "gh_link_auditor.policy_checker._fetch_raw_url",
+            return_value=None,
+        ):
+            result = fetch_contributing_content("https://github.com/org/repo")
+        assert result is None
+
+    # T140: Fetch from root location (REQ-1)
+    def test_fetch_contributing_root(self):
+        """Fetches from root /CONTRIBUTING.md location."""
+        content = _read_fixture("contributing_clean.md")
+        with patch(
+            "gh_link_auditor.policy_checker._fetch_raw_url",
+            side_effect=lambda url: content if "CONTRIBUTING.md" in url else None,
+        ):
+            result = fetch_contributing_content("https://github.com/org/repo")
+        assert result is not None
+
+    # T150: Fetch from .github location (REQ-1)
+    def test_fetch_contributing_github_dir(self):
+        """Fetches from .github/CONTRIBUTING.md when root not found."""
+        content = _read_fixture("contributing_clean.md")
+
+        def _side_effect(url):
+            if ".github/CONTRIBUTING.md" in url:
+                return content
+            return None
+
+        with patch(
+            "gh_link_auditor.policy_checker._fetch_raw_url",
+            side_effect=_side_effect,
+        ):
+            result = fetch_contributing_content("https://github.com/org/repo")
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# T020–T060: Parse individual keywords (REQ-2)
+# ---------------------------------------------------------------------------
+
+
+class TestParseKeywords:
+    # T020
+    def test_parse_no_bot_keyword(self):
+        content = _read_fixture("contributing_no_bot.md")
+        keywords = parse_policy_keywords(content)
+        assert PolicyKeyword.NO_BOT in keywords
+
+    # T030
+    def test_parse_no_pr_keyword(self):
+        content = "We do not accept PRs from bots. no-pr policy applies."
+        keywords = parse_policy_keywords(content)
+        assert PolicyKeyword.NO_PR in keywords
+
+    # T040
+    def test_parse_typos_welcome_keyword(self):
+        content = _read_fixture("contributing_welcome.md")
+        keywords = parse_policy_keywords(content)
+        assert PolicyKeyword.TYPOS_WELCOME in keywords
+
+    # T050
+    def test_parse_skip_doc_prs_keyword(self):
+        content = "Please skip-doc-prs — we handle docs internally."
+        keywords = parse_policy_keywords(content)
+        assert PolicyKeyword.SKIP_DOC_PRS in keywords
+
+    # T060
+    def test_parse_contact_first_keyword(self):
+        content = _read_fixture("contributing_contact.md")
+        keywords = parse_policy_keywords(content)
+        assert PolicyKeyword.CONTACT_FIRST in keywords
+
+    # T090: Case insensitive matching (REQ-5)
+    def test_parse_case_insensitive(self):
+        content = "Policy: NO-BOT. Also No-Bot and no-bot."
+        keywords = parse_policy_keywords(content)
+        assert PolicyKeyword.NO_BOT in keywords
+
+    # T110: No keywords in content (REQ-2)
+    def test_parse_no_keywords(self):
+        content = _read_fixture("contributing_clean.md")
+        keywords = parse_policy_keywords(content)
+        assert keywords == []
+
+
+# ---------------------------------------------------------------------------
+# T070, T120, T130: Determine block status (REQ-3)
+# ---------------------------------------------------------------------------
+
+
+class TestDetermineBlockStatus:
+    # T070
+    def test_determine_blocked_for_blocking_keyword(self):
+        is_blocked, reason = determine_block_status([PolicyKeyword.NO_BOT])
+        assert is_blocked is True
+        assert reason is not None
+        assert "no-bot" in reason.lower() or "no_bot" in reason.lower()
+
+    # T120
+    def test_determine_allowed_typos_welcome(self):
+        is_blocked, reason = determine_block_status([PolicyKeyword.TYPOS_WELCOME])
+        assert is_blocked is False
+        assert reason is None
+
+    # T130: Mixed keywords — blocking wins (REQ-3)
+    def test_determine_blocked_mixed(self):
+        is_blocked, reason = determine_block_status(
+            [PolicyKeyword.TYPOS_WELCOME, PolicyKeyword.NO_BOT]
+        )
+        assert is_blocked is True
+
+
+# ---------------------------------------------------------------------------
+# T080: Log blacklisted result (REQ-4)
+# ---------------------------------------------------------------------------
+
+
+class TestLogPolicyResult:
+    # T080
+    def test_log_policy_blacklisted_status(self):
+        """Blocked result is logged to state database as policy-blacklisted."""
+        mock_db = MagicMock()
+        result = PolicyCheckResult(
+            repo_url="https://github.com/org/repo",
+            contributing_found=True,
+            contributing_path="CONTRIBUTING.md",
+            keywords_found=[PolicyKeyword.NO_BOT],
+            is_blocked=True,
+            block_reason="no-bot policy",
+            status=PolicyStatus.BLOCKED,
+        )
+        # Import here so we can call the logging function
+        from gh_link_auditor.policy_checker import log_policy_result
+
+        log_policy_result(result, mock_db)
+        mock_db.add_to_blacklist.assert_called_once()
+        call_kwargs = mock_db.add_to_blacklist.call_args
+        assert "policy" in str(call_kwargs).lower()
+
+
+# ---------------------------------------------------------------------------
+# T160, T170: Full flow integration (REQ-3, REQ-4, REQ-6)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRepositoryPolicy:
+    # T160: Full flow — blocked repo
+    def test_check_repository_policy_blocked(self):
+        content = _read_fixture("contributing_no_bot.md")
+        with patch(
+            "gh_link_auditor.policy_checker._fetch_raw_url",
+            return_value=content,
+        ):
+            result = check_repository_policy("https://github.com/org/repo")
+        assert result["is_blocked"] is True
+        assert result["status"] == PolicyStatus.BLOCKED
+        assert result["contributing_found"] is True
+
+    # T170: Full flow — allowed repo
+    def test_check_repository_policy_allowed(self):
+        content = _read_fixture("contributing_welcome.md")
+        with patch(
+            "gh_link_auditor.policy_checker._fetch_raw_url",
+            return_value=content,
+        ):
+            result = check_repository_policy("https://github.com/org/repo")
+        assert result["is_blocked"] is False
+        assert result["status"] == PolicyStatus.ALLOWED
+
+    def test_check_repository_policy_unknown_no_file(self):
+        """When no CONTRIBUTING.md found, status is UNKNOWN and scan proceeds."""
+        with patch(
+            "gh_link_auditor.policy_checker._fetch_raw_url",
+            return_value=None,
+        ):
+            result = check_repository_policy("https://github.com/org/repo")
+        assert result["is_blocked"] is False
+        assert result["status"] == PolicyStatus.UNKNOWN
+        assert result["contributing_found"] is False


### PR DESCRIPTION
## Summary

- Adds `src/gh_link_auditor/policy_checker.py` — parses CONTRIBUTING.md for policy keywords (`no-bot`, `no-pr`, `skip-doc-prs`, `contact-first`, `typos-welcome`)
- Checks 3 standard locations (root, `.github/`, `docs/`), fail-open when no file found
- Integrates with `state_db.add_to_blacklist()` for repos with blocking keywords
- Sync API (deviation from LLD-004 async signatures to match existing codebase patterns)

## Test plan

- [x] 18 tests in `test_policy_checker.py` covering all LLD §10.0 scenarios (T010–T170) plus one extra
- [x] 5 fixture files in `tests/fixtures/contributing_samples/`
- [x] All 162 tests pass (`poetry run pytest tests/ -v`)
- [x] Ruff lint clean

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)