### PR TITLE
test: boost Issue #20 coverage to 97%

### DIFF
--- a/tests/unit/test_archive_client.py
+++ b/tests/unit/test_archive_client.py
@@ -6,9 +6,9 @@ Covers: ArchiveClient.get_latest_snapshot(), fetch_snapshot_content(),
         extract_title(), extract_content_summary()
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from gh_link_auditor.archive_client import ArchiveClient
+from gh_link_auditor.archive_client import ArchiveClient, _cdx_request, _fetch_url_content
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -176,3 +176,133 @@ class TestExtractContentSummary:
         summary = client.extract_content_summary(long_html)
         assert summary is not None
         assert len(summary) <= 500
+
+    def test_strips_script_and_style_tags(self):
+        """Script and style content is excluded from summary."""
+        html = "<html><body><script>var x=1;</script><style>.a{}</style><p>Visible</p></body></html>"
+        client = _make_client()
+        summary = client.extract_content_summary(html)
+        assert summary is not None
+        assert "var x" not in summary
+        assert "Visible" in summary
+
+    def test_empty_body_returns_none(self):
+        """HTML with no visible text returns None."""
+        html = "<html><body><script>only script</script></body></html>"
+        client = _make_client()
+        summary = client.extract_content_summary(html)
+        # May return None or very short string depending on parser
+        if summary:
+            assert "only script" not in summary
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (coverage for _cdx_request, _fetch_url_content)
+# ---------------------------------------------------------------------------
+
+
+class TestCdxRequest:
+    def test_cdx_request_success(self):
+        """_cdx_request returns decoded response body."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"response data"
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("gh_link_auditor.archive_client.urllib.request.urlopen", return_value=mock_resp):
+            result = _cdx_request("https://web.archive.org/cdx/search/cdx?url=test")
+        assert result == "response data"
+
+    def test_fetch_url_content_success(self):
+        """_fetch_url_content returns decoded HTML."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"<html>test</html>"
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("gh_link_auditor.archive_client.urllib.request.urlopen", return_value=mock_resp):
+            result = _fetch_url_content("https://web.archive.org/web/snapshot")
+        assert result == "<html>test</html>"
+
+    def test_fetch_url_content_error_returns_none(self):
+        """_fetch_url_content returns None on network error."""
+        with patch(
+            "gh_link_auditor.archive_client.urllib.request.urlopen",
+            side_effect=OSError("connection refused"),
+        ):
+            result = _fetch_url_content("https://bad.example.com")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# BS4 / regex fallback coverage
+# ---------------------------------------------------------------------------
+
+
+class TestRegexFallback:
+    def test_extract_title_regex_path(self):
+        """Exercise regex fallback for title extraction."""
+        client = _make_client()
+        with patch("gh_link_auditor.archive_client._HAS_BS4", False):
+            title = client.extract_title(SAMPLE_HTML)
+        assert title == "Installation Guide - Example"
+
+    def test_extract_title_regex_no_title(self):
+        """Regex fallback returns None when no title tag."""
+        client = _make_client()
+        with patch("gh_link_auditor.archive_client._HAS_BS4", False):
+            title = client.extract_title(SAMPLE_HTML_NO_TITLE)
+        assert title is None
+
+    def test_extract_title_regex_multiline(self):
+        """Regex fallback handles multiline title."""
+        html = "<html><head><title>\n  My Page\n</title></head></html>"
+        client = _make_client()
+        with patch("gh_link_auditor.archive_client._HAS_BS4", False):
+            title = client.extract_title(html)
+        assert title is not None
+        assert "My Page" in title
+
+    def test_extract_title_regex_empty_title(self):
+        """Regex fallback returns None for empty title tag."""
+        html = "<html><head><title>  </title></head></html>"
+        client = _make_client()
+        with patch("gh_link_auditor.archive_client._HAS_BS4", False):
+            title = client.extract_title(html)
+        assert title is None
+
+    def test_extract_content_summary_regex_path(self):
+        """Exercise regex fallback for content extraction."""
+        client = _make_client()
+        with patch("gh_link_auditor.archive_client._HAS_BS4", False):
+            summary = client.extract_content_summary(SAMPLE_HTML)
+        assert summary is not None
+        assert "Installation Guide" in summary
+        assert "<p>" not in summary
+
+    def test_extract_content_summary_regex_strips_scripts(self):
+        """Regex fallback strips script/style tags."""
+        html = "<html><body><script>bad</script><p>Good</p></body></html>"
+        client = _make_client()
+        with patch("gh_link_auditor.archive_client._HAS_BS4", False):
+            summary = client.extract_content_summary(html)
+        assert summary is not None
+        assert "bad" not in summary
+        assert "Good" in summary
+
+
+# ---------------------------------------------------------------------------
+# Edge: malformed CDX response
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedCDX:
+    def test_short_cdx_response_returns_none(self):
+        """CDX response with fewer than 7 fields returns None."""
+        client = _make_client()
+        with patch(
+            "gh_link_auditor.archive_client._cdx_request",
+            return_value="only three fields",
+        ):
+            result = client.get_latest_snapshot("https://example.com")
+        assert result is None

--- a/tests/unit/test_github_resolver.py
+++ b/tests/unit/test_github_resolver.py
@@ -6,9 +6,9 @@ Covers: GitHubResolver.is_github_url(), resolve_repo_redirect(),
         reconstruct_file_url(), _parse_github_url()
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from gh_link_auditor.github_resolver import GitHubResolver
+from gh_link_auditor.github_resolver import GitHubResolver, _github_api_get
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -162,3 +162,81 @@ class TestReconstructFileUrl:
         assert "new-owner" in result
         assert "new-repo" in result
         assert "file.txt" in result
+
+
+# ---------------------------------------------------------------------------
+# Internal _github_api_get coverage
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubApiGet:
+    def test_api_get_success(self):
+        """_github_api_get returns parsed JSON on success."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'{"full_name": "owner/repo"}'
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("gh_link_auditor.github_resolver.urllib.request.urlopen", return_value=mock_resp):
+            result = _github_api_get("https://api.github.com/repos/owner/repo")
+        assert result == {"full_name": "owner/repo"}
+
+    def test_api_get_with_token(self):
+        """_github_api_get includes auth header when token provided."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'{"full_name": "owner/repo"}'
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("gh_link_auditor.github_resolver.urllib.request.urlopen", return_value=mock_resp) as mock_open:
+            _github_api_get("https://api.github.com/repos/owner/repo", token="ghp_test123")
+        # Verify the request was made (token applied in Request headers)
+        mock_open.assert_called_once()
+
+    def test_api_get_404(self):
+        """_github_api_get returns None on 404."""
+        import urllib.error
+
+        err = urllib.error.HTTPError("url", 404, "Not Found", {}, None)
+        with patch("gh_link_auditor.github_resolver.urllib.request.urlopen", side_effect=err):
+            result = _github_api_get("https://api.github.com/repos/owner/gone")
+        assert result is None
+
+    def test_api_get_non_404_error(self):
+        """_github_api_get returns None on non-404 HTTP error."""
+        import urllib.error
+
+        err = urllib.error.HTTPError("url", 403, "Rate Limited", {}, None)
+        with patch("gh_link_auditor.github_resolver.urllib.request.urlopen", side_effect=err):
+            result = _github_api_get("https://api.github.com/repos/owner/repo")
+        assert result is None
+
+    def test_api_get_url_error(self):
+        """_github_api_get returns None on URLError."""
+        import urllib.error
+
+        with patch(
+            "gh_link_auditor.github_resolver.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("DNS failure"),
+        ):
+            result = _github_api_get("https://api.github.com/repos/owner/repo")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Token from env
+# ---------------------------------------------------------------------------
+
+
+class TestTokenFromEnv:
+    def test_reads_token_from_env(self):
+        """GitHubResolver reads GITHUB_TOKEN from environment."""
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_envtoken"}):
+            resolver = GitHubResolver()
+        assert resolver._token == "ghp_envtoken"
+
+    def test_explicit_token_overrides_env(self):
+        """Explicit token takes precedence over env."""
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_envtoken"}):
+            resolver = GitHubResolver(token="ghp_explicit")
+        assert resolver._token == "ghp_explicit"

--- a/tests/unit/test_link_detective.py
+++ b/tests/unit/test_link_detective.py
@@ -297,3 +297,241 @@ class TestDataStructures:
         )
         report = ForensicReport(dead_url="https://dead.com", http_status=404, investigation=inv)
         assert report.dead_url == "https://dead.com"
+
+
+# ---------------------------------------------------------------------------
+# Internal _fetch_page_content coverage
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPageContent:
+    def test_fetch_success(self):
+        """_fetch_page_content returns decoded content."""
+        from gh_link_auditor.link_detective import _fetch_page_content
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"page content"
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("gh_link_auditor.link_detective.urllib.request.urlopen", return_value=mock_resp):
+            result = _fetch_page_content("https://example.com")
+        assert result == "page content"
+
+    def test_fetch_error_returns_none(self):
+        """_fetch_page_content returns None on network error."""
+        from gh_link_auditor.link_detective import _fetch_page_content
+
+        with patch(
+            "gh_link_auditor.link_detective.urllib.request.urlopen",
+            side_effect=OSError("connection refused"),
+        ):
+            result = _fetch_page_content("https://bad.example.com")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# GitHub resolution path in pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubResolutionInPipeline:
+    def test_github_url_resolved(self):
+        """GitHub URL triggers GitHub resolution in pipeline."""
+        detective = _make_detective()
+        with (
+            patch.object(detective, "_redirect_resolver") as mock_rr,
+            patch.object(detective, "_archive_client", _mock_archive_miss()),
+            patch.object(detective, "_url_heuristic") as mock_uh,
+            patch.object(detective, "_github_resolver") as mock_gh,
+        ):
+            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
+            mock_rr.test_url_mutations.return_value = []
+            mock_rr.verify_live.return_value = True
+            mock_uh.generate_candidates.return_value = []
+            mock_uh.probe_candidates.return_value = []
+            mock_gh.is_github_url.return_value = True
+            mock_gh._parse_github_url.return_value = ("old-owner", "old-repo", "blob/main/README.md")
+            mock_gh.resolve_repo_redirect.return_value = "https://github.com/new-owner/new-repo"
+            mock_gh.reconstruct_file_url.return_value = (
+                "https://github.com/new-owner/new-repo/blob/main/README.md"
+            )
+
+            report = detective.investigate("https://github.com/old-owner/old-repo/blob/main/README.md", 404)
+
+        candidates = report.investigation.candidate_replacements
+        github_candidates = [c for c in candidates if c.method == InvestigationMethod.GITHUB_API_REDIRECT]
+        assert len(github_candidates) >= 1
+        assert github_candidates[0].similarity_score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Archive-only fallback path
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveOnlyFallback:
+    def test_archive_only_when_no_live_candidates(self):
+        """Archive-only fallback when snapshot exists but no live candidates."""
+        detective = _make_detective()
+        with (
+            patch.object(detective, "_redirect_resolver") as mock_rr,
+            patch.object(detective, "_archive_client", _mock_archive_hit()),
+            patch.object(detective, "_url_heuristic") as mock_uh,
+            patch.object(detective, "_github_resolver") as mock_gh,
+        ):
+            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
+            mock_rr.test_url_mutations.return_value = []
+            mock_rr.verify_live.return_value = False
+            mock_uh.generate_candidates.return_value = []
+            mock_uh.probe_candidates.return_value = []
+            mock_gh.is_github_url.return_value = False
+
+            report = detective.investigate("https://dead.example.com/page", 404)
+
+        candidates = report.investigation.candidate_replacements
+        archive_only = [c for c in candidates if c.method == InvestigationMethod.ARCHIVE_ONLY]
+        assert len(archive_only) >= 1
+        assert archive_only[0].verified_live is False
+        assert archive_only[0].similarity_score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# URL heuristic with content similarity
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicWithSimilarity:
+    def test_heuristic_below_threshold_excluded(self):
+        """Heuristic candidate with similarity < 0.5 is excluded."""
+        detective = _make_detective()
+        with (
+            patch.object(detective, "_redirect_resolver") as mock_rr,
+            patch.object(detective, "_archive_client", _mock_archive_hit()),
+            patch.object(detective, "_url_heuristic") as mock_uh,
+            patch.object(detective, "_github_resolver") as mock_gh,
+        ):
+            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
+            mock_rr.test_url_mutations.return_value = []
+            mock_rr.verify_live.return_value = False
+            mock_uh.generate_candidates.return_value = ["https://example.com/different"]
+            mock_uh.probe_candidates.return_value = ["https://example.com/different"]
+            mock_gh.is_github_url.return_value = False
+
+            with (
+                patch(
+                    "gh_link_auditor.link_detective._fetch_page_content",
+                    return_value="Completely different content",
+                ),
+                patch(
+                    "gh_link_auditor.link_detective.compute_similarity",
+                    return_value=0.2,
+                ),
+            ):
+                report = detective.investigate("https://dead.example.com/page", 404)
+
+        heuristic_candidates = [
+            c for c in report.investigation.candidate_replacements
+            if c.method == InvestigationMethod.URL_HEURISTIC
+        ]
+        assert len(heuristic_candidates) == 0
+
+    def test_heuristic_no_content_uses_low_score(self):
+        """Heuristic candidate uses 0.3 score when page content unavailable."""
+        detective = _make_detective()
+        with (
+            patch.object(detective, "_redirect_resolver") as mock_rr,
+            patch.object(detective, "_archive_client", _mock_archive_hit()),
+            patch.object(detective, "_url_heuristic") as mock_uh,
+            patch.object(detective, "_github_resolver") as mock_gh,
+        ):
+            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
+            mock_rr.test_url_mutations.return_value = []
+            mock_rr.verify_live.return_value = False
+            mock_uh.generate_candidates.return_value = ["https://example.com/page"]
+            mock_uh.probe_candidates.return_value = ["https://example.com/page"]
+            mock_gh.is_github_url.return_value = False
+
+            with patch(
+                "gh_link_auditor.link_detective._fetch_page_content",
+                return_value=None,
+            ):
+                report = detective.investigate("https://dead.example.com/page", 404)
+
+        # Score 0.3 < 0.5 threshold, so candidate should NOT be included
+        heuristic_candidates = [
+            c for c in report.investigation.candidate_replacements
+            if c.method == InvestigationMethod.URL_HEURISTIC
+        ]
+        assert len(heuristic_candidates) == 0
+
+
+# ---------------------------------------------------------------------------
+# Error handling in pipeline stages
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineErrorHandling:
+    def test_mutation_error_continues(self):
+        """Exception in URL mutations doesn't stop the pipeline."""
+        detective = _make_detective()
+        with (
+            patch.object(detective, "_redirect_resolver") as mock_rr,
+            patch.object(detective, "_archive_client", _mock_archive_miss()),
+            patch.object(detective, "_url_heuristic") as mock_uh,
+            patch.object(detective, "_github_resolver") as mock_gh,
+        ):
+            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
+            mock_rr.test_url_mutations.side_effect = Exception("mutation error")
+            mock_uh.generate_candidates.return_value = []
+            mock_uh.probe_candidates.return_value = []
+            mock_gh.is_github_url.return_value = False
+
+            report = detective.investigate("https://example.com/page", 404)
+
+        assert isinstance(report, ForensicReport)
+        assert any("mutation" in entry.lower() for entry in report.investigation.investigation_log)
+
+    def test_archive_error_continues(self):
+        """Exception in archive lookup doesn't stop the pipeline."""
+        detective = _make_detective()
+        archive_mock = MagicMock()
+        archive_mock.get_latest_snapshot.side_effect = Exception("archive error")
+
+        with (
+            patch.object(detective, "_redirect_resolver") as mock_rr,
+            patch.object(detective, "_archive_client", archive_mock),
+            patch.object(detective, "_url_heuristic") as mock_uh,
+            patch.object(detective, "_github_resolver") as mock_gh,
+        ):
+            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
+            mock_rr.test_url_mutations.return_value = []
+            mock_uh.generate_candidates.return_value = []
+            mock_uh.probe_candidates.return_value = []
+            mock_gh.is_github_url.return_value = False
+
+            report = detective.investigate("https://example.com/page", 404)
+
+        assert isinstance(report, ForensicReport)
+        assert any("archive" in entry.lower() for entry in report.investigation.investigation_log)
+
+    def test_github_error_continues(self):
+        """Exception in GitHub resolution doesn't stop the pipeline."""
+        detective = _make_detective()
+        with (
+            patch.object(detective, "_redirect_resolver") as mock_rr,
+            patch.object(detective, "_archive_client", _mock_archive_miss()),
+            patch.object(detective, "_url_heuristic") as mock_uh,
+            patch.object(detective, "_github_resolver") as mock_gh,
+        ):
+            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
+            mock_rr.test_url_mutations.return_value = []
+            mock_uh.generate_candidates.return_value = []
+            mock_uh.probe_candidates.return_value = []
+            mock_gh.is_github_url.return_value = True
+            mock_gh._parse_github_url.side_effect = Exception("github error")
+
+            report = detective.investigate("https://github.com/owner/repo", 404)
+
+        assert isinstance(report, ForensicReport)
+        assert any("github" in entry.lower() for entry in report.investigation.investigation_log)

--- a/tests/unit/test_redirect_resolver.py
+++ b/tests/unit/test_redirect_resolver.py
@@ -6,11 +6,11 @@ Covers: RedirectResolver.follow_redirects(), test_url_mutations(),
         verify_live(), _validate_not_private_ip(), SSRFBlocked
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from gh_link_auditor.redirect_resolver import RedirectResolver, SSRFBlocked
+from gh_link_auditor.redirect_resolver import RedirectResolver, SSRFBlocked, _http_head
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -296,3 +296,143 @@ class TestVerifyLive:
             side_effect=Exception("connection failed"),
         ):
             assert resolver.verify_live("https://example.com") is False
+
+
+# ---------------------------------------------------------------------------
+# Internal _http_head coverage
+# ---------------------------------------------------------------------------
+
+
+class TestHttpHead:
+    def test_http_head_success(self):
+        """_http_head returns status_code and location on success."""
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.headers = MagicMock()
+        mock_resp.headers.get.return_value = None
+
+        mock_opener = MagicMock()
+        mock_opener.open.return_value = mock_resp
+
+        with patch("gh_link_auditor.redirect_resolver.urllib.request.build_opener", return_value=mock_opener):
+            result = _http_head("https://example.com")
+        assert result["status_code"] == 200
+
+    def test_http_head_http_error(self):
+        """_http_head returns status from HTTPError."""
+        import urllib.error
+
+        mock_headers = MagicMock()
+        mock_headers.get.return_value = "https://new.com"
+        err = urllib.error.HTTPError("https://old.com", 301, "Moved", mock_headers, None)
+
+        mock_opener = MagicMock()
+        mock_opener.open.side_effect = err
+
+        with patch("gh_link_auditor.redirect_resolver.urllib.request.build_opener", return_value=mock_opener):
+            result = _http_head("https://old.com")
+        assert result["status_code"] == 301
+        assert result["location"] == "https://new.com"
+
+    def test_http_head_url_error(self):
+        """_http_head returns None status on URLError."""
+        import urllib.error
+
+        mock_opener = MagicMock()
+        mock_opener.open.side_effect = urllib.error.URLError("DNS failure")
+
+        with patch("gh_link_auditor.redirect_resolver.urllib.request.build_opener", return_value=mock_opener):
+            result = _http_head("https://nonexistent.example.com")
+        assert result["status_code"] is None
+        assert result["location"] is None
+
+
+# ---------------------------------------------------------------------------
+# Additional mutation coverage
+# ---------------------------------------------------------------------------
+
+
+class TestUrlMutationsAdditional:
+    def test_remove_trailing_slash_mutation(self):
+        """Tests removing trailing slash."""
+        resolver = _make_resolver()
+
+        def _mock_head(url):
+            if url == "https://example.com/docs":
+                return {"status_code": 200, "location": None}
+            return {"status_code": 404, "location": None}
+
+        with patch("gh_link_auditor.redirect_resolver._http_head", side_effect=_mock_head):
+            mutations = resolver.test_url_mutations("https://example.com/docs/")
+        assert any(m[1] == "remove_trailing_slash" for m in mutations)
+
+    def test_www_toggle_add(self):
+        """Tests adding www prefix."""
+        resolver = _make_resolver()
+
+        def _mock_head(url):
+            if "www." in url:
+                return {"status_code": 200, "location": None}
+            return {"status_code": 404, "location": None}
+
+        with patch("gh_link_auditor.redirect_resolver._http_head", side_effect=_mock_head):
+            mutations = resolver.test_url_mutations("https://example.com/page")
+        assert any(m[1] == "add_www" for m in mutations)
+
+    def test_www_toggle_remove(self):
+        """Tests removing www prefix."""
+        resolver = _make_resolver()
+
+        def _mock_head(url):
+            if "www." not in url and "example.com" in url:
+                return {"status_code": 200, "location": None}
+            return {"status_code": 404, "location": None}
+
+        with patch("gh_link_auditor.redirect_resolver._http_head", side_effect=_mock_head):
+            mutations = resolver.test_url_mutations("https://www.example.com/page")
+        assert any(m[1] == "remove_www" for m in mutations)
+
+
+# ---------------------------------------------------------------------------
+# Redirect loop detection
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectLoop:
+    def test_redirect_loop_detected(self):
+        """Circular redirect chain is detected and stopped."""
+        resolver = _make_resolver()
+
+        def _mock_head(url):
+            if url == "https://a.com":
+                return {"status_code": 301, "location": "https://b.com"}
+            if url == "https://b.com":
+                return {"status_code": 301, "location": "https://a.com"}
+            return {"status_code": 200, "location": None}
+
+        with (
+            patch("gh_link_auditor.redirect_resolver._http_head", side_effect=_mock_head),
+            patch("gh_link_auditor.redirect_resolver.socket.getaddrinfo", side_effect=_mock_public_dns),
+        ):
+            final_url, log = resolver.follow_redirects("https://a.com")
+        assert final_url is None
+        assert any("loop" in entry.lower() for entry in log)
+
+
+# ---------------------------------------------------------------------------
+# SSRF DNS resolution failure
+# ---------------------------------------------------------------------------
+
+
+class TestSSRFDnsFailure:
+    def test_dns_failure_raises_ssrf_blocked(self):
+        """Unresolvable hostname raises SSRFBlocked."""
+        resolver = _make_resolver()
+        import socket as _socket
+
+        with patch(
+            "gh_link_auditor.redirect_resolver.socket.getaddrinfo",
+            side_effect=_socket.gaierror("Name resolution failed"),
+        ):
+            with pytest.raises(SSRFBlocked):
+                resolver._validate_not_private_ip("unresolvable.invalid")


### PR DESCRIPTION
## Summary
- Added ~36 tests across 4 test files to cover internal helpers, regex fallback paths, error handling branches, and pipeline edge cases
- Coverage improved from 79% → **97%** (all 6 modules ≥96%)
- 307 total tests pass, lint clean

## Coverage Results

| Module | Before | After |
|--------|--------|-------|
| `similarity.py` | 100% | 100% |
| `archive_client.py` | 69% | 98% |
| `redirect_resolver.py` | 76% | 97% |
| `github_resolver.py` | 76% | 96% |
| `link_detective.py` | 79% | 96% |
| `url_heuristic.py` | 96% | 96% |
| **TOTAL** | **79%** | **97%** |

## Test plan
- [x] All 307 tests pass
- [x] Lint clean (`ruff check`)
- [x] Every module ≥95% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)