### PR TITLE
refactor: remove all MagicMock from test suite (#54)

### DIFF
--- a/tests/fakes/github.py
+++ b/tests/fakes/github.py
@@ -22,6 +22,12 @@ class FakeGitHubClient:
         self._repos: dict[str, dict] = {}
         self._request_responses: dict[str, dict | list | None] = {}
         self.request_log: list[str] = []
+        # Call tracking for assertion support
+        self.get_stargazers_calls: list[tuple[str, str, int]] = []
+        self.get_user_repos_calls: list[str] = []
+        self.get_starred_calls: list[str] = []
+        self.repo_exists_calls: list[str] = []
+        self.close_calls: int = 0
 
     def configure_stargazers(self, owner_repo: str, users: list[str]) -> None:
         """Set stargazer usernames for a repo (e.g. "owner/repo")."""
@@ -45,15 +51,18 @@ class FakeGitHubClient:
 
     def get_stargazers(self, owner: str, repo: str, max_count: int = 100) -> list[str]:
         """Return configured stargazer usernames."""
+        self.get_stargazers_calls.append((owner, repo, max_count))
         key = f"{owner}/{repo}"
         return self._stargazers.get(key, [])[:max_count]
 
     def get_user_repos(self, username: str) -> list[RepositoryRecord]:
         """Return configured user repos."""
+        self.get_user_repos_calls.append(username)
         return self._user_repos.get(username, [])
 
     def get_starred(self, username: str) -> list[RepositoryRecord]:
         """Return configured starred repos."""
+        self.get_starred_calls.append(username)
         return self._starred.get(username, [])
 
     def get_repo(self, owner: str, name: str) -> RepositoryRecord | None:
@@ -72,6 +81,7 @@ class FakeGitHubClient:
 
     def repo_exists(self, full_name: str) -> bool:
         """Check if a repo was configured."""
+        self.repo_exists_calls.append(full_name)
         return full_name in self._repos
 
     def request(self, endpoint: str) -> dict | list | None:
@@ -80,4 +90,5 @@ class FakeGitHubClient:
         return self._request_responses.get(endpoint)
 
     def close(self) -> None:
-        """No-op close."""
+        """Track close call."""
+        self.close_calls += 1

--- a/tests/unit/batch/test_cleanup.py
+++ b/tests/unit/batch/test_cleanup.py
@@ -11,7 +11,9 @@ Covers LLD-019 scenarios:
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
+
+import httpx
 
 from gh_link_auditor.batch.cleanup import (
     check_disk_usage,
@@ -19,6 +21,7 @@ from gh_link_auditor.batch.cleanup import (
     cleanup_remote_branch,
     prune_stale_forks,
 )
+from tests.fakes.http import FakeAsyncHTTPClient, FakeHTTPResponse
 
 
 class TestDiskUsage:
@@ -78,35 +81,23 @@ class TestCleanupRemoteBranch:
 
     def test_deletes_branch(self) -> None:
         """API called with correct params."""
-        mock_resp = AsyncMock()
-        mock_resp.status_code = 204
+        fake_resp = FakeHTTPResponse(status_code=204)
+        fake_client = FakeAsyncHTTPClient(default_response=fake_resp)
 
-        with patch("gh_link_auditor.batch.cleanup.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.delete = AsyncMock(return_value=mock_resp)
-            mock_client_cls.return_value = mock_client
-
+        with patch("gh_link_auditor.batch.cleanup.httpx.AsyncClient", return_value=fake_client):
             result = asyncio.run(cleanup_remote_branch("owner/repo", "fix/branch", "ghp_token"))
 
         assert result is True
-        mock_client.delete.assert_called_once()
-        call_url = mock_client.delete.call_args[0][0]
+        assert len(fake_client.calls) == 1
+        call_url = fake_client.calls[0][1]
         assert "owner/repo" in call_url
         assert "fix/branch" in call_url
 
     def test_failure_returns_false(self) -> None:
-        mock_resp = AsyncMock()
-        mock_resp.status_code = 404
+        fake_resp = FakeHTTPResponse(status_code=404)
+        fake_client = FakeAsyncHTTPClient(default_response=fake_resp)
 
-        with patch("gh_link_auditor.batch.cleanup.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.delete = AsyncMock(return_value=mock_resp)
-            mock_client_cls.return_value = mock_client
-
+        with patch("gh_link_auditor.batch.cleanup.httpx.AsyncClient", return_value=fake_client):
             result = asyncio.run(cleanup_remote_branch("owner/repo", "fix/branch", "ghp_token"))
 
         assert result is False
@@ -116,15 +107,9 @@ class TestCleanupRemoteBranchError:
     """Tests for cleanup_remote_branch error handling."""
 
     def test_http_error_returns_false(self) -> None:
-        import httpx
+        fake_client = FakeAsyncHTTPClient(side_effect=httpx.ConnectError("network"))
 
-        with patch("gh_link_auditor.batch.cleanup.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.delete = AsyncMock(side_effect=httpx.ConnectError("network"))
-            mock_client_cls.return_value = mock_client
-
+        with patch("gh_link_auditor.batch.cleanup.httpx.AsyncClient", return_value=fake_client):
             result = asyncio.run(cleanup_remote_branch("owner/repo", "branch", "token"))
 
         assert result is False

--- a/tests/unit/batch/test_token_manager.py
+++ b/tests/unit/batch/test_token_manager.py
@@ -15,7 +15,7 @@ import logging
 import os
 import sys
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -30,6 +30,7 @@ from gh_link_auditor.batch.token_manager import (
     load_tokens_from_env,
     load_tokens_from_file,
 )
+from tests.fakes.http import FakeAsyncHTTPClient, FakeHTTPResponse
 
 
 class TestTokenRotation:
@@ -156,24 +157,17 @@ class TestValidateAll:
 
     def test_insufficient_scopes_raises(self) -> None:
         """Token with wrong scopes raises InsufficientScopesError."""
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.headers = {
-            "X-OAuth-Scopes": "read:user",
-            "X-RateLimit-Remaining": "5000",
-            "X-RateLimit-Reset": "1700000000",
-        }
+        fake_resp = FakeHTTPResponse(
+            status_code=200,
+            headers={
+                "X-OAuth-Scopes": "read:user",
+                "X-RateLimit-Remaining": "5000",
+                "X-RateLimit-Reset": "1700000000",
+            },
+        )
+        fake_client = FakeAsyncHTTPClient(default_response=fake_resp)
 
-        async def mock_get(*args, **kwargs):
-            return mock_resp
-
-        with patch("gh_link_auditor.batch.token_manager.httpx.AsyncClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_resp)
-            mock_cls.return_value = mock_client
-
+        with patch("gh_link_auditor.batch.token_manager.httpx.AsyncClient", return_value=fake_client):
             tm = TokenManager(["ghp_testtoken1234"])
             with pytest.raises(InsufficientScopesError) as exc_info:
                 asyncio.run(tm.validate_all())
@@ -181,21 +175,17 @@ class TestValidateAll:
             assert "public_repo" in exc_info.value.missing or "repo" in exc_info.value.missing
 
     def test_valid_scopes_pass(self) -> None:
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.headers = {
-            "X-OAuth-Scopes": "repo, public_repo, read:user",
-            "X-RateLimit-Remaining": "4500",
-            "X-RateLimit-Reset": "1700000000",
-        }
+        fake_resp = FakeHTTPResponse(
+            status_code=200,
+            headers={
+                "X-OAuth-Scopes": "repo, public_repo, read:user",
+                "X-RateLimit-Remaining": "4500",
+                "X-RateLimit-Reset": "1700000000",
+            },
+        )
+        fake_client = FakeAsyncHTTPClient(default_response=fake_resp)
 
-        with patch("gh_link_auditor.batch.token_manager.httpx.AsyncClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_resp)
-            mock_cls.return_value = mock_client
-
+        with patch("gh_link_auditor.batch.token_manager.httpx.AsyncClient", return_value=fake_client):
             tm = TokenManager(["ghp_goodtoken"])
             states = asyncio.run(tm.validate_all())
 
@@ -203,30 +193,19 @@ class TestValidateAll:
             assert states[0].is_valid is True
 
     def test_401_invalidates_token(self) -> None:
-        mock_resp = MagicMock()
-        mock_resp.status_code = 401
-        mock_resp.headers = {}
+        fake_resp = FakeHTTPResponse(status_code=401, headers={})
+        fake_client = FakeAsyncHTTPClient(default_response=fake_resp)
 
-        with patch("gh_link_auditor.batch.token_manager.httpx.AsyncClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_resp)
-            mock_cls.return_value = mock_client
-
+        with patch("gh_link_auditor.batch.token_manager.httpx.AsyncClient", return_value=fake_client):
             tm = TokenManager(["ghp_badtoken"])
             states = asyncio.run(tm.validate_all())
 
             assert states[0].is_valid is False
 
     def test_http_error_invalidates_token(self) -> None:
-        with patch("gh_link_auditor.batch.token_manager.httpx.AsyncClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(side_effect=httpx.ConnectError("network"))
-            mock_cls.return_value = mock_client
+        fake_client = FakeAsyncHTTPClient(side_effect=httpx.ConnectError("network"))
 
+        with patch("gh_link_auditor.batch.token_manager.httpx.AsyncClient", return_value=fake_client):
             tm = TokenManager(["ghp_errortoken"])
             states = asyncio.run(tm.validate_all())
 

--- a/tests/unit/docfix_bot/test_git_workflow.py
+++ b/tests/unit/docfix_bot/test_git_workflow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from docfix_bot.git_workflow import (
     apply_fixes,
@@ -14,6 +14,8 @@ from docfix_bot.git_workflow import (
     generate_commit_message,
 )
 from docfix_bot.models import make_broken_link, make_target
+from tests.fakes.git import FakeGitRepo
+from tests.fakes.http import FakeHTTPResponse
 
 
 class TestCreateBranchName:
@@ -133,10 +135,10 @@ class TestApplyFixes:
 
 class TestCreatePullRequest:
     @patch("docfix_bot.git_workflow.httpx.post")
-    def test_success(self, mock_post: MagicMock) -> None:
-        mock_post.return_value = MagicMock(
+    def test_success(self, mock_post) -> None:
+        mock_post.return_value = FakeHTTPResponse(
             status_code=201,
-            json=lambda: {"number": 42, "html_url": "https://github.com/org/repo/pull/42"},
+            body={"number": 42, "html_url": "https://github.com/org/repo/pull/42"},
         )
         target = make_target("org", "repo")
         config = {"github_token": "ghp_test"}
@@ -145,8 +147,8 @@ class TestCreatePullRequest:
         assert pr_url == "https://github.com/org/repo/pull/42"
 
     @patch("docfix_bot.git_workflow.httpx.post")
-    def test_failure(self, mock_post: MagicMock) -> None:
-        mock_post.return_value = MagicMock(
+    def test_failure(self, mock_post) -> None:
+        mock_post.return_value = FakeHTTPResponse(
             status_code=422,
             text="Validation failed",
         )
@@ -162,7 +164,7 @@ class TestCreatePullRequest:
         assert pr_num is None
 
     @patch("docfix_bot.git_workflow.httpx.post")
-    def test_http_error(self, mock_post: MagicMock) -> None:
+    def test_http_error(self, mock_post) -> None:
         import httpx
 
         mock_post.side_effect = httpx.ConnectError("fail")
@@ -174,7 +176,7 @@ class TestCreatePullRequest:
 
 class TestCloneRepository:
     @patch("git.Repo.clone_from")
-    def test_success(self, mock_clone: MagicMock, tmp_path: Path) -> None:
+    def test_success(self, mock_clone, tmp_path: Path) -> None:
         target = make_target("org", "repo")
         result = clone_repository(target, tmp_path, shallow=True)
         assert result == tmp_path / "repo"
@@ -183,14 +185,14 @@ class TestCloneRepository:
         assert call_kwargs.get("depth") == 1
 
     @patch("git.Repo.clone_from")
-    def test_non_shallow(self, mock_clone: MagicMock, tmp_path: Path) -> None:
+    def test_non_shallow(self, mock_clone, tmp_path: Path) -> None:
         target = make_target("org", "repo")
         clone_repository(target, tmp_path, shallow=False)
         call_kwargs = mock_clone.call_args[1]
         assert "depth" not in call_kwargs
 
     @patch("git.Repo.clone_from")
-    def test_clone_failure(self, mock_clone: MagicMock, tmp_path: Path) -> None:
+    def test_clone_failure(self, mock_clone, tmp_path: Path) -> None:
         import git as gitmodule
         import pytest
 
@@ -206,16 +208,16 @@ class TestExecuteFixWorkflow:
     @patch("git.Repo")
     def test_full_workflow(
         self,
-        mock_repo_cls: MagicMock,
-        mock_clone: MagicMock,
-        mock_create_pr: MagicMock,
+        mock_repo_cls,
+        mock_clone,
+        mock_create_pr,
         tmp_path: Path,
     ) -> None:
         mock_clone.return_value = tmp_path
         readme = tmp_path / "README.md"
         readme.write_text("Visit [link](https://old.com) for info.\n")
 
-        mock_repo = MagicMock()
+        mock_repo = FakeGitRepo(tmp_path)
         mock_repo_cls.return_value = mock_repo
 
         mock_create_pr.return_value = (42, "https://github.com/org/repo/pull/42")
@@ -252,16 +254,16 @@ class TestExecuteFixWorkflow:
     @patch("git.Repo")
     def test_no_modifications(
         self,
-        mock_repo_cls: MagicMock,
-        mock_clone: MagicMock,
-        mock_create_pr: MagicMock,
+        mock_repo_cls,
+        mock_clone,
+        mock_create_pr,
         tmp_path: Path,
     ) -> None:
         mock_clone.return_value = tmp_path
         readme = tmp_path / "README.md"
         readme.write_text("No matching URLs here.\n")
 
-        mock_repo = MagicMock()
+        mock_repo = FakeGitRepo(tmp_path)
         mock_repo_cls.return_value = mock_repo
 
         target = make_target("org", "repo")
@@ -286,16 +288,16 @@ class TestExecuteFixWorkflow:
     @patch("git.Repo")
     def test_no_token_push_skipped(
         self,
-        mock_repo_cls: MagicMock,
-        mock_clone: MagicMock,
-        mock_create_pr: MagicMock,
+        mock_repo_cls,
+        mock_clone,
+        mock_create_pr,
         tmp_path: Path,
     ) -> None:
         mock_clone.return_value = tmp_path
         readme = tmp_path / "README.md"
         readme.write_text("Visit [link](https://old.com) for info.\n")
 
-        mock_repo = MagicMock()
+        mock_repo = FakeGitRepo(tmp_path)
         mock_repo_cls.return_value = mock_repo
 
         mock_create_pr.return_value = (None, None)
@@ -313,5 +315,5 @@ class TestExecuteFixWorkflow:
 
         result = execute_fix_workflow(target, [link], config, "title", "body")
 
-        mock_repo.git.push.assert_not_called()
+        assert mock_repo.git.push_calls == []
         assert result["status"] == "pending"

--- a/tests/unit/docfix_bot/test_link_scanner.py
+++ b/tests/unit/docfix_bot/test_link_scanner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import httpx
 
@@ -15,6 +15,7 @@ from docfix_bot.link_scanner import (
     suggest_fix,
 )
 from docfix_bot.models import make_target
+from tests.fakes.http import FakeHTTPResponse
 
 
 class TestExtractLinksFromMarkdown:
@@ -65,9 +66,9 @@ See https://c.com for details.
 class TestCheckLink:
     @patch("docfix_bot.link_scanner.validate_ip_safety")
     @patch("docfix_bot.link_scanner.httpx.head")
-    def test_working_link(self, mock_head: MagicMock, mock_validate: MagicMock) -> None:
+    def test_working_link(self, mock_head, mock_validate) -> None:
         mock_validate.return_value = {"is_safe": True, "url": "", "resolved_ip": None, "rejection_reason": None}
-        mock_head.return_value = MagicMock(status_code=200)
+        mock_head.return_value = FakeHTTPResponse(status_code=200)
         config = get_default_config()
         status, error = check_link("https://example.com", config)
         assert status == 200
@@ -75,15 +76,15 @@ class TestCheckLink:
 
     @patch("docfix_bot.link_scanner.validate_ip_safety")
     @patch("docfix_bot.link_scanner.httpx.head")
-    def test_broken_404(self, mock_head: MagicMock, mock_validate: MagicMock) -> None:
+    def test_broken_404(self, mock_head, mock_validate) -> None:
         mock_validate.return_value = {"is_safe": True, "url": "", "resolved_ip": None, "rejection_reason": None}
-        mock_head.return_value = MagicMock(status_code=404)
+        mock_head.return_value = FakeHTTPResponse(status_code=404)
         config = get_default_config()
         status, error = check_link("https://example.com/missing", config)
         assert status == 404
 
     @patch("docfix_bot.link_scanner.validate_ip_safety")
-    def test_ssrf_blocked(self, mock_validate: MagicMock) -> None:
+    def test_ssrf_blocked(self, mock_validate) -> None:
         mock_validate.return_value = {
             "is_safe": False,
             "url": "",
@@ -98,10 +99,10 @@ class TestCheckLink:
     @patch("docfix_bot.link_scanner.validate_ip_safety")
     @patch("docfix_bot.link_scanner.httpx.head")
     @patch("docfix_bot.link_scanner.httpx.get")
-    def test_antibot_retry(self, mock_get: MagicMock, mock_head: MagicMock, mock_validate: MagicMock) -> None:
+    def test_antibot_retry(self, mock_get, mock_head, mock_validate) -> None:
         mock_validate.return_value = {"is_safe": True, "url": "", "resolved_ip": None, "rejection_reason": None}
-        mock_head.return_value = MagicMock(status_code=403)
-        mock_get.return_value = MagicMock(status_code=200)
+        mock_head.return_value = FakeHTTPResponse(status_code=403)
+        mock_get.return_value = FakeHTTPResponse(status_code=200)
         config = get_default_config()
         status, error = check_link("https://example.com", config)
         assert status == 200
@@ -109,7 +110,7 @@ class TestCheckLink:
 
     @patch("docfix_bot.link_scanner.validate_ip_safety")
     @patch("docfix_bot.link_scanner.httpx.head")
-    def test_timeout_retries(self, mock_head: MagicMock, mock_validate: MagicMock) -> None:
+    def test_timeout_retries(self, mock_head, mock_validate) -> None:
         mock_validate.return_value = {"is_safe": True, "url": "", "resolved_ip": None, "rejection_reason": None}
         mock_head.side_effect = httpx.ReadTimeout("timeout")
         config = get_default_config()
@@ -119,7 +120,7 @@ class TestCheckLink:
 
     @patch("docfix_bot.link_scanner.validate_ip_safety")
     @patch("docfix_bot.link_scanner.httpx.head")
-    def test_connection_error(self, mock_head: MagicMock, mock_validate: MagicMock) -> None:
+    def test_connection_error(self, mock_head, mock_validate) -> None:
         mock_validate.return_value = {"is_safe": True, "url": "", "resolved_ip": None, "rejection_reason": None}
         mock_head.side_effect = httpx.ConnectError("fail")
         config = get_default_config()
@@ -129,9 +130,7 @@ class TestCheckLink:
     @patch("docfix_bot.link_scanner.time.sleep")
     @patch("docfix_bot.link_scanner.validate_ip_safety")
     @patch("docfix_bot.link_scanner.httpx.head")
-    def test_http_error_retries_then_fails(
-        self, mock_head: MagicMock, mock_validate: MagicMock, mock_sleep: MagicMock
-    ) -> None:
+    def test_http_error_retries_then_fails(self, mock_head, mock_validate, mock_sleep) -> None:
         mock_validate.return_value = {"is_safe": True, "url": "", "resolved_ip": None, "rejection_reason": None}
         mock_head.side_effect = httpx.ConnectError("fail")
         config = get_default_config()
@@ -143,10 +142,10 @@ class TestCheckLink:
 
 class TestSuggestFix:
     @patch("docfix_bot.link_scanner.httpx.get")
-    def test_archive_found(self, mock_get: MagicMock) -> None:
-        mock_get.return_value = MagicMock(
+    def test_archive_found(self, mock_get) -> None:
+        mock_get.return_value = FakeHTTPResponse(
             status_code=200,
-            json=lambda: {
+            body={
                 "archived_snapshots": {
                     "closest": {
                         "available": True,
@@ -161,17 +160,17 @@ class TestSuggestFix:
         assert confidence > 0.0
 
     @patch("docfix_bot.link_scanner.httpx.get")
-    def test_no_archive(self, mock_get: MagicMock) -> None:
-        mock_get.return_value = MagicMock(
+    def test_no_archive(self, mock_get) -> None:
+        mock_get.return_value = FakeHTTPResponse(
             status_code=200,
-            json=lambda: {"archived_snapshots": {}},
+            body={"archived_snapshots": {}},
         )
         url, confidence = suggest_fix("https://gone.com")
         assert url is None
         assert confidence == 0.0
 
     @patch("docfix_bot.link_scanner.httpx.get")
-    def test_api_error(self, mock_get: MagicMock) -> None:
+    def test_api_error(self, mock_get) -> None:
         mock_get.side_effect = httpx.ConnectError("fail")
         url, confidence = suggest_fix("https://error.com")
         assert url is None
@@ -181,7 +180,7 @@ class TestSuggestFix:
 class TestScanRepository:
     @patch("docfix_bot.link_scanner.check_link")
     @patch("docfix_bot.link_scanner.suggest_fix")
-    def test_finds_broken_links(self, mock_suggest: MagicMock, mock_check: MagicMock, tmp_path: Path) -> None:
+    def test_finds_broken_links(self, mock_suggest, mock_check, tmp_path: Path) -> None:
         # Create a markdown file with a link
         md_file = tmp_path / "README.md"
         md_file.write_text("[Test](https://example.com/broken)\n")
@@ -199,7 +198,7 @@ class TestScanRepository:
         assert result["broken_links"][0]["status_code"] == 404
 
     @patch("docfix_bot.link_scanner.check_link")
-    def test_no_broken_links(self, mock_check: MagicMock, tmp_path: Path) -> None:
+    def test_no_broken_links(self, mock_check, tmp_path: Path) -> None:
         md_file = tmp_path / "README.md"
         md_file.write_text("[OK](https://example.com)\n")
         mock_check.return_value = (200, None)
@@ -215,7 +214,7 @@ class TestScanRepository:
         assert result["links_checked"] == 0
 
     @patch("docfix_bot.link_scanner.check_link")
-    def test_connection_error_logged(self, mock_check: MagicMock, tmp_path: Path) -> None:
+    def test_connection_error_logged(self, mock_check, tmp_path: Path) -> None:
         md_file = tmp_path / "README.md"
         md_file.write_text("[Link](https://example.com)\n")
         mock_check.return_value = (0, "Connection error")
@@ -244,7 +243,7 @@ class TestCheckLinkCoverageGaps:
     """Tests for uncovered lines in check_link."""
 
     @patch("docfix_bot.link_scanner.validate_ip_safety")
-    def test_zero_retries_returns_max_retries_exceeded(self, mock_ssrf: MagicMock) -> None:
+    def test_zero_retries_returns_max_retries_exceeded(self, mock_ssrf) -> None:
         """max_retries=0 falls through to 'Max retries exceeded' (line 124)."""
         mock_ssrf.return_value = {"is_safe": True, "rejection_reason": None}
         status, error = check_link("https://example.com", get_default_config(), max_retries=0)

--- a/tests/unit/docfix_bot/test_scheduler.py
+++ b/tests/unit/docfix_bot/test_scheduler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from docfix_bot.models import make_broken_link, make_target, now_iso
 from docfix_bot.scheduler import (
@@ -43,7 +43,7 @@ class TestShouldContinue:
 
 class TestRunDailyScan:
     @patch("docfix_bot.scheduler.load_targets")
-    def test_invalid_targets_returns_empty(self, mock_load: MagicMock, tmp_path: Path) -> None:
+    def test_invalid_targets_returns_empty(self, mock_load, tmp_path: Path) -> None:
         mock_load.side_effect = ValueError("not found")
         state = StateStore(tmp_path / "state.json")
         config = {"targets_path": str(tmp_path / "targets.yaml")}
@@ -60,13 +60,13 @@ class TestRunDailyScan:
     @patch("docfix_bot.scheduler.prioritize_targets")
     def test_full_workflow(
         self,
-        mock_prioritize: MagicMock,
-        mock_load: MagicMock,
-        mock_blocklist: MagicMock,
-        mock_contributing: MagicMock,
-        mock_clone: MagicMock,
-        mock_scan: MagicMock,
-        mock_execute: MagicMock,
+        mock_prioritize,
+        mock_load,
+        mock_blocklist,
+        mock_contributing,
+        mock_clone,
+        mock_scan,
+        mock_execute,
         tmp_path: Path,
     ) -> None:
         target = make_target("org", "repo")
@@ -121,12 +121,12 @@ class TestRunDailyScan:
     @patch("docfix_bot.scheduler.prioritize_targets")
     def test_no_broken_links(
         self,
-        mock_prioritize: MagicMock,
-        mock_load: MagicMock,
-        mock_blocklist: MagicMock,
-        mock_contributing: MagicMock,
-        mock_clone: MagicMock,
-        mock_scan: MagicMock,
+        mock_prioritize,
+        mock_load,
+        mock_blocklist,
+        mock_contributing,
+        mock_clone,
+        mock_scan,
         tmp_path: Path,
     ) -> None:
         target = make_target("org", "repo")
@@ -156,10 +156,10 @@ class TestRunDailyScan:
     @patch("docfix_bot.scheduler.prioritize_targets")
     def test_clone_failure(
         self,
-        mock_prioritize: MagicMock,
-        mock_load: MagicMock,
-        mock_blocklist: MagicMock,
-        mock_clone: MagicMock,
+        mock_prioritize,
+        mock_load,
+        mock_blocklist,
+        mock_clone,
         tmp_path: Path,
     ) -> None:
         target = make_target("org", "repo")
@@ -179,9 +179,9 @@ class TestRunDailyScan:
     @patch("docfix_bot.scheduler.prioritize_targets")
     def test_blocklisted_repo_skipped(
         self,
-        mock_prioritize: MagicMock,
-        mock_load: MagicMock,
-        mock_blocklist: MagicMock,
+        mock_prioritize,
+        mock_load,
+        mock_blocklist,
         tmp_path: Path,
     ) -> None:
         target = make_target("org", "repo")
@@ -202,11 +202,11 @@ class TestRunDailyScan:
     @patch("docfix_bot.scheduler.prioritize_targets")
     def test_contributing_disallows_bots(
         self,
-        mock_prioritize: MagicMock,
-        mock_load: MagicMock,
-        mock_blocklist: MagicMock,
-        mock_contributing: MagicMock,
-        mock_clone: MagicMock,
+        mock_prioritize,
+        mock_load,
+        mock_blocklist,
+        mock_contributing,
+        mock_clone,
         tmp_path: Path,
     ) -> None:
         target = make_target("org", "repo")
@@ -241,12 +241,12 @@ class TestRunDailyScan:
     @patch("docfix_bot.scheduler.prioritize_targets")
     def test_recently_scanned_skipped(
         self,
-        mock_prioritize: MagicMock,
-        mock_load: MagicMock,
-        mock_blocklist: MagicMock,
-        mock_contributing: MagicMock,
-        mock_clone: MagicMock,
-        mock_scan: MagicMock,
+        mock_prioritize,
+        mock_load,
+        mock_blocklist,
+        mock_contributing,
+        mock_clone,
+        mock_scan,
         tmp_path: Path,
     ) -> None:
         target = make_target("org", "repo")
@@ -274,12 +274,12 @@ class TestRunDailyScan:
     @patch("docfix_bot.scheduler.prioritize_targets")
     def test_all_links_already_fixed(
         self,
-        mock_prioritize: MagicMock,
-        mock_load: MagicMock,
-        mock_blocklist: MagicMock,
-        mock_contributing: MagicMock,
-        mock_clone: MagicMock,
-        mock_scan: MagicMock,
+        mock_prioritize,
+        mock_load,
+        mock_blocklist,
+        mock_contributing,
+        mock_clone,
+        mock_scan,
         tmp_path: Path,
     ) -> None:
         target = make_target("org", "repo")
@@ -334,12 +334,12 @@ class TestRunDailyScan:
     @patch("docfix_bot.scheduler.prioritize_targets")
     def test_no_fixable_links(
         self,
-        mock_prioritize: MagicMock,
-        mock_load: MagicMock,
-        mock_blocklist: MagicMock,
-        mock_contributing: MagicMock,
-        mock_clone: MagicMock,
-        mock_scan: MagicMock,
+        mock_prioritize,
+        mock_load,
+        mock_blocklist,
+        mock_contributing,
+        mock_clone,
+        mock_scan,
         tmp_path: Path,
     ) -> None:
         target = make_target("org", "repo")
@@ -372,10 +372,10 @@ class TestRunDailyScan:
     @patch("docfix_bot.scheduler.prioritize_targets")
     def test_limit_reached_mid_loop(
         self,
-        mock_prioritize: MagicMock,
-        mock_load: MagicMock,
-        mock_blocklist: MagicMock,
-        mock_should_continue: MagicMock,
+        mock_prioritize,
+        mock_load,
+        mock_blocklist,
+        mock_should_continue,
         tmp_path: Path,
     ) -> None:
         targets = [make_target("org", "repo1"), make_target("org", "repo2")]
@@ -392,7 +392,7 @@ class TestRunDailyScan:
         state.close()
 
     @patch("docfix_bot.scheduler.load_targets")
-    def test_default_config_and_state(self, mock_load: MagicMock, tmp_path: Path) -> None:
+    def test_default_config_and_state(self, mock_load, tmp_path: Path) -> None:
         """When config is None, get_default_config() is used."""
         mock_load.side_effect = ValueError("not found")
         # Pass None for config to trigger the default path

--- a/tests/unit/pipeline/test_n2.py
+++ b/tests/unit/pipeline/test_n2.py
@@ -5,8 +5,14 @@ See LLD #22 §10.0 T100/T110: N2 Wayback success, no candidates.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
+from gh_link_auditor.link_detective import (
+    CandidateReplacement,
+    ForensicReport,
+    Investigation,
+    InvestigationMethod,
+)
 from gh_link_auditor.pipeline.nodes.n2_investigate import (
     investigate_dead_link,
     n2_investigate,
@@ -32,41 +38,52 @@ class TestRunInvestigation:
         """_run_investigation lazily imports and calls LinkDetective.investigate."""
         from gh_link_auditor.pipeline.nodes.n2_investigate import _run_investigation
 
-        mock_detective_cls = MagicMock()
-        mock_detective_inst = MagicMock()
-        mock_detective_cls.return_value = mock_detective_inst
-        mock_detective_inst.investigate.return_value = MagicMock()
+        report = ForensicReport(
+            dead_url="https://example.com/dead",
+            http_status=404,
+            investigation=Investigation(
+                archive_snapshot=None,
+                archive_title=None,
+                archive_content_summary=None,
+                candidate_replacements=[],
+                investigation_log=["test"],
+            ),
+        )
 
-        with patch.dict(
-            "sys.modules",
-            {"gh_link_auditor.link_detective": MagicMock(LinkDetective=mock_detective_cls)},
+        with patch(
+            "gh_link_auditor.link_detective.LinkDetective.investigate",
+            return_value=report,
         ):
             result = _run_investigation("https://example.com/dead", 404)
 
-        mock_detective_inst.investigate.assert_called_once_with("https://example.com/dead", 404)
-        assert result is mock_detective_inst.investigate.return_value
+        assert result.dead_url == "https://example.com/dead"
 
 
 class TestInvestigateDeadLink:
     """Tests for investigate_dead_link()."""
 
     def test_returns_candidates_from_investigation(self) -> None:
-        mock_report = MagicMock()
-        mock_report.dead_url = "https://example.com/broken"
-        mock_report.investigation.archive_snapshot = "https://web.archive.org/web/2024/https://example.com/broken"
-        mock_report.investigation.archive_title = "Example Page"
-        mock_report.investigation.archive_content_summary = "Some content"
-        mock_report.investigation.candidate_replacements = [
-            MagicMock(
-                url="https://example.com/new-page",
-                method=MagicMock(value="redirect_chain"),
-                similarity_score=0.95,
-                verified_live=True,
+        report = ForensicReport(
+            dead_url="https://example.com/broken",
+            http_status=404,
+            investigation=Investigation(
+                archive_snapshot="https://web.archive.org/web/2024/https://example.com/broken",
+                archive_title="Example Page",
+                archive_content_summary="Some content",
+                candidate_replacements=[
+                    CandidateReplacement(
+                        url="https://example.com/new-page",
+                        method=InvestigationMethod.REDIRECT_CHAIN,
+                        similarity_score=0.95,
+                        verified_live=True,
+                    ),
+                ],
+                investigation_log=["test"],
             ),
-        ]
+        )
         with patch(
             "gh_link_auditor.pipeline.nodes.n2_investigate._run_investigation",
-            return_value=mock_report,
+            return_value=report,
         ):
             dead_link = _make_dead_link()
             candidates = investigate_dead_link(dead_link)
@@ -74,15 +91,20 @@ class TestInvestigateDeadLink:
         assert candidates[0]["url"] == "https://example.com/new-page"
 
     def test_returns_empty_when_no_candidates(self) -> None:
-        mock_report = MagicMock()
-        mock_report.dead_url = "https://example.com/gone"
-        mock_report.investigation.archive_snapshot = None
-        mock_report.investigation.archive_title = None
-        mock_report.investigation.archive_content_summary = None
-        mock_report.investigation.candidate_replacements = []
+        report = ForensicReport(
+            dead_url="https://example.com/gone",
+            http_status=404,
+            investigation=Investigation(
+                archive_snapshot=None,
+                archive_title=None,
+                archive_content_summary=None,
+                candidate_replacements=[],
+                investigation_log=["no candidates"],
+            ),
+        )
         with patch(
             "gh_link_auditor.pipeline.nodes.n2_investigate._run_investigation",
-            return_value=mock_report,
+            return_value=report,
         ):
             candidates = investigate_dead_link(_make_dead_link("https://example.com/gone"))
         assert candidates == []

--- a/tests/unit/repo_scout/test_awesome_parser.py
+++ b/tests/unit/repo_scout/test_awesome_parser.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import httpx
 
@@ -12,6 +12,7 @@ from repo_scout.awesome_parser import (
     normalize_github_url,
     parse_awesome_list,
 )
+from tests.fakes.http import FakeHTTPResponse
 
 
 class TestNormalizeGitHubUrl:
@@ -132,11 +133,8 @@ class TestFetchMarkdown:
     """Tests for _fetch_markdown."""
 
     @patch("repo_scout.awesome_parser.httpx.get")
-    def test_github_url_converts_to_raw(self, mock_get: MagicMock) -> None:
-        mock_response = MagicMock()
-        mock_response.text = "# Awesome"
-        mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+    def test_github_url_converts_to_raw(self, mock_get) -> None:
+        mock_get.return_value = FakeHTTPResponse(status_code=200, text="# Awesome")
 
         result = _fetch_markdown("https://github.com/org/awesome-list")
         assert result == "# Awesome"
@@ -147,11 +145,8 @@ class TestFetchMarkdown:
         )
 
     @patch("repo_scout.awesome_parser.httpx.get")
-    def test_non_github_url_used_directly(self, mock_get: MagicMock) -> None:
-        mock_response = MagicMock()
-        mock_response.text = "content"
-        mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+    def test_non_github_url_used_directly(self, mock_get) -> None:
+        mock_get.return_value = FakeHTTPResponse(status_code=200, text="content")
 
         result = _fetch_markdown("https://example.com/list.md")
         assert result == "content"
@@ -162,18 +157,15 @@ class TestFetchMarkdown:
         )
 
     @patch("repo_scout.awesome_parser.httpx.get")
-    def test_http_error_returns_empty(self, mock_get: MagicMock) -> None:
+    def test_http_error_returns_empty(self, mock_get) -> None:
         mock_get.side_effect = httpx.ConnectError("fail")
         result = _fetch_markdown("https://github.com/org/repo")
         assert result == ""
 
     @patch("repo_scout.awesome_parser.httpx.get")
-    def test_raise_for_status_error(self, mock_get: MagicMock) -> None:
-        mock_response = MagicMock()
-        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
-            "404", request=MagicMock(), response=MagicMock()
-        )
-        mock_get.return_value = mock_response
+    def test_raise_for_status_error(self, mock_get) -> None:
+        fake_resp = FakeHTTPResponse(status_code=404, text="Not Found")
+        mock_get.return_value = fake_resp
 
         result = _fetch_markdown("https://github.com/org/repo")
         assert result == ""
@@ -183,7 +175,7 @@ class TestParseAwesomeList:
     """Tests for parse_awesome_list."""
 
     @patch("repo_scout.awesome_parser._fetch_markdown")
-    def test_full_parse(self, mock_fetch: MagicMock) -> None:
+    def test_full_parse(self, mock_fetch) -> None:
         mock_fetch.return_value = """# Awesome
 
 ## Tools
@@ -200,13 +192,13 @@ class TestParseAwesomeList:
         assert records[0]["metadata"]["source_url"] == "https://github.com/org/awesome-list"
 
     @patch("repo_scout.awesome_parser._fetch_markdown")
-    def test_empty_markdown(self, mock_fetch: MagicMock) -> None:
+    def test_empty_markdown(self, mock_fetch) -> None:
         mock_fetch.return_value = ""
         records = parse_awesome_list("https://github.com/org/awesome")
         assert records == []
 
     @patch("repo_scout.awesome_parser._fetch_markdown")
-    def test_dedup_within_list(self, mock_fetch: MagicMock) -> None:
+    def test_dedup_within_list(self, mock_fetch) -> None:
         mock_fetch.return_value = """- [A](https://github.com/org/repo) - First mention
 - [B](https://github.com/org/repo) - Duplicate
 """
@@ -214,28 +206,24 @@ class TestParseAwesomeList:
         assert len(records) == 1
 
     @patch("repo_scout.awesome_parser._fetch_markdown")
-    def test_no_section_metadata(self, mock_fetch: MagicMock) -> None:
+    def test_no_section_metadata(self, mock_fetch) -> None:
         mock_fetch.return_value = "- [Repo](https://github.com/org/repo) - Desc"
         records = parse_awesome_list("https://github.com/org/awesome")
         assert len(records) == 1
         assert "section" not in records[0]["metadata"]
 
     @patch("repo_scout.awesome_parser._fetch_markdown")
-    def test_link_text_in_metadata(self, mock_fetch: MagicMock) -> None:
+    def test_link_text_in_metadata(self, mock_fetch) -> None:
         mock_fetch.return_value = "- [My Tool](https://github.com/org/tool) - Desc"
         records = parse_awesome_list("https://github.com/org/awesome")
         assert records[0]["metadata"]["link_text"] == "My Tool"
 
     @patch("repo_scout.awesome_parser._fetch_markdown")
-    def test_filtered_urls_excluded(self, mock_fetch: MagicMock) -> None:
+    def test_filtered_urls_excluded(self, mock_fetch) -> None:
         mock_fetch.return_value = (
             "- [Features](https://github.com/features/something) - Not a repo\n"
             "- [Real](https://github.com/org/real) - A repo"
         )
         records = parse_awesome_list("https://github.com/org/awesome")
-        # "features/something" won't match _GITHUB_LINK_RE since the regex requires
-        # the link to be in the format github.com/owner/repo, and the link format
-        # in extract_github_links is different from normalize_github_url.
-        # The normalize step will filter it.
         for r in records:
             assert r["owner"] != "features"

--- a/tests/unit/repo_scout/test_cli.py
+++ b/tests/unit/repo_scout/test_cli.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from repo_scout.cli import build_parser, main, print_progress, print_statistics
 from repo_scout.models import DiscoverySource, make_repo_record
+from tests.fakes.github import FakeGitHubClient
 
 
 def _repo(owner: str = "org", name: str = "repo", source: str = "awesome_list") -> dict:
@@ -117,28 +118,28 @@ class TestMain:
 
     @patch("repo_scout.cli.GitHubClient")
     @patch("repo_scout.cli.write_output")
-    def test_no_sources_writes_empty(self, mock_write: MagicMock, mock_client_cls: MagicMock, tmp_path: Path) -> None:
-        mock_client = MagicMock()
-        mock_client_cls.return_value = mock_client
+    def test_no_sources_writes_empty(self, mock_write, mock_client_cls, tmp_path: Path) -> None:
+        fake_client = FakeGitHubClient()
+        mock_client_cls.return_value = fake_client
         mock_write.return_value = 0
 
         output = str(tmp_path / "out.json")
         exit_code = main(["--output", output])
         assert exit_code == 0
-        mock_client.close.assert_called_once()
+        assert fake_client.close_calls == 1
 
     @patch("repo_scout.cli.GitHubClient")
     @patch("repo_scout.cli.parse_awesome_list")
     @patch("repo_scout.cli.write_output")
     def test_awesome_list_source(
         self,
-        mock_write: MagicMock,
-        mock_parse: MagicMock,
-        mock_client_cls: MagicMock,
+        mock_write,
+        mock_parse,
+        mock_client_cls,
         tmp_path: Path,
     ) -> None:
-        mock_client = MagicMock()
-        mock_client_cls.return_value = mock_client
+        fake_client = FakeGitHubClient()
+        mock_client_cls.return_value = fake_client
         mock_parse.return_value = [_repo("org", "repo")]
         mock_write.return_value = 1
 
@@ -152,33 +153,33 @@ class TestMain:
     @patch("repo_scout.cli.write_output")
     def test_star_walking_source(
         self,
-        mock_write: MagicMock,
-        mock_walk: MagicMock,
-        mock_client_cls: MagicMock,
+        mock_write,
+        mock_walk,
+        mock_client_cls,
         tmp_path: Path,
     ) -> None:
-        mock_client = MagicMock()
-        mock_client_cls.return_value = mock_client
+        fake_client = FakeGitHubClient()
+        mock_client_cls.return_value = fake_client
         mock_walk.return_value = [_repo("org", "starred", "starred_repo")]
         mock_write.return_value = 1
 
         output = str(tmp_path / "out.json")
         exit_code = main(["--root-users", "user1", "--star-depth", "3", "--output", output])
         assert exit_code == 0
-        mock_walk.assert_called_once_with("user1", mock_client, max_depth=3)
+        mock_walk.assert_called_once_with("user1", fake_client, max_depth=3)
 
     @patch("repo_scout.cli.GitHubClient")
     @patch("repo_scout.cli.suggest_repos")
     @patch("repo_scout.cli.write_output")
     def test_keywords_source(
         self,
-        mock_write: MagicMock,
-        mock_suggest: MagicMock,
-        mock_client_cls: MagicMock,
+        mock_write,
+        mock_suggest,
+        mock_client_cls,
         tmp_path: Path,
     ) -> None:
-        mock_client = MagicMock()
-        mock_client_cls.return_value = mock_client
+        fake_client = FakeGitHubClient()
+        mock_client_cls.return_value = fake_client
         mock_suggest.return_value = []
         mock_write.return_value = 0
 
@@ -189,27 +190,27 @@ class TestMain:
 
     @patch("repo_scout.cli.GitHubClient")
     @patch("repo_scout.cli.parse_awesome_list")
-    def test_error_returns_1(self, mock_parse: MagicMock, mock_client_cls: MagicMock) -> None:
-        mock_client = MagicMock()
-        mock_client_cls.return_value = mock_client
+    def test_error_returns_1(self, mock_parse, mock_client_cls) -> None:
+        fake_client = FakeGitHubClient()
+        mock_client_cls.return_value = fake_client
         mock_parse.side_effect = RuntimeError("Boom")
 
         exit_code = main(["--awesome-lists", "https://example.com"])
         assert exit_code == 1
-        mock_client.close.assert_called_once()
+        assert fake_client.close_calls == 1
 
     @patch("repo_scout.cli.harvest_from_stargazers")
     @patch("repo_scout.cli.GitHubClient")
     @patch("repo_scout.cli.write_output")
     def test_seed_repos_calls_harvester(
         self,
-        mock_write: MagicMock,
-        mock_client_cls: MagicMock,
-        mock_harvest: MagicMock,
+        mock_write,
+        mock_client_cls,
+        mock_harvest,
         tmp_path: Path,
     ) -> None:
-        mock_client = MagicMock()
-        mock_client_cls.return_value = mock_client
+        fake_client = FakeGitHubClient()
+        mock_client_cls.return_value = fake_client
         mock_harvest.return_value = [_repo("alice", "tool", "stargazer_target")]
         mock_write.return_value = 1
 
@@ -236,11 +237,9 @@ class TestMain:
     @patch("repo_scout.cli.GitHubClient")
     @patch("repo_scout.cli.write_output")
     @patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_test"})
-    def test_reads_github_token_from_env(
-        self, mock_write: MagicMock, mock_client_cls: MagicMock, tmp_path: Path
-    ) -> None:
-        mock_client = MagicMock()
-        mock_client_cls.return_value = mock_client
+    def test_reads_github_token_from_env(self, mock_write, mock_client_cls, tmp_path: Path) -> None:
+        fake_client = FakeGitHubClient()
+        mock_client_cls.return_value = fake_client
         mock_write.return_value = 0
 
         output = str(tmp_path / "out.json")

--- a/tests/unit/repo_scout/test_github_client.py
+++ b/tests/unit/repo_scout/test_github_client.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import httpx
 
 from repo_scout.github_client import GitHubClient
+from tests.fakes.http import FakeHTTPResponse
 
 
 class TestGitHubClientInit:
@@ -45,7 +46,7 @@ class TestRateLimit:
     """Tests for rate limiting."""
 
     @patch("repo_scout.github_client.time")
-    def test_rate_limit_enforced(self, mock_time: MagicMock) -> None:
+    def test_rate_limit_enforced(self, mock_time) -> None:
         mock_time.time.side_effect = [0.0, 0.5, 1.5]
         client = GitHubClient(rate_limit_delay=1.0)
         client._last_request_time = 0.0
@@ -57,7 +58,7 @@ class TestRateLimit:
         client.close()
 
     @patch("repo_scout.github_client.time")
-    def test_no_wait_if_enough_time_passed(self, mock_time: MagicMock) -> None:
+    def test_no_wait_if_enough_time_passed(self, mock_time) -> None:
         client = GitHubClient(rate_limit_delay=1.0)
         client._last_request_time = 0.0
 
@@ -73,31 +74,27 @@ class TestRequest:
 
     def test_success_200(self) -> None:
         client = GitHubClient(rate_limit_delay=0.0)
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"id": 1}
+        fake_response = FakeHTTPResponse(status_code=200, body={"id": 1})
 
-        with patch.object(client._client, "get", return_value=mock_response):
+        with patch.object(client._client, "get", return_value=fake_response):
             result = client.request("/repos/owner/name")
         assert result == {"id": 1}
         client.close()
 
     def test_not_found_404(self) -> None:
         client = GitHubClient(rate_limit_delay=0.0)
-        mock_response = MagicMock()
-        mock_response.status_code = 404
+        fake_response = FakeHTTPResponse(status_code=404)
 
-        with patch.object(client._client, "get", return_value=mock_response):
+        with patch.object(client._client, "get", return_value=fake_response):
             result = client.request("/repos/owner/nonexistent")
         assert result is None
         client.close()
 
     def test_other_status_code(self) -> None:
         client = GitHubClient(rate_limit_delay=0.0)
-        mock_response = MagicMock()
-        mock_response.status_code = 403
+        fake_response = FakeHTTPResponse(status_code=403)
 
-        with patch.object(client._client, "get", return_value=mock_response):
+        with patch.object(client._client, "get", return_value=fake_response):
             result = client.request("/repos/owner/name")
         assert result is None
         client.close()
@@ -112,11 +109,9 @@ class TestRequest:
 
     def test_full_url_used_when_no_slash_prefix(self) -> None:
         client = GitHubClient(rate_limit_delay=0.0)
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"ok": True}
+        fake_response = FakeHTTPResponse(status_code=200, body={"ok": True})
 
-        with patch.object(client._client, "get", return_value=mock_response) as mock_get:
+        with patch.object(client._client, "get", return_value=fake_response) as mock_get:
             client.request("https://custom.api/endpoint")
         mock_get.assert_called_once_with("https://custom.api/endpoint")
         client.close()

--- a/tests/unit/repo_scout/test_llm_brainstormer.py
+++ b/tests/unit/repo_scout/test_llm_brainstormer.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 from repo_scout.llm_brainstormer import (
     build_suggestion_prompt,
     parse_llm_response,
     suggest_repos,
     validate_suggestions,
 )
+from tests.fakes.github import FakeGitHubClient
 
 
 class TestBuildSuggestionPrompt:
@@ -82,31 +81,33 @@ class TestValidateSuggestions:
     """Tests for validate_suggestions."""
 
     def test_valid_repos(self) -> None:
-        mock_client = MagicMock()
-        mock_client.repo_exists.return_value = True
+        client = FakeGitHubClient()
+        client.configure_repo("org/repo1", {"name": "repo1"})
+        client.configure_repo("org/repo2", {"name": "repo2"})
 
-        records = validate_suggestions(["org/repo1", "org/repo2"], mock_client)
+        records = validate_suggestions(["org/repo1", "org/repo2"], client)
         assert len(records) == 2
         assert records[0]["full_name"] == "org/repo1"
         assert records[0]["sources"] == ["llm_suggestion"]
 
     def test_invalid_repo_skipped(self) -> None:
-        mock_client = MagicMock()
-        mock_client.repo_exists.side_effect = [True, False]
+        client = FakeGitHubClient()
+        client.configure_repo("org/real", {"name": "real"})
+        # org/fake not configured → repo_exists returns False
 
-        records = validate_suggestions(["org/real", "org/fake"], mock_client)
+        records = validate_suggestions(["org/real", "org/fake"], client)
         assert len(records) == 1
         assert records[0]["full_name"] == "org/real"
 
     def test_bad_format_skipped(self) -> None:
-        mock_client = MagicMock()
-        records = validate_suggestions(["not-a-repo-format"], mock_client)
+        client = FakeGitHubClient()
+        records = validate_suggestions(["not-a-repo-format"], client)
         assert records == []
-        mock_client.repo_exists.assert_not_called()
+        assert client.repo_exists_calls == []
 
     def test_empty_list(self) -> None:
-        mock_client = MagicMock()
-        records = validate_suggestions([], mock_client)
+        client = FakeGitHubClient()
+        records = validate_suggestions([], client)
         assert records == []
 
 
@@ -133,14 +134,14 @@ class TestSuggestRepos:
         assert result[0]["metadata"]["validated"] is False
 
     def test_with_response_and_client(self) -> None:
-        mock_client = MagicMock()
-        mock_client.repo_exists.return_value = True
+        client = FakeGitHubClient()
+        client.configure_repo("org/repo1", {"name": "repo1"})
 
         result = suggest_repos(
             keywords=["python"],
             existing_repos=[],
             llm_response="org/repo1",
-            github_client=mock_client,
+            github_client=client,
         )
         assert len(result) == 1
         assert result[0]["full_name"] == "org/repo1"

--- a/tests/unit/repo_scout/test_star_walker.py
+++ b/tests/unit/repo_scout/test_star_walker.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 from repo_scout.models import DiscoverySource, make_repo_record
 from repo_scout.star_walker import get_user_starred, walk_starred_repos
+from tests.fakes.github import FakeGitHubClient
 
 
 def _make_starred(owner: str, name: str) -> dict:
@@ -21,70 +20,63 @@ class TestGetUserStarred:
     """Tests for get_user_starred."""
 
     def test_delegates_to_client(self) -> None:
-        mock_client = MagicMock()
+        client = FakeGitHubClient()
         expected = [_make_starred("org", "repo")]
-        mock_client.get_starred.return_value = expected
+        client.configure_starred("user1", expected)
 
-        result = get_user_starred("user1", mock_client)
+        result = get_user_starred("user1", client)
         assert result == expected
-        mock_client.get_starred.assert_called_once_with("user1")
+        assert client.get_starred_calls == ["user1"]
 
 
 class TestWalkStarredRepos:
     """Tests for walk_starred_repos."""
 
     def test_single_depth(self) -> None:
-        mock_client = MagicMock()
-        mock_client.get_starred.return_value = [
-            _make_starred("org1", "repo1"),
-            _make_starred("org2", "repo2"),
-        ]
+        client = FakeGitHubClient()
+        client.configure_starred(
+            "root_user",
+            [
+                _make_starred("org1", "repo1"),
+                _make_starred("org2", "repo2"),
+            ],
+        )
 
-        result = walk_starred_repos("root_user", mock_client, max_depth=1)
+        result = walk_starred_repos("root_user", client, max_depth=1)
         assert len(result) == 2
         assert result[0]["metadata"]["root_user"] == "root_user"
         assert result[0]["metadata"]["depth"] == 0
 
     def test_cycle_detection(self) -> None:
-        mock_client = MagicMock()
-        repo1 = _make_starred("org", "repo1")
-        repo2 = _make_starred("org", "repo2")
+        client = FakeGitHubClient()
+        repos = [_make_starred("org", "repo1"), _make_starred("org", "repo2")]
+        # Both root_user and org return the same repos
+        client.configure_starred("root_user", repos)
+        client.configure_starred("org", repos)
 
-        # Both depth 0 and depth 1 return the same repos
-        mock_client.get_starred.side_effect = [
-            [repo1, repo2],
-            [repo1, repo2],  # duplicates at depth 1
-        ]
-
-        result = walk_starred_repos("root_user", mock_client, max_depth=2)
+        result = walk_starred_repos("root_user", client, max_depth=2)
         # Only 2 unique repos, not 4
         assert len(result) == 2
 
     def test_max_depth_zero(self) -> None:
-        mock_client = MagicMock()
-        result = walk_starred_repos("root_user", mock_client, max_depth=0)
+        client = FakeGitHubClient()
+        result = walk_starred_repos("root_user", client, max_depth=0)
         assert result == []
-        mock_client.get_starred.assert_not_called()
+        assert client.get_starred_calls == []
 
     def test_depth_two_traversal(self) -> None:
-        mock_client = MagicMock()
+        client = FakeGitHubClient()
+        client.configure_starred(
+            "root_user",
+            [
+                _make_starred("org1", "repo1"),
+                _make_starred("org2", "repo2"),
+            ],
+        )
+        client.configure_starred("org1", [_make_starred("org3", "repo3")])
+        client.configure_starred("org2", [_make_starred("org4", "repo4")])
 
-        # Depth 0: root_user starred repo1 (owned by org1) and repo2 (owned by org2)
-        depth0_repos = [
-            _make_starred("org1", "repo1"),
-            _make_starred("org2", "repo2"),
-        ]
-        # Depth 1: org1 starred repo3, org2 starred repo4
-        depth1_repos_org1 = [_make_starred("org3", "repo3")]
-        depth1_repos_org2 = [_make_starred("org4", "repo4")]
-
-        mock_client.get_starred.side_effect = [
-            depth0_repos,
-            depth1_repos_org1,
-            depth1_repos_org2,
-        ]
-
-        result = walk_starred_repos("root_user", mock_client, max_depth=2)
+        result = walk_starred_repos("root_user", client, max_depth=2)
         assert len(result) == 4
         # Depth 0 repos have depth=0
         assert result[0]["metadata"]["depth"] == 0
@@ -94,36 +86,33 @@ class TestWalkStarredRepos:
         assert result[3]["metadata"]["depth"] == 1
 
     def test_root_user_excluded_from_next_depth(self) -> None:
-        mock_client = MagicMock()
-
+        client = FakeGitHubClient()
         # root_user starred a repo owned by root_user themselves
-        depth0_repos = [_make_starred("root_user", "my-repo")]
+        client.configure_starred("root_user", [_make_starred("root_user", "my-repo")])
 
-        mock_client.get_starred.side_effect = [
-            depth0_repos,
-            # root_user should NOT be walked again at depth 1
-        ]
-
-        result = walk_starred_repos("root_user", mock_client, max_depth=2)
+        result = walk_starred_repos("root_user", client, max_depth=2)
         assert len(result) == 1
         # Only called once (for root_user at depth 0)
-        assert mock_client.get_starred.call_count == 1
+        assert len(client.get_starred_calls) == 1
 
     def test_visited_parameter_pre_seeds(self) -> None:
-        mock_client = MagicMock()
-        mock_client.get_starred.return_value = [
-            _make_starred("org", "already-seen"),
-            _make_starred("org", "new-repo"),
-        ]
+        client = FakeGitHubClient()
+        client.configure_starred(
+            "root_user",
+            [
+                _make_starred("org", "already-seen"),
+                _make_starred("org", "new-repo"),
+            ],
+        )
 
         visited = {"org/already-seen"}
-        result = walk_starred_repos("root_user", mock_client, max_depth=1, visited=visited)
+        result = walk_starred_repos("root_user", client, max_depth=1, visited=visited)
         assert len(result) == 1
         assert result[0]["name"] == "new-repo"
 
     def test_empty_starred(self) -> None:
-        mock_client = MagicMock()
-        mock_client.get_starred.return_value = []
+        client = FakeGitHubClient()
+        # No starred repos configured → returns empty
 
-        result = walk_starred_repos("root_user", mock_client, max_depth=2)
+        result = walk_starred_repos("root_user", client, max_depth=2)
         assert result == []

--- a/tests/unit/repo_scout/test_stargazer_harvester.py
+++ b/tests/unit/repo_scout/test_stargazer_harvester.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 from repo_scout.models import DiscoverySource, make_repo_record
 from repo_scout.stargazer_harvester import (
     _is_recently_active,
     harvest_from_stargazers,
 )
+from tests.fakes.github import FakeGitHubClient
 
 
 def _make_user_repo(
@@ -65,22 +64,25 @@ class TestHarvestFromStargazers:
     """Tests for harvest_from_stargazers."""
 
     def test_basic_harvest(self) -> None:
-        client = MagicMock()
-        client.get_stargazers.return_value = ["alice"]
-        client.get_user_repos.return_value = [
-            make_repo_record(
-                owner="alice",
-                name="cool-tool",
-                source=DiscoverySource.STARGAZER_TARGET,
-                metadata={
-                    "seed_repo": "anthropics/claude-code",
-                    "stargazer_username": "alice",
-                    "pushed_at": "2026-02-01T00:00:00Z",
-                    "has_issues": True,
-                    "language": "Python",
-                },
-            )
-        ]
+        client = FakeGitHubClient()
+        client.configure_stargazers("anthropics/claude-code", ["alice"])
+        client.configure_user_repos(
+            "alice",
+            [
+                make_repo_record(
+                    owner="alice",
+                    name="cool-tool",
+                    source=DiscoverySource.STARGAZER_TARGET,
+                    metadata={
+                        "seed_repo": "anthropics/claude-code",
+                        "stargazer_username": "alice",
+                        "pushed_at": "2026-02-01T00:00:00Z",
+                        "has_issues": True,
+                        "language": "Python",
+                    },
+                )
+            ],
+        )
 
         result = harvest_from_stargazers(
             seed_repos=["anthropics/claude-code"],
@@ -93,45 +95,44 @@ class TestHarvestFromStargazers:
         assert result[0]["sources"] == ["stargazer_target"]
 
     def test_empty_stargazers_returns_empty(self) -> None:
-        client = MagicMock()
-        client.get_stargazers.return_value = []
+        client = FakeGitHubClient()
+        # No stargazers configured → returns empty
 
         result = harvest_from_stargazers(
             seed_repos=["org/repo"],
             github_client=client,
         )
         assert result == []
-        client.get_user_repos.assert_not_called()
+        assert client.get_user_repos_calls == []
 
     def test_max_stargazers_respected(self) -> None:
-        client = MagicMock()
-        client.get_stargazers.return_value = ["u1", "u2", "u3"]
-        client.get_user_repos.return_value = []
+        client = FakeGitHubClient()
+        client.configure_stargazers("org/repo", ["u1", "u2", "u3"])
 
         harvest_from_stargazers(
             seed_repos=["org/repo"],
             github_client=client,
             max_stargazers=50,
         )
-        client.get_stargazers.assert_called_once_with("org", "repo", max_count=50)
+        assert len(client.get_stargazers_calls) == 1
+        assert client.get_stargazers_calls[0] == ("org", "repo", 50)
 
     def test_duplicate_stargazers_across_seeds_processed_once(self) -> None:
-        client = MagicMock()
+        client = FakeGitHubClient()
         # Both seeds return the same stargazer
-        client.get_stargazers.side_effect = [["alice"], ["alice"]]
-        client.get_user_repos.return_value = []
+        client.configure_stargazers("org/repo1", ["alice"])
+        client.configure_stargazers("org/repo2", ["alice"])
 
         harvest_from_stargazers(
             seed_repos=["org/repo1", "org/repo2"],
             github_client=client,
         )
         # get_user_repos should only be called once for alice
-        assert client.get_user_repos.call_count == 1
+        assert len(client.get_user_repos_calls) == 1
 
     def test_repo_age_filtering_old_repo_excluded(self) -> None:
-        client = MagicMock()
-        client.get_stargazers.return_value = ["alice"]
-        # get_user_repos returns a repo but with old pushed_at
+        client = FakeGitHubClient()
+        client.configure_stargazers("org/repo", ["alice"])
         old_repo = make_repo_record(
             owner="alice",
             name="old-repo",
@@ -144,7 +145,7 @@ class TestHarvestFromStargazers:
                 "language": "Python",
             },
         )
-        client.get_user_repos.return_value = [old_repo]
+        client.configure_user_repos("alice", [old_repo])
 
         result = harvest_from_stargazers(
             seed_repos=["org/repo"],
@@ -154,8 +155,8 @@ class TestHarvestFromStargazers:
         assert result == []
 
     def test_repo_age_filtering_recent_repo_included(self) -> None:
-        client = MagicMock()
-        client.get_stargazers.return_value = ["alice"]
+        client = FakeGitHubClient()
+        client.configure_stargazers("org/repo", ["alice"])
         recent_repo = make_repo_record(
             owner="alice",
             name="new-repo",
@@ -168,7 +169,7 @@ class TestHarvestFromStargazers:
                 "language": "Python",
             },
         )
-        client.get_user_repos.return_value = [recent_repo]
+        client.configure_user_repos("alice", [recent_repo])
 
         result = harvest_from_stargazers(
             seed_repos=["org/repo"],
@@ -178,8 +179,8 @@ class TestHarvestFromStargazers:
         assert len(result) == 1
 
     def test_repo_age_filtering_none_pushed_at_excluded(self) -> None:
-        client = MagicMock()
-        client.get_stargazers.return_value = ["alice"]
+        client = FakeGitHubClient()
+        client.configure_stargazers("org/repo", ["alice"])
         no_push_repo = make_repo_record(
             owner="alice",
             name="no-push",
@@ -192,7 +193,7 @@ class TestHarvestFromStargazers:
                 "language": None,
             },
         )
-        client.get_user_repos.return_value = [no_push_repo]
+        client.configure_user_repos("alice", [no_push_repo])
 
         result = harvest_from_stargazers(
             seed_repos=["org/repo"],
@@ -202,8 +203,8 @@ class TestHarvestFromStargazers:
         assert result == []
 
     def test_metadata_includes_seed_and_stargazer(self) -> None:
-        client = MagicMock()
-        client.get_stargazers.return_value = ["bob"]
+        client = FakeGitHubClient()
+        client.configure_stargazers("anthropics/claude-code", ["bob"])
         repo = make_repo_record(
             owner="bob",
             name="tool",
@@ -216,7 +217,7 @@ class TestHarvestFromStargazers:
                 "language": "TypeScript",
             },
         )
-        client.get_user_repos.return_value = [repo]
+        client.configure_user_repos("bob", [repo])
 
         result = harvest_from_stargazers(
             seed_repos=["anthropics/claude-code"],
@@ -226,31 +227,34 @@ class TestHarvestFromStargazers:
         assert result[0]["metadata"]["stargazer_username"] == "bob"
 
     def test_invalid_seed_repo_format_skipped(self) -> None:
-        client = MagicMock()
+        client = FakeGitHubClient()
 
         result = harvest_from_stargazers(
             seed_repos=["invalid-no-slash"],
             github_client=client,
         )
         assert result == []
-        client.get_stargazers.assert_not_called()
+        assert client.get_stargazers_calls == []
 
     def test_progress_callback_invoked(self) -> None:
-        client = MagicMock()
-        client.get_stargazers.return_value = ["alice"]
-        client.get_user_repos.return_value = []
-        callback = MagicMock()
+        client = FakeGitHubClient()
+        client.configure_stargazers("org/repo", ["alice"])
+        call_count = 0
+
+        def tracking_callback(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
 
         harvest_from_stargazers(
             seed_repos=["org/repo"],
             github_client=client,
-            progress_callback=callback,
+            progress_callback=tracking_callback,
         )
-        assert callback.call_count >= 1
+        assert call_count >= 1
 
     def test_source_is_stargazer_target(self) -> None:
-        client = MagicMock()
-        client.get_stargazers.return_value = ["alice"]
+        client = FakeGitHubClient()
+        client.configure_stargazers("org/repo", ["alice"])
         repo = make_repo_record(
             owner="alice",
             name="tool",
@@ -263,7 +267,7 @@ class TestHarvestFromStargazers:
                 "language": "Python",
             },
         )
-        client.get_user_repos.return_value = [repo]
+        client.configure_user_repos("alice", [repo])
 
         result = harvest_from_stargazers(
             seed_repos=["org/repo"],
@@ -272,8 +276,9 @@ class TestHarvestFromStargazers:
         assert result[0]["sources"] == ["stargazer_target"]
 
     def test_multiple_seeds_aggregate_results(self) -> None:
-        client = MagicMock()
-        client.get_stargazers.side_effect = [["alice"], ["bob"]]
+        client = FakeGitHubClient()
+        client.configure_stargazers("org/r1", ["alice"])
+        client.configure_stargazers("org/r2", ["bob"])
         repo_a = make_repo_record(
             owner="alice",
             name="a-tool",
@@ -298,7 +303,8 @@ class TestHarvestFromStargazers:
                 "language": None,
             },
         )
-        client.get_user_repos.side_effect = [[repo_a], [repo_b]]
+        client.configure_user_repos("alice", [repo_a])
+        client.configure_user_repos("bob", [repo_b])
 
         result = harvest_from_stargazers(
             seed_repos=["org/r1", "org/r2"],

--- a/tests/unit/test_archive_client.py
+++ b/tests/unit/test_archive_client.py
@@ -6,9 +6,10 @@ Covers: ArchiveClient.get_latest_snapshot(), fetch_snapshot_content(),
         extract_title(), extract_content_summary()
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from gh_link_auditor.archive_client import ArchiveClient, _cdx_request, _fetch_url_content
+from tests.fakes.http import FakeURLResponse
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -201,23 +202,17 @@ class TestExtractContentSummary:
 class TestCdxRequest:
     def test_cdx_request_success(self):
         """_cdx_request returns decoded response body."""
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = b"response data"
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
+        fake_resp = FakeURLResponse(data=b"response data")
 
-        with patch("gh_link_auditor.archive_client.urllib.request.urlopen", return_value=mock_resp):
+        with patch("gh_link_auditor.archive_client.urllib.request.urlopen", return_value=fake_resp):
             result = _cdx_request("https://web.archive.org/cdx/search/cdx?url=test")
         assert result == "response data"
 
     def test_fetch_url_content_success(self):
         """_fetch_url_content returns decoded HTML."""
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = b"<html>test</html>"
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
+        fake_resp = FakeURLResponse(data=b"<html>test</html>")
 
-        with patch("gh_link_auditor.archive_client.urllib.request.urlopen", return_value=mock_resp):
+        with patch("gh_link_auditor.archive_client.urllib.request.urlopen", return_value=fake_resp):
             result = _fetch_url_content("https://web.archive.org/web/snapshot")
         assert result == "<html>test</html>"
 

--- a/tests/unit/test_github_resolver.py
+++ b/tests/unit/test_github_resolver.py
@@ -6,9 +6,10 @@ Covers: GitHubResolver.is_github_url(), resolve_repo_redirect(),
         reconstruct_file_url(), _parse_github_url()
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from gh_link_auditor.github_resolver import GitHubResolver, _github_api_get
+from tests.fakes.http import FakeURLResponse
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -170,23 +171,17 @@ class TestReconstructFileUrl:
 class TestGitHubApiGet:
     def test_api_get_success(self):
         """_github_api_get returns parsed JSON on success."""
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = b'{"full_name": "owner/repo"}'
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
+        fake_resp = FakeURLResponse(data=b'{"full_name": "owner/repo"}')
 
-        with patch("gh_link_auditor.github_resolver.urllib.request.urlopen", return_value=mock_resp):
+        with patch("gh_link_auditor.github_resolver.urllib.request.urlopen", return_value=fake_resp):
             result = _github_api_get("https://api.github.com/repos/owner/repo")
         assert result == {"full_name": "owner/repo"}
 
     def test_api_get_with_token(self):
         """_github_api_get includes auth header when token provided."""
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = b'{"full_name": "owner/repo"}'
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
+        fake_resp = FakeURLResponse(data=b'{"full_name": "owner/repo"}')
 
-        with patch("gh_link_auditor.github_resolver.urllib.request.urlopen", return_value=mock_resp) as mock_open:
+        with patch("gh_link_auditor.github_resolver.urllib.request.urlopen", return_value=fake_resp) as mock_open:
             _github_api_get("https://api.github.com/repos/owner/repo", token="ghp_test123")
         # Verify the request was made (token applied in Request headers)
         mock_open.assert_called_once()

--- a/tests/unit/test_link_detective.py
+++ b/tests/unit/test_link_detective.py
@@ -4,7 +4,7 @@ TDD: Tests written BEFORE implementation.
 Covers: LinkDetective.investigate(), data structures, cache, pipeline flow.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -15,6 +15,9 @@ from gh_link_auditor.link_detective import (
     InvestigationMethod,
     LinkDetective,
 )
+from tests.fakes.archive import make_archive_hit, make_archive_miss
+from tests.fakes.detectives import FakeGitHubResolver, FakeRedirectResolver, FakeURLHeuristic
+from tests.fakes.http import FakeURLResponse
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -22,47 +25,8 @@ from gh_link_auditor.link_detective import (
 
 
 def _make_detective(state_db=None) -> LinkDetective:
-    """Build a LinkDetective with a mock state_db."""
-    if state_db is None:
-        state_db = MagicMock()
+    """Build a LinkDetective with a None state_db."""
     return LinkDetective(state_db=state_db)
-
-
-def _mock_redirect_none(*args, **kwargs):
-    """No redirect found."""
-    return (None, ["No redirect chain detected"])
-
-
-def _mock_no_mutations(*args, **kwargs):
-    """No URL mutations found."""
-    return []
-
-
-def _mock_archive_hit():
-    """Mock archive client that returns a snapshot."""
-    client = MagicMock()
-    client.get_latest_snapshot.return_value = {
-        "url": "https://example.com/docs",
-        "timestamp": "20240101120000",
-        "original": "https://example.com/docs",
-        "mimetype": "text/html",
-        "statuscode": "200",
-        "digest": "ABC",
-        "length": "1234",
-    }
-    client.fetch_snapshot_content.return_value = (
-        "<html><head><title>Example Docs</title></head><body>Content here</body></html>"
-    )
-    client.extract_title.return_value = "Example Docs"
-    client.extract_content_summary.return_value = "Content here"
-    return client
-
-
-def _mock_archive_miss():
-    """Mock archive client that returns no snapshot."""
-    client = MagicMock()
-    client.get_latest_snapshot.return_value = None
-    return client
 
 
 # ---------------------------------------------------------------------------
@@ -74,19 +38,12 @@ class TestInvestigateReturnsReport:
     def test_returns_forensic_report(self):
         """investigate() returns a ForensicReport with all required fields."""
         detective = _make_detective()
-        with (
-            patch.object(detective, "_redirect_resolver") as mock_rr,
-            patch.object(detective, "_archive_client", _mock_archive_miss()),
-            patch.object(detective, "_url_heuristic") as mock_uh,
-            patch.object(detective, "_github_resolver") as mock_gh,
-        ):
-            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
-            mock_rr.test_url_mutations.return_value = []
-            mock_uh.generate_candidates.return_value = []
-            mock_uh.probe_candidates.return_value = []
-            mock_gh.is_github_url.return_value = False
+        detective._redirect_resolver = FakeRedirectResolver()
+        detective._archive_client = make_archive_miss()
+        detective._url_heuristic = FakeURLHeuristic()
+        detective._github_resolver = FakeGitHubResolver()
 
-            report = detective.investigate("https://dead.example.com/page", 404)
+        report = detective.investigate("https://dead.example.com/page", 404)
 
         assert isinstance(report, ForensicReport)
         assert report.dead_url == "https://dead.example.com/page"
@@ -122,18 +79,15 @@ class TestRedirectCandidate:
     def test_redirect_chain_short_circuits(self):
         """High-confidence redirect produces early return."""
         detective = _make_detective()
-        with (
-            patch.object(detective, "_redirect_resolver") as mock_rr,
-            patch.object(detective, "_archive_client", _mock_archive_miss()),
-            patch.object(detective, "_url_heuristic"),
-            patch.object(detective, "_github_resolver") as mock_gh,
-        ):
-            mock_rr.follow_redirects.return_value = ("https://new.com/page", ["301 -> https://new.com/page"])
-            mock_rr.verify_live.return_value = True
-            mock_rr.test_url_mutations.return_value = []
-            mock_gh.is_github_url.return_value = False
+        detective._redirect_resolver = FakeRedirectResolver(
+            redirect_map={"https://old.com/page": ("https://new.com/page", ["301 -> https://new.com/page"])},
+            live_urls={"https://new.com/page"},
+        )
+        detective._archive_client = make_archive_miss()
+        detective._url_heuristic = FakeURLHeuristic()
+        detective._github_resolver = FakeGitHubResolver()
 
-            report = detective.investigate("https://old.com/page", 301)
+        report = detective.investigate("https://old.com/page", 301)
 
         candidates = report.investigation.candidate_replacements
         assert len(candidates) >= 1
@@ -150,19 +104,12 @@ class TestArchiveMiss:
     def test_archive_miss_continues_investigation(self):
         """No archive snapshot — investigation_log records it, continues."""
         detective = _make_detective()
-        with (
-            patch.object(detective, "_redirect_resolver") as mock_rr,
-            patch.object(detective, "_archive_client", _mock_archive_miss()),
-            patch.object(detective, "_url_heuristic") as mock_uh,
-            patch.object(detective, "_github_resolver") as mock_gh,
-        ):
-            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
-            mock_rr.test_url_mutations.return_value = []
-            mock_uh.generate_candidates.return_value = []
-            mock_uh.probe_candidates.return_value = []
-            mock_gh.is_github_url.return_value = False
+        detective._redirect_resolver = FakeRedirectResolver()
+        detective._archive_client = make_archive_miss()
+        detective._url_heuristic = FakeURLHeuristic()
+        detective._github_resolver = FakeGitHubResolver()
 
-            report = detective.investigate("https://dead.example.com", 404)
+        report = detective.investigate("https://dead.example.com", 404)
 
         assert any("no archive" in entry.lower() for entry in report.investigation.investigation_log)
 
@@ -176,31 +123,27 @@ class TestCandidateSorting:
     def test_candidates_sorted_descending(self):
         """Multiple candidates are sorted by similarity_score descending."""
         detective = _make_detective()
-        with (
-            patch.object(detective, "_redirect_resolver") as mock_rr,
-            patch.object(detective, "_archive_client", _mock_archive_hit()),
-            patch.object(detective, "_url_heuristic") as mock_uh,
-            patch.object(detective, "_github_resolver") as mock_gh,
-        ):
-            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
-            mock_rr.test_url_mutations.return_value = [
-                ("https://example.com/docs-new", "trailing_slash"),
-            ]
-            mock_rr.verify_live.return_value = True
-            mock_uh.generate_candidates.return_value = ["https://example.com/example-docs"]
-            mock_uh.probe_candidates.return_value = ["https://example.com/example-docs"]
-            mock_gh.is_github_url.return_value = False
+        detective._redirect_resolver = FakeRedirectResolver(
+            mutations={"https://example.com/docs": [("https://example.com/docs-new", "trailing_slash")]},
+            live_urls={"https://example.com/docs-new"},
+        )
+        detective._archive_client = make_archive_hit()
+        detective._url_heuristic = FakeURLHeuristic(
+            candidates=["https://example.com/example-docs"],
+            live=["https://example.com/example-docs"],
+        )
+        detective._github_resolver = FakeGitHubResolver()
 
-            # Mock content fetch for similarity comparison
+        # Mock content fetch for similarity comparison
+        with patch(
+            "gh_link_auditor.link_detective._fetch_page_content",
+            return_value="Content here similar",
+        ):
             with patch(
-                "gh_link_auditor.link_detective._fetch_page_content",
-                return_value="Content here similar",
+                "gh_link_auditor.link_detective.compute_similarity",
+                return_value=0.7,
             ):
-                with patch(
-                    "gh_link_auditor.link_detective.compute_similarity",
-                    return_value=0.7,
-                ):
-                    report = detective.investigate("https://example.com/docs", 404)
+                report = detective.investigate("https://example.com/docs", 404)
 
         candidates = report.investigation.candidate_replacements
         if len(candidates) >= 2:
@@ -217,19 +160,12 @@ class TestNoCandidates:
     def test_empty_candidates_when_nothing_found(self):
         """Returns empty candidate list when no matches found anywhere."""
         detective = _make_detective()
-        with (
-            patch.object(detective, "_redirect_resolver") as mock_rr,
-            patch.object(detective, "_archive_client", _mock_archive_miss()),
-            patch.object(detective, "_url_heuristic") as mock_uh,
-            patch.object(detective, "_github_resolver") as mock_gh,
-        ):
-            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
-            mock_rr.test_url_mutations.return_value = []
-            mock_uh.generate_candidates.return_value = []
-            mock_uh.probe_candidates.return_value = []
-            mock_gh.is_github_url.return_value = False
+        detective._redirect_resolver = FakeRedirectResolver()
+        detective._archive_client = make_archive_miss()
+        detective._url_heuristic = FakeURLHeuristic()
+        detective._github_resolver = FakeGitHubResolver()
 
-            report = detective.investigate("https://totally-gone.example.com", 404)
+        report = detective.investigate("https://totally-gone.example.com", 404)
 
         assert report.investigation.candidate_replacements == []
         assert len(report.investigation.investigation_log) > 0
@@ -243,8 +179,7 @@ class TestNoCandidates:
 class TestCaching:
     def test_cache_hit_returns_without_external_calls(self):
         """Second investigation of same URL uses cache."""
-        mock_db = MagicMock()
-        detective = _make_detective(state_db=mock_db)
+        detective = _make_detective()
 
         cached_report = ForensicReport(
             dead_url="https://cached.com",
@@ -309,12 +244,9 @@ class TestFetchPageContent:
         """_fetch_page_content returns decoded content."""
         from gh_link_auditor.link_detective import _fetch_page_content
 
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = b"page content"
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
+        fake_resp = FakeURLResponse(b"page content")
 
-        with patch("gh_link_auditor.link_detective.urllib.request.urlopen", return_value=mock_resp):
+        with patch("gh_link_auditor.link_detective.urllib.request.urlopen", return_value=fake_resp):
             result = _fetch_page_content("https://example.com")
         assert result == "page content"
 
@@ -339,23 +271,16 @@ class TestGitHubResolutionInPipeline:
     def test_github_url_resolved(self):
         """GitHub URL triggers GitHub resolution in pipeline."""
         detective = _make_detective()
-        with (
-            patch.object(detective, "_redirect_resolver") as mock_rr,
-            patch.object(detective, "_archive_client", _mock_archive_miss()),
-            patch.object(detective, "_url_heuristic") as mock_uh,
-            patch.object(detective, "_github_resolver") as mock_gh,
-        ):
-            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
-            mock_rr.test_url_mutations.return_value = []
-            mock_rr.verify_live.return_value = True
-            mock_uh.generate_candidates.return_value = []
-            mock_uh.probe_candidates.return_value = []
-            mock_gh.is_github_url.return_value = True
-            mock_gh._parse_github_url.return_value = ("old-owner", "old-repo", "blob/main/README.md")
-            mock_gh.resolve_repo_redirect.return_value = "https://github.com/new-owner/new-repo"
-            mock_gh.reconstruct_file_url.return_value = "https://github.com/new-owner/new-repo/blob/main/README.md"
+        detective._redirect_resolver = FakeRedirectResolver(
+            live_urls={"https://github.com/new-owner/new-repo/blob/main/README.md"},
+        )
+        detective._archive_client = make_archive_miss()
+        detective._url_heuristic = FakeURLHeuristic()
+        detective._github_resolver = FakeGitHubResolver(
+            redirects={"old-owner/old-repo": "https://github.com/new-owner/new-repo"},
+        )
 
-            report = detective.investigate("https://github.com/old-owner/old-repo/blob/main/README.md", 404)
+        report = detective.investigate("https://github.com/old-owner/old-repo/blob/main/README.md", 404)
 
         candidates = report.investigation.candidate_replacements
         github_candidates = [c for c in candidates if c.method == InvestigationMethod.GITHUB_API_REDIRECT]
@@ -372,20 +297,12 @@ class TestArchiveOnlyFallback:
     def test_archive_only_when_no_live_candidates(self):
         """Archive-only fallback when snapshot exists but no live candidates."""
         detective = _make_detective()
-        with (
-            patch.object(detective, "_redirect_resolver") as mock_rr,
-            patch.object(detective, "_archive_client", _mock_archive_hit()),
-            patch.object(detective, "_url_heuristic") as mock_uh,
-            patch.object(detective, "_github_resolver") as mock_gh,
-        ):
-            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
-            mock_rr.test_url_mutations.return_value = []
-            mock_rr.verify_live.return_value = False
-            mock_uh.generate_candidates.return_value = []
-            mock_uh.probe_candidates.return_value = []
-            mock_gh.is_github_url.return_value = False
+        detective._redirect_resolver = FakeRedirectResolver()  # no live_urls
+        detective._archive_client = make_archive_hit()
+        detective._url_heuristic = FakeURLHeuristic()
+        detective._github_resolver = FakeGitHubResolver()
 
-            report = detective.investigate("https://dead.example.com/page", 404)
+        report = detective.investigate("https://dead.example.com/page", 404)
 
         candidates = report.investigation.candidate_replacements
         archive_only = [c for c in candidates if c.method == InvestigationMethod.ARCHIVE_ONLY]
@@ -403,30 +320,25 @@ class TestHeuristicWithSimilarity:
     def test_heuristic_below_threshold_excluded(self):
         """Heuristic candidate with similarity < 0.5 is excluded."""
         detective = _make_detective()
-        with (
-            patch.object(detective, "_redirect_resolver") as mock_rr,
-            patch.object(detective, "_archive_client", _mock_archive_hit()),
-            patch.object(detective, "_url_heuristic") as mock_uh,
-            patch.object(detective, "_github_resolver") as mock_gh,
-        ):
-            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
-            mock_rr.test_url_mutations.return_value = []
-            mock_rr.verify_live.return_value = False
-            mock_uh.generate_candidates.return_value = ["https://example.com/different"]
-            mock_uh.probe_candidates.return_value = ["https://example.com/different"]
-            mock_gh.is_github_url.return_value = False
+        detective._redirect_resolver = FakeRedirectResolver()
+        detective._archive_client = make_archive_hit()
+        detective._url_heuristic = FakeURLHeuristic(
+            candidates=["https://example.com/different"],
+            live=["https://example.com/different"],
+        )
+        detective._github_resolver = FakeGitHubResolver()
 
-            with (
-                patch(
-                    "gh_link_auditor.link_detective._fetch_page_content",
-                    return_value="Completely different content",
-                ),
-                patch(
-                    "gh_link_auditor.link_detective.compute_similarity",
-                    return_value=0.2,
-                ),
-            ):
-                report = detective.investigate("https://dead.example.com/page", 404)
+        with (
+            patch(
+                "gh_link_auditor.link_detective._fetch_page_content",
+                return_value="Completely different content",
+            ),
+            patch(
+                "gh_link_auditor.link_detective.compute_similarity",
+                return_value=0.2,
+            ),
+        ):
+            report = detective.investigate("https://dead.example.com/page", 404)
 
         heuristic_candidates = [
             c for c in report.investigation.candidate_replacements if c.method == InvestigationMethod.URL_HEURISTIC
@@ -436,24 +348,19 @@ class TestHeuristicWithSimilarity:
     def test_heuristic_no_content_uses_low_score(self):
         """Heuristic candidate uses 0.3 score when page content unavailable."""
         detective = _make_detective()
-        with (
-            patch.object(detective, "_redirect_resolver") as mock_rr,
-            patch.object(detective, "_archive_client", _mock_archive_hit()),
-            patch.object(detective, "_url_heuristic") as mock_uh,
-            patch.object(detective, "_github_resolver") as mock_gh,
-        ):
-            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
-            mock_rr.test_url_mutations.return_value = []
-            mock_rr.verify_live.return_value = False
-            mock_uh.generate_candidates.return_value = ["https://example.com/page"]
-            mock_uh.probe_candidates.return_value = ["https://example.com/page"]
-            mock_gh.is_github_url.return_value = False
+        detective._redirect_resolver = FakeRedirectResolver()
+        detective._archive_client = make_archive_hit()
+        detective._url_heuristic = FakeURLHeuristic(
+            candidates=["https://example.com/page"],
+            live=["https://example.com/page"],
+        )
+        detective._github_resolver = FakeGitHubResolver()
 
-            with patch(
-                "gh_link_auditor.link_detective._fetch_page_content",
-                return_value=None,
-            ):
-                report = detective.investigate("https://dead.example.com/page", 404)
+        with patch(
+            "gh_link_auditor.link_detective._fetch_page_content",
+            return_value=None,
+        ):
+            report = detective.investigate("https://dead.example.com/page", 404)
 
         # Score 0.3 < 0.5 threshold, so candidate should NOT be included
         heuristic_candidates = [
@@ -471,19 +378,18 @@ class TestPipelineErrorHandling:
     def test_mutation_error_continues(self):
         """Exception in URL mutations doesn't stop the pipeline."""
         detective = _make_detective()
-        with (
-            patch.object(detective, "_redirect_resolver") as mock_rr,
-            patch.object(detective, "_archive_client", _mock_archive_miss()),
-            patch.object(detective, "_url_heuristic") as mock_uh,
-            patch.object(detective, "_github_resolver") as mock_gh,
-        ):
-            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
-            mock_rr.test_url_mutations.side_effect = Exception("mutation error")
-            mock_uh.generate_candidates.return_value = []
-            mock_uh.probe_candidates.return_value = []
-            mock_gh.is_github_url.return_value = False
+        detective._redirect_resolver = FakeRedirectResolver()
+        detective._archive_client = make_archive_miss()
+        detective._url_heuristic = FakeURLHeuristic()
+        detective._github_resolver = FakeGitHubResolver()
 
-            report = detective.investigate("https://example.com/page", 404)
+        # Override test_url_mutations to raise
+        def _raise_on_mutations(url):
+            raise Exception("mutation error")
+
+        detective._redirect_resolver.test_url_mutations = _raise_on_mutations
+
+        report = detective.investigate("https://example.com/page", 404)
 
         assert isinstance(report, ForensicReport)
         assert any("mutation" in entry.lower() for entry in report.investigation.investigation_log)
@@ -491,22 +397,14 @@ class TestPipelineErrorHandling:
     def test_archive_error_continues(self):
         """Exception in archive lookup doesn't stop the pipeline."""
         detective = _make_detective()
-        archive_mock = MagicMock()
-        archive_mock.get_latest_snapshot.side_effect = Exception("archive error")
+        detective._redirect_resolver = FakeRedirectResolver()
+        archive = make_archive_miss()
+        archive.get_latest_snapshot = lambda url: (_ for _ in ()).throw(Exception("archive error"))
+        detective._archive_client = archive
+        detective._url_heuristic = FakeURLHeuristic()
+        detective._github_resolver = FakeGitHubResolver()
 
-        with (
-            patch.object(detective, "_redirect_resolver") as mock_rr,
-            patch.object(detective, "_archive_client", archive_mock),
-            patch.object(detective, "_url_heuristic") as mock_uh,
-            patch.object(detective, "_github_resolver") as mock_gh,
-        ):
-            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
-            mock_rr.test_url_mutations.return_value = []
-            mock_uh.generate_candidates.return_value = []
-            mock_uh.probe_candidates.return_value = []
-            mock_gh.is_github_url.return_value = False
-
-            report = detective.investigate("https://example.com/page", 404)
+        report = detective.investigate("https://example.com/page", 404)
 
         assert isinstance(report, ForensicReport)
         assert any("archive" in entry.lower() for entry in report.investigation.investigation_log)
@@ -514,20 +412,14 @@ class TestPipelineErrorHandling:
     def test_github_error_continues(self):
         """Exception in GitHub resolution doesn't stop the pipeline."""
         detective = _make_detective()
-        with (
-            patch.object(detective, "_redirect_resolver") as mock_rr,
-            patch.object(detective, "_archive_client", _mock_archive_miss()),
-            patch.object(detective, "_url_heuristic") as mock_uh,
-            patch.object(detective, "_github_resolver") as mock_gh,
-        ):
-            mock_rr.follow_redirects.return_value = (None, ["No redirect"])
-            mock_rr.test_url_mutations.return_value = []
-            mock_uh.generate_candidates.return_value = []
-            mock_uh.probe_candidates.return_value = []
-            mock_gh.is_github_url.return_value = True
-            mock_gh._parse_github_url.side_effect = Exception("github error")
+        detective._redirect_resolver = FakeRedirectResolver()
+        detective._archive_client = make_archive_miss()
+        detective._url_heuristic = FakeURLHeuristic()
+        gh = FakeGitHubResolver(github_urls={"https://github.com/owner/repo"})
+        gh._parse_github_url = lambda url: (_ for _ in ()).throw(Exception("github error"))
+        detective._github_resolver = gh
 
-            report = detective.investigate("https://github.com/owner/repo", 404)
+        report = detective.investigate("https://github.com/owner/repo", 404)
 
         assert isinstance(report, ForensicReport)
         assert any("github" in entry.lower() for entry in report.investigation.investigation_log)

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -27,6 +27,7 @@ from gh_link_auditor.network import (
     create_request_config,
     should_retry,
 )
+from tests.fakes.http import FakeURLResponse
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -52,17 +53,8 @@ def no_retry_backoff_config() -> BackoffConfig:
 
 
 def _mock_urlopen_response(status: int = 200, headers: dict | None = None):
-    """Create a mock response object for urllib.request.urlopen."""
-    resp = mock.MagicMock()
-    resp.status = status
-    resp.headers = mock.MagicMock()
-    if headers:
-        resp.headers.get = lambda key, default=None: headers.get(key, default)
-    else:
-        resp.headers.get = lambda key, default=None: default
-    resp.__enter__ = mock.MagicMock(return_value=resp)
-    resp.__exit__ = mock.MagicMock(return_value=False)
-    return resp
+    """Create a fake response object for urllib.request.urlopen."""
+    return FakeURLResponse(data=b"", status=status, headers=headers or {})
 
 
 # ---------------------------------------------------------------------------
@@ -253,8 +245,7 @@ class TestRetryOn429:
 
     def test_retry_on_429(self):
         """429 twice then 200 → ok with retries=2."""
-        headers_429 = mock.MagicMock()
-        headers_429.get = lambda key, default=None: None
+        headers_429 = {}  # Empty headers dict (no Retry-After)
 
         http_error_429 = urllib.error.HTTPError(
             "https://example.com",
@@ -297,8 +288,7 @@ class TestRetryRespectsRetryAfter:
 
     def test_retry_respects_retry_after(self):
         """429 with Retry-After: 5 → delay ≥ 5 seconds."""
-        headers_429 = mock.MagicMock()
-        headers_429.get = lambda key, default=None: "5" if key == "Retry-After" else default
+        headers_429 = {"Retry-After": "5"}
 
         http_error_429 = urllib.error.HTTPError(
             "https://example.com",
@@ -467,8 +457,7 @@ class TestMaxRetriesHonored:
 
     def test_max_retries_honored(self):
         """Always 429 → stops at max_retries=2, returns error."""
-        headers_429 = mock.MagicMock()
-        headers_429.get = lambda key, default=None: None
+        headers_429 = {}  # Empty headers dict (no Retry-After)
 
         http_error_429 = urllib.error.HTTPError(
             "https://example.com",
@@ -792,8 +781,7 @@ class TestCheckUrlFullFlow:
 
     def test_429_then_405_then_get_success(self):
         """429 → retry → 405 → GET fallback → 200."""
-        headers_429 = mock.MagicMock()
-        headers_429.get = lambda key, default=None: None
+        headers_429 = {}  # Empty headers dict (no Retry-After)
 
         call_count = 0
 
@@ -835,8 +823,7 @@ class TestCheckUrlFullFlow:
 
     def test_503_exhausts_retries(self):
         """503 on every attempt exhausts retries and returns error."""
-        headers_503 = mock.MagicMock()
-        headers_503.get = lambda key, default=None: None
+        headers_503 = {}  # Empty headers dict (no Retry-After)
 
         def side_effect(*args, **kwargs):
             raise urllib.error.HTTPError(

--- a/tests/unit/test_policy_checker.py
+++ b/tests/unit/test_policy_checker.py
@@ -7,7 +7,7 @@ Mock target for HTTP fetching: ``policy_checker.network_check_url``
 """
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from gh_link_auditor.policy_checker import (
     PolicyCheckResult,
@@ -18,6 +18,7 @@ from gh_link_auditor.policy_checker import (
     fetch_contributing_content,
     parse_policy_keywords,
 )
+from tests.fakes.http import FakeURLResponse
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "contributing_samples"
 
@@ -193,11 +194,21 @@ class TestDetermineBlockStatus:
 # ---------------------------------------------------------------------------
 
 
+class _FakeStateDB:
+    """Simple tracking fake for StateDatabase blacklist operations."""
+
+    def __init__(self):
+        self.blacklist_calls: list[dict] = []
+
+    def add_to_blacklist(self, **kwargs):
+        self.blacklist_calls.append(kwargs)
+
+
 class TestLogPolicyResult:
     # T080
     def test_log_policy_blacklisted_status(self):
         """Blocked result is logged to state database as policy-blacklisted."""
-        mock_db = MagicMock()
+        fake_db = _FakeStateDB()
         result = PolicyCheckResult(
             repo_url="https://github.com/org/repo",
             contributing_found=True,
@@ -210,10 +221,9 @@ class TestLogPolicyResult:
         # Import here so we can call the logging function
         from gh_link_auditor.policy_checker import log_policy_result
 
-        log_policy_result(result, mock_db)
-        mock_db.add_to_blacklist.assert_called_once()
-        call_kwargs = mock_db.add_to_blacklist.call_args
-        assert "policy" in str(call_kwargs).lower()
+        log_policy_result(result, fake_db)
+        assert len(fake_db.blacklist_calls) == 1
+        assert "policy" in str(fake_db.blacklist_calls[0]).lower()
 
 
 # ---------------------------------------------------------------------------
@@ -267,13 +277,9 @@ class TestFetchRawUrl:
         """_fetch_raw_url returns decoded content on 200 response."""
         from gh_link_auditor.policy_checker import _fetch_raw_url
 
-        mock_resp = MagicMock()
-        mock_resp.status = 200
-        mock_resp.read.return_value = b"# Contributing\nWelcome!"
-        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
-        mock_resp.__exit__ = MagicMock(return_value=False)
+        fake_resp = FakeURLResponse(b"# Contributing\nWelcome!", status=200)
 
-        with patch("gh_link_auditor.policy_checker.urllib.request.urlopen", return_value=mock_resp):
+        with patch("gh_link_auditor.policy_checker.urllib.request.urlopen", return_value=fake_resp):
             result = _fetch_raw_url("https://example.com/CONTRIBUTING.md")
 
         assert result == "# Contributing\nWelcome!"
@@ -312,12 +318,9 @@ class TestFetchRawUrl:
         """_fetch_raw_url returns None when response status >= 400."""
         from gh_link_auditor.policy_checker import _fetch_raw_url
 
-        mock_resp = MagicMock()
-        mock_resp.status = 500
-        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
-        mock_resp.__exit__ = MagicMock(return_value=False)
+        fake_resp = FakeURLResponse(b"Error", status=500)
 
-        with patch("gh_link_auditor.policy_checker.urllib.request.urlopen", return_value=mock_resp):
+        with patch("gh_link_auditor.policy_checker.urllib.request.urlopen", return_value=fake_resp):
             result = _fetch_raw_url("https://example.com/error")
 
         assert result is None
@@ -345,7 +348,7 @@ class TestLogPolicyResultEdgeCases:
         """When block_reason is None, fallback to 'policy-blacklisted'."""
         from gh_link_auditor.policy_checker import log_policy_result
 
-        mock_db = MagicMock()
+        fake_db = _FakeStateDB()
         result = PolicyCheckResult(
             repo_url="https://github.com/org/repo",
             contributing_found=True,
@@ -355,17 +358,18 @@ class TestLogPolicyResultEdgeCases:
             block_reason=None,
             status=PolicyStatus.BLOCKED,
         )
-        log_policy_result(result, mock_db)
-        mock_db.add_to_blacklist.assert_called_once_with(
-            repo_url="https://github.com/org/repo",
-            reason="policy-blacklisted",
-        )
+        log_policy_result(result, fake_db)
+        assert len(fake_db.blacklist_calls) == 1
+        assert fake_db.blacklist_calls[0] == {
+            "repo_url": "https://github.com/org/repo",
+            "reason": "policy-blacklisted",
+        }
 
     def test_log_allowed_result_does_not_blacklist(self):
         """Non-blocked result is not added to blacklist."""
         from gh_link_auditor.policy_checker import log_policy_result
 
-        mock_db = MagicMock()
+        fake_db = _FakeStateDB()
         result = PolicyCheckResult(
             repo_url="https://github.com/org/repo",
             contributing_found=True,
@@ -375,5 +379,5 @@ class TestLogPolicyResultEdgeCases:
             block_reason=None,
             status=PolicyStatus.ALLOWED,
         )
-        log_policy_result(result, mock_db)
-        mock_db.add_to_blacklist.assert_not_called()
+        log_policy_result(result, fake_db)
+        assert fake_db.blacklist_calls == []

--- a/tests/unit/test_redirect_resolver.py
+++ b/tests/unit/test_redirect_resolver.py
@@ -6,11 +6,12 @@ Covers: RedirectResolver.follow_redirects(), test_url_mutations(),
         verify_live(), _validate_not_private_ip(), SSRFBlocked
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from gh_link_auditor.redirect_resolver import RedirectResolver, SSRFBlocked, _http_head
+from tests.fakes.http import FakeURLResponse
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -306,30 +307,30 @@ class TestVerifyLive:
 class TestHttpHead:
     def test_http_head_success(self):
         """_http_head returns status_code and location on success."""
-        mock_resp = MagicMock()
-        mock_resp.status = 200
-        mock_resp.headers = MagicMock()
-        mock_resp.headers.get.return_value = None
+        fake_resp = FakeURLResponse(data=b"", status=200)
 
-        mock_opener = MagicMock()
-        mock_opener.open.return_value = mock_resp
+        class _FakeOpener:
+            def open(self, *args, **kwargs):
+                return fake_resp
 
-        with patch("gh_link_auditor.redirect_resolver.urllib.request.build_opener", return_value=mock_opener):
+        with patch("gh_link_auditor.redirect_resolver.urllib.request.build_opener", return_value=_FakeOpener()):
             result = _http_head("https://example.com")
         assert result["status_code"] == 200
 
     def test_http_head_http_error(self):
         """_http_head returns status from HTTPError."""
+        import email.message
         import urllib.error
 
-        mock_headers = MagicMock()
-        mock_headers.get.return_value = "https://new.com"
-        err = urllib.error.HTTPError("https://old.com", 301, "Moved", mock_headers, None)
+        headers = email.message.Message()
+        headers["Location"] = "https://new.com"
+        err = urllib.error.HTTPError("https://old.com", 301, "Moved", headers, None)
 
-        mock_opener = MagicMock()
-        mock_opener.open.side_effect = err
+        class _FakeOpener:
+            def open(self, *args, **kwargs):
+                raise err
 
-        with patch("gh_link_auditor.redirect_resolver.urllib.request.build_opener", return_value=mock_opener):
+        with patch("gh_link_auditor.redirect_resolver.urllib.request.build_opener", return_value=_FakeOpener()):
             result = _http_head("https://old.com")
         assert result["status_code"] == 301
         assert result["location"] == "https://new.com"
@@ -338,10 +339,11 @@ class TestHttpHead:
         """_http_head returns None status on URLError."""
         import urllib.error
 
-        mock_opener = MagicMock()
-        mock_opener.open.side_effect = urllib.error.URLError("DNS failure")
+        class _FakeOpener:
+            def open(self, *args, **kwargs):
+                raise urllib.error.URLError("DNS failure")
 
-        with patch("gh_link_auditor.redirect_resolver.urllib.request.build_opener", return_value=mock_opener):
+        with patch("gh_link_auditor.redirect_resolver.urllib.request.build_opener", return_value=_FakeOpener()):
             result = _http_head("https://nonexistent.example.com")
         assert result["status_code"] is None
         assert result["location"] is None


### PR DESCRIPTION
## Summary
- Remove **235+ MagicMock instances** across **19 test files** (all 17 identified + 2 extras)
- Replace with typed fakes from `tests/fakes/` and real dataclasses
- Zero `MagicMock` remains in any test file under `tests/unit/`
- All 1079 tests still pass, lint and format clean
- Enhanced `FakeGitHubClient` with call tracking for assertion support

Closes #54
Closes #55
Closes #56
Closes #57
Closes #58

## Test plan
- [x] `grep -r "MagicMock" tests/unit/` returns zero matches
- [x] `poetry run pytest --tb=short -q` — 1079 passed, 1 skipped
- [x] `poetry run ruff check tests/` — clean
- [x] `poetry run ruff format --check tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)