### PR TITLE
fix: resolve relative Location headers in redirect resolver (#75)

### DIFF
--- a/src/gh_link_auditor/redirect_resolver.py
+++ b/src/gh_link_auditor/redirect_resolver.py
@@ -13,7 +13,7 @@ import ipaddress
 import socket
 import urllib.error
 import urllib.request
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 from src.logging_config import setup_logging
 
@@ -123,8 +123,10 @@ class RedirectResolver:
             location = result["location"]
 
             if code in _REDIRECT_CODES and location:
-                log.append(f"{code} {current} -> {location}")
-                current = location
+                # Resolve relative Location headers (RFC 7231 §7.1.2)
+                resolved = urljoin(current, location)
+                log.append(f"{code} {current} -> {resolved}")
+                current = resolved
                 continue
 
             # Not a redirect — check if we actually followed any redirects

--- a/tests/unit/test_redirect_resolver.py
+++ b/tests/unit/test_redirect_resolver.py
@@ -420,6 +420,24 @@ class TestRedirectLoop:
         assert final_url is None
         assert any("loop" in entry.lower() for entry in log)
 
+    def test_relative_redirect_resolved(self):
+        """Relative Location header is resolved against the request URL."""
+        resolver = _make_resolver()
+
+        def _mock_head(url):
+            if url == "https://security.stackexchange.com/q/39118":
+                return {"status_code": 301, "location": "/questions/39118/how-to-protect"}
+            if url == "https://security.stackexchange.com/questions/39118/how-to-protect":
+                return {"status_code": 200, "location": None}
+            return {"status_code": 404, "location": None}
+
+        with (
+            patch("gh_link_auditor.redirect_resolver._http_head", side_effect=_mock_head),
+            patch("gh_link_auditor.redirect_resolver.socket.getaddrinfo", side_effect=_mock_public_dns),
+        ):
+            final_url, log = resolver.follow_redirects("https://security.stackexchange.com/q/39118")
+        assert final_url == "https://security.stackexchange.com/questions/39118/how-to-protect"
+
 
 # ---------------------------------------------------------------------------
 # SSRF DNS resolution failure


### PR DESCRIPTION
## Summary

- Redirect resolver crashed on relative `Location` headers (e.g., `/questions/39118/...`)
- `urllib.request.Request` rejects non-absolute URLs with `ValueError: unknown url type`
- Fix: use `urljoin(current_url, location)` to resolve relative redirects per RFC 7231 §7.1.2
- Found during live dry-run on `pallets/flask` (StackExchange uses relative redirects)

Closes #75

## Test plan

- [x] New test: `test_relative_redirect_resolved` — relative Location resolved correctly
- [x] All 29 redirect resolver tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)