### PR TITLE
feat: add 15 integration tests across 5 modules (#59)

### DIFF
--- a/tests/integration/test_data_contracts.py
+++ b/tests/integration/test_data_contracts.py
@@ -1,0 +1,129 @@
+"""Data contract integration tests.
+
+Validates that data flows correctly between pipeline nodes by running
+real node functions with controlled inputs and checking output shapes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gh_link_auditor.pipeline.nodes.n3_judge import n3_judge
+from gh_link_auditor.pipeline.nodes.n4_human_review import n4_human_review
+from gh_link_auditor.pipeline.nodes.n5_generate_fix import generate_unified_diff
+from gh_link_auditor.pipeline.state import (
+    DeadLink,
+    ReplacementCandidate,
+    Verdict,
+    create_initial_state,
+    load_state,
+    persist_state,
+)
+
+
+def _make_dead_link(url: str = "https://dead.example.com/page") -> DeadLink:
+    return DeadLink(
+        url=url,
+        source_file="README.md",
+        line_number=5,
+        link_text="link text",
+        http_status=404,
+        error_type="http_error",
+    )
+
+
+def _make_candidate(url: str = "https://new.example.com/page") -> ReplacementCandidate:
+    return ReplacementCandidate(
+        url=url,
+        source="redirect_chain",
+        title="New Page",
+        snippet=None,
+    )
+
+
+@pytest.mark.integration
+class TestDataContracts:
+    """Cross-node data shape validation."""
+
+    def test_n2_output_feeds_n3(self) -> None:
+        """State with candidates passes to N3, produces typed Verdicts."""
+        state = create_initial_state(target="t")
+        dead_link = _make_dead_link()
+        state["dead_links"] = [dead_link]
+        state["candidates"] = {
+            dead_link["url"]: [_make_candidate()],
+        }
+
+        with patch(
+            "gh_link_auditor.pipeline.nodes.n3_judge._score_candidates",
+            return_value=Verdict(
+                dead_link=dead_link,
+                candidate=_make_candidate(),
+                confidence=0.95,
+                reasoning="redirect match",
+                approved=None,
+            ),
+        ):
+            result = n3_judge(state)
+
+        assert "verdicts" in result
+        assert len(result["verdicts"]) >= 1
+        v = result["verdicts"][0]
+        assert "confidence" in v
+        assert "dead_link" in v
+
+    def test_n3_output_feeds_n4(self) -> None:
+        """Verdicts pass through N4 auto-approve for high confidence."""
+        state = create_initial_state(target="t")
+        dead_link = _make_dead_link()
+        state["verdicts"] = [
+            Verdict(
+                dead_link=dead_link,
+                candidate=_make_candidate(),
+                confidence=0.99,
+                reasoning="perfect match",
+                approved=None,
+            ),
+        ]
+
+        # N4 auto-approves verdicts above threshold
+        result = n4_human_review(state)
+        assert "reviewed_verdicts" in result
+        assert len(result["reviewed_verdicts"]) >= 1
+        # High-confidence should be auto-approved
+        assert result["reviewed_verdicts"][0]["approved"] is True
+
+    def test_n5_produces_parseable_diffs(self, tmp_path: Path) -> None:
+        """N5 output diffs are valid unified diff format."""
+        readme = tmp_path / "README.md"
+        readme.write_text("Visit https://dead.example.com/page for info.\n")
+
+        diff = generate_unified_diff(
+            str(readme),
+            "https://dead.example.com/page",
+            "https://new.example.com/page",
+        )
+
+        assert diff != ""
+        assert "---" in diff
+        assert "+++" in diff
+        assert "-Visit https://dead.example.com/page" in diff
+        assert "+Visit https://new.example.com/page" in diff
+
+    def test_pipeline_state_serialization_roundtrip(self, tmp_path: Path) -> None:
+        """persist_state + load_state preserves all fields."""
+        db_path = str(tmp_path / "state.db")
+        state = create_initial_state(target="https://github.com/org/repo", db_path=db_path)
+        state["dead_links"] = [_make_dead_link()]
+        state["scan_complete"] = True
+
+        persist_state(state, "n1_scan")
+
+        loaded = load_state(state["run_id"], db_path)
+        assert loaded is not None
+        assert loaded["target"] == "https://github.com/org/repo"
+        assert loaded["scan_complete"] is True
+        assert len(loaded["dead_links"]) == 1

--- a/tests/integration/test_docfix_bot_flow.py
+++ b/tests/integration/test_docfix_bot_flow.py
@@ -1,0 +1,73 @@
+"""DocFix Bot flow integration tests.
+
+Tests scan-to-fix workflow using real objects with patched HTTP.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from docfix_bot.models import make_broken_link
+from docfix_bot.pr_generator import generate_pr_body, generate_pr_title
+
+
+@pytest.mark.integration
+class TestDocFixBotFlow:
+    """Scan → PR generation flow tests."""
+
+    def test_pr_generation_from_broken_links(self) -> None:
+        """generate_pr_title + body from real BrokenLink objects."""
+        links = [
+            make_broken_link(
+                "README.md",
+                5,
+                "https://old.com/docs",
+                404,
+                suggested_fix="https://new.com/docs",
+                fix_confidence=0.95,
+            ),
+            make_broken_link(
+                "CONTRIBUTING.md",
+                10,
+                "https://gone.com/guide",
+                404,
+                suggested_fix="https://archive.org/guide",
+                fix_confidence=0.7,
+            ),
+        ]
+
+        title = generate_pr_title(links)
+        body = generate_pr_body(links)
+
+        assert isinstance(title, str)
+        assert len(title) > 0
+        assert "2 broken links" in title
+        assert isinstance(body, str)
+        assert len(body) > 0
+
+    def test_full_fix_workflow_dry_run(self, tmp_path: Path) -> None:
+        """apply_fixes modifies files in tmp_path."""
+        from docfix_bot.git_workflow import apply_fixes
+
+        readme = tmp_path / "README.md"
+        readme.write_text("# Project\n\nVisit [docs](https://old.example.com/docs) for help.\n")
+
+        links = [
+            make_broken_link(
+                "README.md",
+                3,
+                "https://old.example.com/docs",
+                404,
+                suggested_fix="https://new.example.com/docs",
+                fix_confidence=0.9,
+            ),
+        ]
+
+        modified = apply_fixes(tmp_path, links)
+        assert modified == ["README.md"]
+
+        content = readme.read_text()
+        assert "https://new.example.com/docs" in content
+        assert "https://old.example.com/docs" not in content

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -1,0 +1,143 @@
+"""Pipeline E2E integration tests.
+
+Tests the full N0→N5 pipeline flow with network layer patched.
+Verifies nodes wire together correctly and state flows through.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gh_link_auditor.link_detective import ForensicReport, Investigation
+from gh_link_auditor.pipeline.graph import run_pipeline
+from gh_link_auditor.pipeline.state import create_initial_state
+
+
+def _make_empty_report(url: str) -> ForensicReport:
+    """Create a ForensicReport with no candidates."""
+    return ForensicReport(
+        dead_url=url,
+        http_status=404,
+        investigation=Investigation(
+            archive_snapshot=None,
+            archive_title=None,
+            archive_content_summary=None,
+            candidate_replacements=[],
+            investigation_log=["no candidates found"],
+        ),
+    )
+
+
+def _fake_check_url_dead(url, **kwargs):
+    """Fake check_url that returns all links as dead (404)."""
+    return {
+        "url": url,
+        "status": "error",
+        "status_code": 404,
+        "method": "HEAD",
+        "response_time_ms": 50,
+        "retries": 0,
+        "error": "HTTP 404",
+    }
+
+
+def _fake_check_url_ok(url, **kwargs):
+    """Fake check_url that returns all links as alive (200)."""
+    return {
+        "url": url,
+        "status": "ok",
+        "status_code": 200,
+        "method": "HEAD",
+        "response_time_ms": 50,
+        "retries": 0,
+        "error": None,
+    }
+
+
+@pytest.mark.integration
+class TestPipelineE2E:
+    """Full pipeline integration tests."""
+
+    def test_full_pipeline_happy_path(self, tmp_path: Path) -> None:
+        """N0→N5 produces FixPatch from temp dir with dead links."""
+        # Set up a temp repo with a dead link
+        readme = tmp_path / "README.md"
+        readme.write_text("Check [link](https://dead.example.com/page) for info.\n")
+
+        state = create_initial_state(
+            target=str(tmp_path),
+            max_links=50,
+            dry_run=False,
+            db_path=str(tmp_path / "state.db"),
+        )
+
+        with (
+            patch(
+                "gh_link_auditor.pipeline.nodes.n1_scan.network_check_url",
+                side_effect=_fake_check_url_dead,
+            ),
+            patch(
+                "gh_link_auditor.pipeline.nodes.n2_investigate._run_investigation",
+                side_effect=lambda url, status: _make_empty_report(url),
+            ),
+            patch(
+                "gh_link_auditor.pipeline.nodes.n4_human_review.prompt_user_approval",
+                return_value=True,
+            ),
+        ):
+            result = run_pipeline(state)
+
+        # Pipeline should complete without errors
+        assert result.get("scan_complete") is True
+        assert isinstance(result.get("dead_links"), list)
+
+    def test_no_dead_links_clean_run(self, tmp_path: Path) -> None:
+        """All links return 200 → empty results."""
+        readme = tmp_path / "README.md"
+        readme.write_text("Check [link](https://alive.example.com) for info.\n")
+
+        state = create_initial_state(
+            target=str(tmp_path),
+            db_path=str(tmp_path / "state.db"),
+        )
+
+        with patch(
+            "gh_link_auditor.pipeline.nodes.n1_scan.network_check_url",
+            side_effect=_fake_check_url_ok,
+        ):
+            result = run_pipeline(state)
+
+        assert result.get("scan_complete") is True
+        assert result.get("dead_links") == []
+        # No candidates/verdicts when no dead links
+        assert result.get("candidates", {}) == {}
+
+    def test_dry_run_skips_fix_generation(self, tmp_path: Path) -> None:
+        """dry_run=True still scans/judges but stops before N5."""
+        readme = tmp_path / "README.md"
+        readme.write_text("Visit [link](https://dead.example.com/gone) today.\n")
+
+        state = create_initial_state(
+            target=str(tmp_path),
+            dry_run=True,
+            db_path=str(tmp_path / "state.db"),
+        )
+
+        with (
+            patch(
+                "gh_link_auditor.pipeline.nodes.n1_scan.network_check_url",
+                side_effect=_fake_check_url_dead,
+            ),
+            patch(
+                "gh_link_auditor.pipeline.nodes.n2_investigate._run_investigation",
+                side_effect=lambda url, status: _make_empty_report(url),
+            ),
+        ):
+            result = run_pipeline(state)
+
+        assert result.get("scan_complete") is True
+        # dry_run should not produce fixes
+        assert result.get("fixes", []) == []

--- a/tests/integration/test_repo_scout_flow.py
+++ b/tests/integration/test_repo_scout_flow.py
@@ -1,0 +1,89 @@
+"""Repo Scout flow integration tests.
+
+Tests multi-source aggregation and output compatibility with batch engine.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from repo_scout.aggregator import deduplicate_repos, sort_by_relevance
+from repo_scout.models import DiscoverySource, make_repo_record
+from repo_scout.output_writer import write_output
+
+
+@pytest.mark.integration
+class TestRepoScoutFlow:
+    """Multi-source aggregation and output flow tests."""
+
+    def test_multi_source_aggregation(self) -> None:
+        """Awesome + Starred + Stargazer → deduplicated output."""
+        awesome_repos = [
+            make_repo_record("org", "tool-a", DiscoverySource.AWESOME_LIST),
+            make_repo_record("org", "tool-b", DiscoverySource.AWESOME_LIST),
+        ]
+        starred_repos = [
+            make_repo_record("org", "tool-b", DiscoverySource.STARRED_REPO, stars=50),
+            make_repo_record("user", "tool-c", DiscoverySource.STARRED_REPO),
+        ]
+        stargazer_repos = [
+            make_repo_record("alice", "tool-d", DiscoverySource.STARGAZER_TARGET),
+        ]
+
+        all_repos = awesome_repos + starred_repos + stargazer_repos
+        deduped = deduplicate_repos(all_repos)
+        sorted_repos = sort_by_relevance(deduped)
+
+        # Should have 4 unique repos (tool-b merged)
+        assert len(sorted_repos) == 4
+        # tool-b should have both sources
+        tool_b = next(r for r in sorted_repos if r["name"] == "tool-b")
+        assert "awesome_list" in tool_b["sources"]
+        assert "starred_repo" in tool_b["sources"]
+
+    def test_output_loads_as_valid_json(self, tmp_path: Path) -> None:
+        """write_output JSON → JSON.loads succeeds."""
+        repos = [
+            make_repo_record("org", "repo1", DiscoverySource.AWESOME_LIST, stars=100),
+            make_repo_record("user", "repo2", DiscoverySource.STARRED_REPO),
+        ]
+
+        output_path = str(tmp_path / "targets.json")
+        count = write_output(repos, output_path, fmt="json")
+        assert count == 2
+
+        # Verify the output is valid JSON that can be loaded
+        data = json.loads(Path(output_path).read_text())
+        assert len(data) == 2
+        assert data[0]["full_name"] == "org/repo1"
+
+    def test_duplicate_repos_across_sources_merged(self) -> None:
+        """Same repo from 2 sources has merged source list."""
+        repo1 = make_repo_record(
+            "org",
+            "shared-repo",
+            DiscoverySource.AWESOME_LIST,
+            description="From awesome list",
+            stars=10,
+        )
+        repo2 = make_repo_record(
+            "org",
+            "shared-repo",
+            DiscoverySource.STARRED_REPO,
+            description=None,
+            stars=50,
+        )
+
+        deduped = deduplicate_repos([repo1, repo2])
+        assert len(deduped) == 1
+
+        merged = deduped[0]
+        assert "awesome_list" in merged["sources"]
+        assert "starred_repo" in merged["sources"]
+        # Stars should be highest
+        assert merged["stars"] == 50
+        # Description should be preserved from first source
+        assert merged["description"] == "From awesome list"

--- a/tests/integration/test_slant_flow.py
+++ b/tests/integration/test_slant_flow.py
@@ -1,0 +1,109 @@
+"""Slant scoring flow integration tests.
+
+Tests scoring and verdict tier mapping with real scorer code.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from slant.scorer import map_confidence_to_tier, score_report, write_verdicts
+
+
+def _fake_signal_high(*args, **kwargs):
+    """Fake signal that returns high score."""
+    return 0.9
+
+
+def _fake_signal_low(*args, **kwargs):
+    """Fake signal that returns low score."""
+    return 0.1
+
+
+@pytest.mark.integration
+class TestSlantFlow:
+    """Scoring and verdict flow tests."""
+
+    def test_verdict_tiers_match_confidence(self) -> None:
+        """Verify >=95=AUTO, 75-94=REVIEW, 50-74=LOW, <50=INSUFFICIENT."""
+        assert map_confidence_to_tier(95) == "AUTO-APPROVE"
+        assert map_confidence_to_tier(100) == "AUTO-APPROVE"
+        assert map_confidence_to_tier(75) == "HUMAN-REVIEW"
+        assert map_confidence_to_tier(94) == "HUMAN-REVIEW"
+        assert map_confidence_to_tier(50) == "LOW-CONFIDENCE"
+        assert map_confidence_to_tier(74) == "LOW-CONFIDENCE"
+        assert map_confidence_to_tier(49) == "INSUFFICIENT"
+        assert map_confidence_to_tier(0) == "INSUFFICIENT"
+
+    def test_score_report_end_to_end(self, tmp_path: Path) -> None:
+        """JSON report → score_report → VerdictsFile with correct tiers."""
+        report = {
+            "dead_links": [
+                {
+                    "dead_url": "https://dead.example.com/page",
+                    "archived_url": "https://web.archive.org/web/2024/https://dead.example.com/page",
+                    "archived_title": "Example Page",
+                    "archived_content": "Some content here",
+                    "investigation_method": "redirect_chain",
+                    "candidates": [
+                        {"url": "https://new.example.com/page", "source": "redirect_chain"},
+                    ],
+                },
+            ],
+        }
+        report_path = tmp_path / "report.json"
+        report_path.write_text(json.dumps(report))
+
+        # Patch all signals to return high scores
+        with (
+            patch("slant.scorer.check_redirect", return_value=0.9),
+            patch("slant.scorer.match_title", return_value=0.9),
+            patch("slant.scorer.compare_content", return_value=0.9),
+            patch("slant.scorer.compare_url_paths", return_value=0.9),
+            patch("slant.scorer.match_domain", return_value=0.9),
+        ):
+            verdicts_file = score_report(report_path)
+
+        assert "verdicts" in verdicts_file
+        assert len(verdicts_file["verdicts"]) == 1
+        v = verdicts_file["verdicts"][0]
+        assert v["dead_url"] == "https://dead.example.com/page"
+        assert v["confidence"] > 0
+        assert v["verdict"] in ("AUTO-APPROVE", "HUMAN-REVIEW", "LOW-CONFIDENCE", "INSUFFICIENT")
+
+    def test_write_and_read_verdicts_roundtrip(self, tmp_path: Path) -> None:
+        """write_verdicts + Path.read_text produces valid JSON."""
+        verdicts_file = {
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "source_report": "test_report.json",
+            "verdicts": [
+                {
+                    "dead_url": "https://dead.example.com",
+                    "verdict": "AUTO-APPROVE",
+                    "confidence": 98,
+                    "replacement_url": "https://new.example.com",
+                    "scoring_breakdown": {
+                        "redirect": 0.9,
+                        "title_match": 0.8,
+                        "content_similarity": 0.7,
+                        "url_similarity": 0.6,
+                        "domain_match": 1.0,
+                    },
+                    "human_decision": None,
+                    "decided_at": None,
+                },
+            ],
+        }
+
+        output_path = tmp_path / "verdicts.json"
+        write_verdicts(verdicts_file, output_path)
+
+        assert output_path.exists()
+        loaded = json.loads(output_path.read_text())
+        assert loaded["verdicts"][0]["dead_url"] == "https://dead.example.com"
+        assert loaded["verdicts"][0]["confidence"] == 98
+        assert loaded["verdicts"][0]["verdict"] == "AUTO-APPROVE"


### PR DESCRIPTION
## Summary
- Add **15 new integration tests** across **5 test files** testing real module boundaries
- Pipeline E2E: full N0→N5 flow, clean run, dry-run
- Data contracts: cross-node state validation, serialization roundtrip
- Repo Scout: multi-source aggregation, JSON output, dedup merge
- DocFix Bot: PR generation from BrokenLinks, apply_fixes workflow
- Slant: confidence tiers, score_report E2E, verdicts roundtrip
- Test count: 1079 → 1094

Closes #59
Closes #60
Closes #61
Closes #62
Closes #63

## Test plan
- [x] `poetry run pytest tests/integration/ -v` — 18 passed (15 new + 3 existing)
- [x] `poetry run pytest --tb=short -q` — 1094 passed, 1 skipped
- [x] `poetry run ruff check tests/integration/` — clean
- [x] `poetry run ruff format --check tests/integration/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)