### PR TITLE
docs: close Doc-Fix Bot reports and fill coverage gaps (#2)

### DIFF
--- a/docs/reports/active/10002-implementation-report.md
+++ b/docs/reports/active/10002-implementation-report.md
@@ -1,0 +1,28 @@
+# Implementation Report: #2 Doc-Fix Bot — Automated External Contributions
+
+**Date:** 2026-03-18
+**LLD:** LLD-002
+
+## Changes
+
+### New Files
+- `src/docfix_bot/config.py` — Bot configuration with defaults
+- `src/docfix_bot/models.py` — TypedDicts: TargetRepository, BrokenLink, ScanResult, PRSubmission, BotState, BotConfig
+- `src/docfix_bot/link_scanner.py` — Markdown link extraction, HTTP checking, Wayback suggest_fix
+- `src/docfix_bot/url_validator.py` — SSRF validation for outbound requests
+- `src/docfix_bot/git_workflow.py` — Fork/clone/branch/commit/push/PR workflow
+- `src/docfix_bot/pr_generator.py` — PR title and body generation with markdown tables
+- `src/docfix_bot/scheduler.py` — Periodic scanning scheduler
+- `src/docfix_bot/state_store.py` — SQLite persistence for bot state
+- `src/docfix_bot/target_manager.py` — Target repository management
+- Tests: full test suite in `tests/unit/docfix_bot/`
+
+### Modified Files (coverage closure)
+- `tests/unit/docfix_bot/test_link_scanner.py` — +1 test: zero retries fallback (line 124)
+
+## Deviations from LLD
+- None
+
+## Test Count
+- Before: 1079 tests
+- After: 1080 tests (+1 coverage gap test)

--- a/docs/reports/active/10002-test-report.md
+++ b/docs/reports/active/10002-test-report.md
@@ -1,0 +1,29 @@
+# Test Report: #2 Doc-Fix Bot — Automated External Contributions
+
+**Date:** 2026-03-18
+
+## Summary
+- Total tests: 1080 passed, 1 skipped
+- New tests: 1 (coverage gap closure)
+
+## Coverage (docfix_bot files)
+| File | Before | After |
+|------|--------|-------|
+| `link_scanner.py` | 99% | 100% |
+| `config.py` | 100% | 100% |
+| `models.py` | 100% | 100% |
+| `pr_generator.py` | 100% | 100% |
+| `git_workflow.py` | 100% | 100% |
+| `scheduler.py` | 100% | 100% |
+| `state_store.py` | 100% | 100% |
+| `target_manager.py` | 100% | 100% |
+| `url_validator.py` | 100% | 100% |
+
+## New Test Breakdown
+
+### test_link_scanner.py (+1)
+- `test_zero_retries_returns_max_retries_exceeded`: max_retries=0 falls through retry loop to fallback return (line 124)
+
+## Lint/Format
+- `ruff check`: clean
+- `ruff format`: clean

--- a/tests/unit/docfix_bot/test_link_scanner.py
+++ b/tests/unit/docfix_bot/test_link_scanner.py
@@ -233,3 +233,20 @@ class TestScanRepository:
         with patch.object(Path, "read_text", side_effect=OSError("Permission denied")):
             result = scan_repository(target, get_default_config(), tmp_path)
         assert result["files_scanned"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckLinkCoverageGaps:
+    """Tests for uncovered lines in check_link."""
+
+    @patch("docfix_bot.link_scanner.validate_ip_safety")
+    def test_zero_retries_returns_max_retries_exceeded(self, mock_ssrf: MagicMock) -> None:
+        """max_retries=0 falls through to 'Max retries exceeded' (line 124)."""
+        mock_ssrf.return_value = {"is_safe": True, "rejection_reason": None}
+        status, error = check_link("https://example.com", get_default_config(), max_retries=0)
+        assert status == 0
+        assert error == "Max retries exceeded"


### PR DESCRIPTION
## Summary
- Add 1 test targeting uncovered line in link_scanner.py
- Coverage improvement: link_scanner 99%→100%. All docfix_bot modules now at 100%
- Create implementation and test reports for issue closure

## Test plan
- [x] `poetry run pytest` — all pass
- [x] `poetry run ruff check` — clean
- [x] Coverage verified ≥98%

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)