### PR TITLE
fix: GitHubContentsClient auth fallback to gh CLI (#73)

### DIFF
--- a/src/gh_link_auditor/github_api.py
+++ b/src/gh_link_auditor/github_api.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import base64
 import logging
-import os
 
 import httpx
 
@@ -35,7 +34,12 @@ class GitHubContentsClient:
             token: GitHub personal access token.
                    Falls back to GITHUB_TOKEN env var if not provided.
         """
-        self._token = token or os.environ.get("GITHUB_TOKEN", "")
+        if token is not None:
+            self._token = token
+        else:
+            from gh_link_auditor.auth import resolve_github_token
+
+            self._token = resolve_github_token()
         headers: dict[str, str] = {
             "Accept": "application/vnd.github.v3+json",
             "User-Agent": "gh-link-auditor",


### PR DESCRIPTION
## Summary

- `GitHubContentsClient` only checked `GITHUB_TOKEN` env var, missing the `gh auth token` CLI fallback
- Caused 403 rate limit on first live run against `pallets/flask`
- Now uses `resolve_github_token()` from `auth.py` which checks env var then falls back to `gh auth token`

Closes #73

## Test plan

- [x] Verified `resolve_github_token()` returns a 93-char token via `gh auth`
- [x] Live dry-run on `pallets/flask` succeeded after fix (3 dead links found, exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)