### PR TITLE
sec: add token resolver + fix .env bridging (#42)

### DIFF
--- a/docs/runbooks/operator-guide.md
+++ b/docs/runbooks/operator-guide.md
@@ -11,21 +11,24 @@ gh-link-auditor finds dead links in GitHub repositories and generates fixes. The
 
 ## Prerequisites
 
-### 1. Create your .env file
+### 1. GitHub authentication
+
+If you already ran `gh auth login`, the tool automatically uses that token. No `.env` needed.
+
+Only create `.env` to **override** the token or set other variables:
 
 ```bash
 cp .env.example .env
 ```
 
-Edit `.env` with your actual values:
-
 ```
+# Optional: override gh auth token with a specific PAT
 GITHUB_TOKEN=github_pat_your_token_here
+# Optional: change the LLM model (default: gpt-4o-mini)
 LLM_MODEL_NAME=gpt-4o-mini
 ```
 
-- `GITHUB_TOKEN` — your Fine-Grained PAT (see AssemblyZero runbook 0925)
-- `LLM_MODEL_NAME` — the model used for link investigation and fix generation (default: `gpt-4o-mini`)
+**Do NOT paste tokens into `.env` if you are running inside a Claude Code session.** The token resolver picks up your `gh auth login` credential automatically and safely.
 
 ### 2. Verify installation
 
@@ -222,9 +225,8 @@ sys.exit(main(['metrics', 'campaign']))
 If you've never run this before, do this:
 
 ```bash
-# 1. Set up .env
-cp .env.example .env
-# Edit .env with your token
+# 1. Authenticate (if not already done)
+gh auth login
 
 # 2. Discover 5 repos from stargazers of a popular project
 poetry run python -c "
@@ -279,7 +281,7 @@ sys.exit(main([
 | Problem | Fix |
 |---------|-----|
 | `ModuleNotFoundError` | Run from project root with `poetry run` |
-| 401 from GitHub API | Token expired or missing — check `.env` |
+| 401 from GitHub API | Token expired or missing — run `gh auth login` or check `.env` |
 | Circuit breaker triggers immediately | Repo has many dead links — raise `--max-links` or pick a different repo |
 | Cost limit reached | Raise `--max-cost` or use a cheaper model in `.env` |
 | No dead links found | Good news — the repo is clean |

--- a/src/gh_link_auditor/auth.py
+++ b/src/gh_link_auditor/auth.py
@@ -1,0 +1,40 @@
+"""GitHub token resolution with gh CLI fallback.
+
+Resolves GITHUB_TOKEN from environment first, then falls back to
+``gh auth token`` via subprocess. The subprocess output stays internal
+to Python and never reaches Claude's stdout.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+
+def resolve_github_token() -> str:
+    """Resolve a GitHub token from environment or gh CLI.
+
+    Priority:
+        1. ``GITHUB_TOKEN`` environment variable
+        2. ``gh auth token`` subprocess (silent, captured)
+
+    Returns:
+        The token string, or empty string if unavailable.
+    """
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        return token
+
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            token = result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    return token

--- a/src/repo_scout/cli.py
+++ b/src/repo_scout/cli.py
@@ -7,7 +7,6 @@ Deviation: uses argparse instead of typer to match codebase conventions.
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 
 from repo_scout.aggregator import deduplicate_repos, sort_by_relevance
@@ -131,7 +130,9 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    token = os.environ.get("GITHUB_TOKEN", "")
+    from gh_link_auditor.auth import resolve_github_token
+
+    token = resolve_github_token()
     client = GitHubClient(token=token)
     all_repos: list[RepositoryRecord] = []
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,130 @@
+"""Tests for gh_link_auditor.auth — GitHub token resolution."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from gh_link_auditor.auth import resolve_github_token
+
+
+class TestResolveGithubToken:
+    """Tests for resolve_github_token()."""
+
+    def test_returns_env_var_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_from_env")
+        assert resolve_github_token() == "ghp_from_env"
+
+    def test_env_var_takes_priority_over_cli(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_from_env")
+        with patch("gh_link_auditor.auth.subprocess.run") as mock_run:
+            token = resolve_github_token()
+        mock_run.assert_not_called()
+        assert token == "ghp_from_env"
+
+    def test_falls_back_to_gh_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        completed = subprocess.CompletedProcess(
+            args=["gh", "auth", "token"],
+            returncode=0,
+            stdout="ghp_from_cli\n",
+            stderr="",
+        )
+        with patch("gh_link_auditor.auth.subprocess.run", return_value=completed):
+            assert resolve_github_token() == "ghp_from_cli"
+
+    def test_strips_whitespace_from_cli_output(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        completed = subprocess.CompletedProcess(
+            args=["gh", "auth", "token"],
+            returncode=0,
+            stdout="  ghp_trimmed  \n",
+            stderr="",
+        )
+        with patch("gh_link_auditor.auth.subprocess.run", return_value=completed):
+            assert resolve_github_token() == "ghp_trimmed"
+
+    def test_returns_empty_when_cli_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        completed = subprocess.CompletedProcess(
+            args=["gh", "auth", "token"],
+            returncode=1,
+            stdout="",
+            stderr="not logged in",
+        )
+        with patch("gh_link_auditor.auth.subprocess.run", return_value=completed):
+            assert resolve_github_token() == ""
+
+    def test_returns_empty_when_gh_not_installed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with patch(
+            "gh_link_auditor.auth.subprocess.run", side_effect=FileNotFoundError
+        ):
+            assert resolve_github_token() == ""
+
+    def test_returns_empty_on_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with patch(
+            "gh_link_auditor.auth.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=5),
+        ):
+            assert resolve_github_token() == ""
+
+    def test_returns_empty_string_not_none_when_no_sources(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        completed = subprocess.CompletedProcess(
+            args=["gh", "auth", "token"],
+            returncode=1,
+            stdout="",
+            stderr="",
+        )
+        with patch("gh_link_auditor.auth.subprocess.run", return_value=completed):
+            result = resolve_github_token()
+            assert result == ""
+            assert isinstance(result, str)
+
+    def test_passes_correct_args_to_subprocess(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        completed = subprocess.CompletedProcess(
+            args=["gh", "auth", "token"],
+            returncode=0,
+            stdout="ghp_test\n",
+            stderr="",
+        )
+        with patch("gh_link_auditor.auth.subprocess.run", return_value=completed) as mock_run:
+            resolve_github_token()
+            mock_run.assert_called_once_with(
+                ["gh", "auth", "token"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+
+    def test_empty_env_var_triggers_cli_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_TOKEN", "")
+        completed = subprocess.CompletedProcess(
+            args=["gh", "auth", "token"],
+            returncode=0,
+            stdout="ghp_fallback\n",
+            stderr="",
+        )
+        with patch("gh_link_auditor.auth.subprocess.run", return_value=completed):
+            assert resolve_github_token() == "ghp_fallback"


### PR DESCRIPTION
## Summary

- Add `gh_link_auditor.auth.resolve_github_token()` — checks `GITHUB_TOKEN` env var first, falls back to `gh auth token` via subprocess (output stays in Python, never reaches transcript stdout)
- Update `repo_scout/cli.py` to use the resolver instead of raw `os.environ.get`
- Update operator runbook to stop instructing users to paste tokens into `.env`

## Test plan

- [x] 10 unit tests covering: env priority, CLI fallback, whitespace stripping, error handling (not installed, timeout, non-zero exit), subprocess args verification, empty-env fallback
- [x] Full suite: 1066 passed, 1 skipped

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)