### PR TITLE
feat: add tests/fakes/ infrastructure for MagicMock replacement (#53)

### DIFF
--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -1,0 +1,4 @@
+"""Shared fake implementations for testing.
+
+Replaces MagicMock with predictable, typed fakes that mirror real interfaces.
+"""

--- a/tests/fakes/archive.py
+++ b/tests/fakes/archive.py
@@ -1,0 +1,70 @@
+"""Fake ArchiveClient for testing.
+
+Replaces MagicMock with a configurable fake that mirrors ArchiveClient's interface.
+"""
+
+from __future__ import annotations
+
+from gh_link_auditor.archive_client import CDXResponse
+
+
+class FakeArchiveClient:
+    """Fake ArchiveClient with pre-configured responses."""
+
+    def __init__(
+        self,
+        snapshot: CDXResponse | None = None,
+        html: str | None = None,
+        title: str | None = None,
+        summary: str | None = None,
+    ) -> None:
+        self._snapshot = snapshot
+        self._html = html
+        self._title = title
+        self._summary = summary
+
+    def get_latest_snapshot(self, url: str) -> CDXResponse | None:
+        """Return pre-configured snapshot."""
+        return self._snapshot
+
+    def fetch_snapshot_content(self, snapshot_url: str) -> str | None:
+        """Return pre-configured HTML content."""
+        return self._html
+
+    def extract_title(self, html: str) -> str | None:
+        """Return pre-configured title."""
+        return self._title
+
+    def extract_content_summary(self, html: str, max_chars: int = 500) -> str | None:
+        """Return pre-configured summary."""
+        return self._summary
+
+
+def make_archive_hit(
+    url: str = "https://example.com/docs",
+    timestamp: str = "20240101120000",
+    title: str = "Example Docs",
+    summary: str = "Content here",
+) -> FakeArchiveClient:
+    """Create a FakeArchiveClient that returns a snapshot with title and summary."""
+    snapshot = CDXResponse(
+        url=url,
+        timestamp=timestamp,
+        original=url,
+        mimetype="text/html",
+        statuscode="200",
+        digest="ABC",
+        length="1234",
+    )
+    html = f"<html><head><title>{title}</title></head><body>{summary}</body></html>"
+    return FakeArchiveClient(
+        snapshot=snapshot,
+        html=html,
+        title=title,
+        summary=summary,
+    )
+
+
+def make_archive_miss() -> FakeArchiveClient:
+    """Create a FakeArchiveClient that returns no snapshot."""
+    return FakeArchiveClient()

--- a/tests/fakes/detectives.py
+++ b/tests/fakes/detectives.py
@@ -1,0 +1,104 @@
+"""Fake detective components for testing.
+
+Replaces MagicMock with configurable fakes for RedirectResolver,
+GitHubResolver, and URLHeuristic.
+"""
+
+from __future__ import annotations
+
+
+class FakeRedirectResolver:
+    """Fake RedirectResolver with configurable redirect behavior."""
+
+    def __init__(
+        self,
+        redirect_map: dict[str, tuple[str | None, list[str]]] | None = None,
+        mutations: dict[str, list[tuple[str, str]]] | None = None,
+        live_urls: set[str] | None = None,
+    ) -> None:
+        self._redirect_map = redirect_map or {}
+        self._mutations = mutations or {}
+        self._live_urls = live_urls or set()
+
+    def follow_redirects(self, url: str) -> tuple[str | None, list[str]]:
+        """Return configured redirect result for url."""
+        return self._redirect_map.get(url, (None, ["No redirect chain detected"]))
+
+    def test_url_mutations(self, url: str) -> list[tuple[str, str]]:
+        """Return configured mutation results for url."""
+        return self._mutations.get(url, [])
+
+    def verify_live(self, url: str) -> bool:
+        """Return True if url is in the live_urls set."""
+        return url in self._live_urls
+
+
+class FakeGitHubResolver:
+    """Fake GitHubResolver with configurable redirect detection."""
+
+    GITHUB_DOMAINS: set[str] = {"github.com", "raw.githubusercontent.com"}
+
+    def __init__(
+        self,
+        redirects: dict[str, str] | None = None,
+        github_urls: set[str] | None = None,
+    ) -> None:
+        self._redirects = redirects or {}
+        self._github_urls = github_urls or set()
+
+    def is_github_url(self, url: str) -> bool:
+        """Return True if url was configured as a GitHub URL."""
+        if self._github_urls:
+            return url in self._github_urls
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        return parsed.hostname in self.GITHUB_DOMAINS
+
+    def _parse_github_url(self, url: str) -> tuple[str, str, str | None]:
+        """Parse GitHub URL into (owner, repo, file_path)."""
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        parts = [p for p in parsed.path.strip("/").split("/") if p]
+        owner = parts[0] if len(parts) >= 1 else ""
+        repo = parts[1] if len(parts) >= 2 else ""
+        file_path = "/".join(parts[2:]) if len(parts) > 2 else None
+        return owner, repo, file_path
+
+    def resolve_repo_redirect(self, owner: str, repo: str) -> str | None:
+        """Return configured redirect for owner/repo."""
+        key = f"{owner}/{repo}"
+        return self._redirects.get(key)
+
+    def reconstruct_file_url(self, original_url: str, new_repo_url: str) -> str:
+        """Reconstruct file URL from original and new repo URL."""
+        from urllib.parse import urlparse
+
+        orig_parsed = urlparse(original_url)
+        orig_parts = [p for p in orig_parsed.path.strip("/").split("/") if p]
+        file_parts = orig_parts[2:] if len(orig_parts) > 2 else []
+        new_base = new_repo_url.rstrip("/")
+        if file_parts:
+            return f"{new_base}/{'/'.join(file_parts)}"
+        return new_base
+
+
+class FakeURLHeuristic:
+    """Fake URLHeuristic with configurable candidate generation."""
+
+    def __init__(
+        self,
+        candidates: list[str] | None = None,
+        live: list[str] | None = None,
+    ) -> None:
+        self._candidates = candidates or []
+        self._live = live or []
+
+    def generate_candidates(self, domain: str, title: str, path: str) -> list[str]:
+        """Return pre-configured candidates."""
+        return self._candidates
+
+    def probe_candidates(self, candidates: list[str], max_results: int = 3) -> list[str]:
+        """Return pre-configured live URLs."""
+        return self._live[:max_results]

--- a/tests/fakes/git.py
+++ b/tests/fakes/git.py
@@ -1,0 +1,65 @@
+"""Fake Git objects for testing.
+
+Replaces MagicMock with typed fakes for git.Repo, git.cmd.Git, and git.IndexFile.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class FakeGitCmd:
+    """Fake git.cmd.Git for testing git CLI operations."""
+
+    def __init__(self) -> None:
+        self.checkout_calls: list[tuple[tuple, dict]] = []
+        self.push_calls: list[tuple[tuple, dict]] = []
+
+    def checkout(self, *args: str, **kwargs: object) -> None:
+        """Record checkout call."""
+        self.checkout_calls.append((args, kwargs))
+
+    def push(self, *args: str, **kwargs: object) -> None:
+        """Record push call."""
+        self.push_calls.append((args, kwargs))
+
+
+class FakeIndex:
+    """Fake git.IndexFile for testing staging/commit operations."""
+
+    def __init__(self) -> None:
+        self.added: list[list[str]] = []
+        self.commit_messages: list[str] = []
+
+    def add(self, items: list[str]) -> None:
+        """Record staged items."""
+        self.added.append(items)
+
+    def commit(self, message: str) -> None:
+        """Record commit."""
+        self.commit_messages.append(message)
+
+
+class FakeGitRepo:
+    """Fake git.Repo for testing repository operations.
+
+    Supports clone_from, git commands, and index operations.
+    """
+
+    _clone_calls: list[tuple[str, str | Path, dict]] = []
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.working_dir = str(path) if path else "."
+        self.git = FakeGitCmd()
+        self.index = FakeIndex()
+
+    @classmethod
+    def clone_from(cls, url: str, to_path: str | Path, **kwargs: object) -> FakeGitRepo:
+        """Simulate cloning a repository."""
+        cls._clone_calls.append((url, to_path, kwargs))
+        return cls(to_path)
+
+    @classmethod
+    def reset_clone_calls(cls) -> None:
+        """Reset recorded clone calls between tests."""
+        cls._clone_calls = []

--- a/tests/fakes/github.py
+++ b/tests/fakes/github.py
@@ -1,0 +1,83 @@
+"""Fake GitHub API client for testing.
+
+Replaces MagicMock with a configurable fake that mirrors GitHubClient's interface.
+"""
+
+from __future__ import annotations
+
+from repo_scout.models import DiscoverySource, RepositoryRecord, make_repo_record
+
+
+class FakeGitHubClient:
+    """Fake GitHubClient with pre-configured responses.
+
+    Configure data via configure_* methods, then call the same methods
+    as the real GitHubClient.
+    """
+
+    def __init__(self) -> None:
+        self._stargazers: dict[str, list[str]] = {}
+        self._user_repos: dict[str, list[RepositoryRecord]] = {}
+        self._starred: dict[str, list[RepositoryRecord]] = {}
+        self._repos: dict[str, dict] = {}
+        self._request_responses: dict[str, dict | list | None] = {}
+        self.request_log: list[str] = []
+
+    def configure_stargazers(self, owner_repo: str, users: list[str]) -> None:
+        """Set stargazer usernames for a repo (e.g. "owner/repo")."""
+        self._stargazers[owner_repo] = users
+
+    def configure_user_repos(self, username: str, repos: list[RepositoryRecord]) -> None:
+        """Set repos owned by a user."""
+        self._user_repos[username] = repos
+
+    def configure_starred(self, username: str, repos: list[RepositoryRecord]) -> None:
+        """Set repos starred by a user."""
+        self._starred[username] = repos
+
+    def configure_repo(self, full_name: str, data: dict) -> None:
+        """Set raw API response for a specific repo."""
+        self._repos[full_name] = data
+
+    def configure_request(self, endpoint: str, response: dict | list | None) -> None:
+        """Set response for a raw request() call."""
+        self._request_responses[endpoint] = response
+
+    def get_stargazers(self, owner: str, repo: str, max_count: int = 100) -> list[str]:
+        """Return configured stargazer usernames."""
+        key = f"{owner}/{repo}"
+        return self._stargazers.get(key, [])[:max_count]
+
+    def get_user_repos(self, username: str) -> list[RepositoryRecord]:
+        """Return configured user repos."""
+        return self._user_repos.get(username, [])
+
+    def get_starred(self, username: str) -> list[RepositoryRecord]:
+        """Return configured starred repos."""
+        return self._starred.get(username, [])
+
+    def get_repo(self, owner: str, name: str) -> RepositoryRecord | None:
+        """Return a RepositoryRecord if configured."""
+        key = f"{owner}/{name}"
+        data = self._repos.get(key)
+        if data is None:
+            return None
+        return make_repo_record(
+            owner=data.get("owner", {}).get("login", owner),
+            name=data.get("name", name),
+            source=DiscoverySource.STARRED_REPO,
+            description=data.get("description"),
+            stars=data.get("stargazers_count"),
+        )
+
+    def repo_exists(self, full_name: str) -> bool:
+        """Check if a repo was configured."""
+        return full_name in self._repos
+
+    def request(self, endpoint: str) -> dict | list | None:
+        """Return configured response for an endpoint."""
+        self.request_log.append(endpoint)
+        return self._request_responses.get(endpoint)
+
+    def close(self) -> None:
+        """No-op close."""

--- a/tests/fakes/http.py
+++ b/tests/fakes/http.py
@@ -1,0 +1,109 @@
+"""Fake HTTP response objects for testing.
+
+Replaces MagicMock-based HTTP mocks with typed, predictable fakes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+
+@dataclass
+class FakeHTTPResponse:
+    """Fake httpx-style response with status_code, json(), and text."""
+
+    status_code: int
+    body: dict | list | str | None = None
+    text: str = ""
+    headers: dict[str, str] = field(default_factory=dict)
+
+    def json(self) -> Any:
+        """Return the body as parsed JSON."""
+        return self.body
+
+    def raise_for_status(self) -> None:
+        """Raise httpx.HTTPStatusError if status_code >= 400."""
+        if self.status_code >= 400:
+            request = httpx.Request("GET", "https://fake.test")
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=request,
+                response=response,
+            )
+
+
+class FakeURLResponse:
+    """Fake urllib-style response with read(), context manager, and headers.
+
+    Mimics the object returned by urllib.request.urlopen().
+    """
+
+    def __init__(
+        self,
+        data: bytes,
+        status: int = 200,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self._data = data
+        self.status = status
+        self.headers = headers or {}
+
+    def read(self) -> bytes:
+        """Return response body as bytes."""
+        return self._data
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        """Get a header value (dict-style)."""
+        return self.headers.get(key, default)
+
+    def __enter__(self) -> FakeURLResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
+class FakeAsyncHTTPClient:
+    """Fake httpx.AsyncClient for testing async code.
+
+    Supports get, delete, post methods and async context manager protocol.
+    """
+
+    def __init__(
+        self,
+        default_response: FakeHTTPResponse | None = None,
+        responses: dict[str, FakeHTTPResponse] | None = None,
+        side_effect: Exception | None = None,
+    ) -> None:
+        self._default_response = default_response or FakeHTTPResponse(status_code=200)
+        self._responses = responses or {}
+        self._side_effect = side_effect
+        self.calls: list[tuple[str, str, dict]] = []
+
+    async def __aenter__(self) -> FakeAsyncHTTPClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        pass
+
+    def _resolve(self, method: str, url: str, **kwargs: Any) -> FakeHTTPResponse:
+        self.calls.append((method, url, kwargs))
+        if self._side_effect:
+            raise self._side_effect
+        return self._responses.get(url, self._default_response)
+
+    async def get(self, url: str, **kwargs: Any) -> FakeHTTPResponse:
+        """Fake GET request."""
+        return self._resolve("GET", url, **kwargs)
+
+    async def delete(self, url: str, **kwargs: Any) -> FakeHTTPResponse:
+        """Fake DELETE request."""
+        return self._resolve("DELETE", url, **kwargs)
+
+    async def post(self, url: str, **kwargs: Any) -> FakeHTTPResponse:
+        """Fake POST request."""
+        return self._resolve("POST", url, **kwargs)


### PR DESCRIPTION
## Summary
- Create `tests/fakes/` with shared fake implementations to replace MagicMock across all 17 test files
- Fakes: FakeHTTPResponse, FakeURLResponse, FakeAsyncHTTPClient, FakeGitHubClient, FakeArchiveClient, FakeRedirectResolver, FakeGitHubResolver, FakeURLHeuristic, FakeGitRepo
- All 1079 existing tests still pass

Closes #53

## Test plan
- [x] All fakes import successfully
- [x] `poetry run ruff check` clean
- [x] `poetry run ruff format --check` clean
- [x] Full test suite: 1079 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)