### PR TITLE
fix: first live run quality — backtick regex, Slant scoring, dry-run output (#80)

### DIFF
--- a/src/gh_link_auditor/cli/run.py
+++ b/src/gh_link_auditor/cli/run.py
@@ -112,8 +112,39 @@ def cmd_run(args: argparse.Namespace) -> int:
     # Success summary
     fixes = result.get("fixes", [])
     dead_links = result.get("dead_links", [])
+    verdicts = result.get("verdicts", [])
+
     if not dead_links:
         print("No dead links found. Documentation is clean!")
+        return 0
+
+    print(f"\n{'=' * 60}")
+    print(f"  RESULTS: {len(dead_links)} dead links found")
+    print(f"{'=' * 60}\n")
+
+    for i, verdict in enumerate(verdicts, 1):
+        dl = verdict.get("dead_link", {})
+        candidate = verdict.get("candidate")
+        confidence = verdict.get("confidence", 0)
+
+        print(f"  [{i}] {dl.get('url', '?')}")
+        print(f"      File:       {dl.get('source_file', '?')}:{dl.get('line_number', '?')}")
+        print(f"      Status:     {dl.get('http_status', 'unknown')}")
+        print(f"      Confidence: {confidence:.0%}")
+
+        if candidate:
+            print(f"      Replace:    {candidate['url']}")
+            print(f"      Source:     {candidate.get('source', '?')}")
+        else:
+            print("      Replace:    (no candidate)")
+
+        reasoning = verdict.get("reasoning", "")
+        if reasoning:
+            print(f"      Reasoning:  {reasoning}")
+        print()
+
+    if args.dry_run:
+        print(f"Dry-run complete. {len(verdicts)} verdicts produced, no fixes applied.")
     else:
         print(f"Found {len(dead_links)} dead links, generated {len(fixes)} fixes.")
 

--- a/src/gh_link_auditor/pipeline/nodes/n1_scan.py
+++ b/src/gh_link_auditor/pipeline/nodes/n1_scan.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from gh_link_auditor.network import check_url as network_check_url
 from gh_link_auditor.pipeline.state import DeadLink, PipelineState
 
-_URL_RE = re.compile(r"https?://[^\s\)>\"\]]+")
+_URL_RE = re.compile(r"https?://[^\s\)>\"\]`]+")
 
 
 def _read_file_content(

--- a/src/slant/scorer.py
+++ b/src/slant/scorer.py
@@ -77,7 +77,7 @@ def score_candidate(
     """
     candidate_url = candidate["url"]
 
-    redirect_raw = check_redirect(dead_url, candidate_url)
+    redirect_raw = check_redirect(dead_url, candidate_url, candidate_source=candidate.get("source", ""))
     title_raw = match_title(candidate_url, archived_title)
     content_raw = compare_content(candidate_url, archived_content)
     url_path_raw = compare_url_paths(dead_url, candidate_url)

--- a/src/slant/signals/redirect.py
+++ b/src/slant/signals/redirect.py
@@ -58,20 +58,31 @@ def _normalize_url(url: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def check_redirect(dead_url: str, candidate_url: str, timeout: float = 10.0) -> float:
+def check_redirect(
+    dead_url: str,
+    candidate_url: str,
+    timeout: float = 10.0,
+    candidate_source: str = "",
+) -> float:
     """Check if dead URL redirects to candidate via HTTP 3xx chain.
 
-    Follows up to 5 redirect hops. Returns 1.0 if the chain reaches
-    the candidate URL (normalized), 0.0 otherwise.
+    If the candidate was already discovered via redirect chain (source
+    is "redirect_chain"), returns 1.0 immediately — N2 already verified it.
+
+    Otherwise follows up to 5 redirect hops. Returns 1.0 if the chain
+    reaches the candidate URL (normalized), 0.0 otherwise.
 
     Args:
         dead_url: The dead URL to check.
         candidate_url: The candidate replacement URL.
         timeout: HTTP request timeout in seconds.
+        candidate_source: How the candidate was discovered (e.g., "redirect_chain").
 
     Returns:
         1.0 if redirect reaches candidate, 0.0 otherwise.
     """
+    if candidate_source == "redirect_chain":
+        return 1.0
     try:
         current = dead_url
         visited: set[str] = set()

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -143,6 +143,29 @@ class TestCheckRedirect:
             score = check_redirect("https://example.com/page", "https://example.com/new-page")
         assert score == 1.0
 
+    def test_redirect_chain_source_short_circuits(self):
+        """Candidate from redirect_chain source returns 1.0 without HTTP call."""
+        score = check_redirect(
+            "https://example.com/q/123",
+            "https://example.com/questions/123/full-title",
+            candidate_source="redirect_chain",
+        )
+        assert score == 1.0
+
+    def test_non_redirect_source_still_checks_http(self):
+        """Candidate from other sources still does HTTP verification."""
+
+        def _mock_get(url, *, timeout=10):
+            return {"status_code": 200, "location": None}
+
+        with patch("slant.signals.redirect._http_get", side_effect=_mock_get):
+            score = check_redirect(
+                "https://example.com/page",
+                "https://example.com/new-page",
+                candidate_source="archive",
+            )
+        assert score == 0.0
+
     def test_score_range_zero_to_one(self):
         """Score is always in [0.0, 1.0] range."""
 


### PR DESCRIPTION
## Summary

Three fixes discovered during first live dry-run on `pallets/flask`:

- **#77 Backtick leakage**: N1 URL regex now excludes backticks — no more RST markup leaking into extracted URLs
- **#78 Slant scoring**: redirect signal returns 1.0 immediately when candidate source is `redirect_chain` (N2 already verified it, no need to re-check via HTTP and get blocked by bot detection)
- **#79 Dry-run output**: prints structured verdict summary showing each dead link, file/line, confidence, replacement, and reasoning

Closes #77, closes #78, closes #79, closes #80

## Test plan

- [x] 2 new tests for redirect_chain source short-circuit
- [x] All 146 affected tests pass
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)