### PR TITLE
fix: upgrade langgraph 1.0.8 → 1.0.10 for CVE-2026-28277 (#34)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -345,20 +345,20 @@ uuid-utils = ">=0.12.0,<1.0"
 
 [[package]]
 name = "langgraph"
-version = "1.0.8"
+version = "1.0.10"
 description = "Building stateful, multi-actor applications with LLMs"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "langgraph-1.0.8-py3-none-any.whl", hash = "sha256:da737177c024caad7e5262642bece4f54edf4cba2c905a1d1338963f41cf0904"},
-    {file = "langgraph-1.0.8.tar.gz", hash = "sha256:2630fc578846995114fd659f8b14df9eff5a4e78c49413f67718725e88ceb544"},
+    {file = "langgraph-1.0.10-py3-none-any.whl", hash = "sha256:7c298bef4f6ea292fcf9824d6088fe41a6727e2904ad6066f240c4095af12247"},
+    {file = "langgraph-1.0.10.tar.gz", hash = "sha256:73bd10ee14a8020f31ef07e9cd4c1a70c35cc07b9c2b9cd637509a10d9d51e29"},
 ]
 
 [package.dependencies]
 langchain-core = ">=0.1"
 langgraph-checkpoint = ">=2.1.0,<5.0.0"
-langgraph-prebuilt = ">=1.0.7,<1.1.0"
+langgraph-prebuilt = ">=1.0.8,<1.1.0"
 langgraph-sdk = ">=0.3.0,<0.4.0"
 pydantic = ">=2.7.4"
 xxhash = ">=3.5.0"
@@ -381,14 +381,14 @@ ormsgpack = ">=1.12.0"
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.7"
+version = "1.0.8"
 description = "Library with high-level APIs for creating and executing LangGraph agents and tools."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "langgraph_prebuilt-1.0.7-py3-none-any.whl", hash = "sha256:e14923516504405bb5edc3977085bc9622c35476b50c1808544490e13871fe7c"},
-    {file = "langgraph_prebuilt-1.0.7.tar.gz", hash = "sha256:38e097e06de810de4d0e028ffc0e432bb56d1fb417620fb1dfdc76c5e03e4bf9"},
+    {file = "langgraph_prebuilt-1.0.8-py3-none-any.whl", hash = "sha256:d16a731e591ba4470f3e313a319c7eee7dbc40895bcf15c821f985a3522a7ce0"},
+    {file = "langgraph_prebuilt-1.0.8.tar.gz", hash = "sha256:0cd3cf5473ced8a6cd687cc5294e08d3de57529d8dd14fdc6ae4899549efcf69"},
 ]
 
 [package.dependencies]
@@ -1568,4 +1568,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "5cdb9512ff2e59f7350bdd263cf24d0424b1de30f4596827b8a7dad02d581da5"
+content-hash = "2b44f04af73cfec4d18879119a57bcb6a2c97531adc377030fb08bbfa19fe6c2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ pythonpath = [".", "src"]
 
 [tool.poetry.dependencies]
 pydantic = "^2.12.5"
-langgraph = "^1.0.8"
+langgraph = "^1.0.10"
 rich = "^14.3.2"
 prompt-toolkit = "^3.0.52"
 httpx = "^0.28.1"


### PR DESCRIPTION
## Summary
- Upgrades langgraph from 1.0.8 to 1.0.10 to address CVE-2026-28277 (unsafe msgpack deserialization in checkpoint loading)
- Transitive updates: langsmith 0.6.9→0.7.4, langgraph-prebuilt 1.0.7→1.0.8, langgraph-sdk 0.3.4→0.3.7, tenacity 9.1.3→9.1.4
- GitHub reports no known patched version yet — upgrade reduces attack surface, alert may persist

Closes #34

## Test plan
- [x] Baseline tests pass (912 passed)
- [x] Post-upgrade tests pass (912 passed, same count)
- [x] `poetry show langgraph` confirms 1.0.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)