### PR TITLE
fix: progress output and N4 prompt clarity (#82)

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,0 +1,7 @@
+"""Run the pipeline on pallets/flask (full run with human review)."""
+
+import sys
+
+from gh_link_auditor.cli.main import main
+
+sys.exit(main(["run", "https://github.com/pallets/flask", "--verbose", "--max-links", "20"]))

--- a/src/gh_link_auditor/cli/run.py
+++ b/src/gh_link_auditor/cli/run.py
@@ -7,7 +7,6 @@ Deviation from LLD: uses argparse instead of click to match codebase stdlib pref
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 
 from gh_link_auditor.pipeline.graph import run_pipeline
@@ -76,11 +75,6 @@ def cmd_run(args: argparse.Namespace) -> int:
         verbose=args.verbose,
         db_path=args.db_path,
     )
-
-    # Check for LLM model override
-    model = os.environ.get("LLM_MODEL_NAME", "gpt-4o-mini")
-    if args.verbose:
-        print(f"Using model: {model}", file=sys.stderr)
 
     try:
         result = run_pipeline(state)

--- a/src/gh_link_auditor/pipeline/nodes/n0_load_target.py
+++ b/src/gh_link_auditor/pipeline/nodes/n0_load_target.py
@@ -9,6 +9,7 @@ See LLD #22 §2.4 for n0_load_target specification.
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 from typing import Literal
 
@@ -152,6 +153,10 @@ def n0_load_target(state: PipelineState) -> PipelineState:
         Updated PipelineState.
     """
     target = state.get("target", "")
+    verbose = state.get("verbose", False)
+
+    if verbose:
+        print(f"[N0] Loading target: {target}", file=sys.stderr, flush=True)
 
     try:
         normalized, target_type = validate_target(target)
@@ -167,7 +172,17 @@ def n0_load_target(state: PipelineState) -> PipelineState:
             state["repo_owner"] = ""
             state["repo_name_short"] = ""
 
+        if verbose:
+            print("[N0] Listing doc files...", file=sys.stderr, flush=True)
+
         state["doc_files"] = list_documentation_files(normalized, target_type)
+
+        if verbose:
+            print(
+                f"[N0] Found {len(state['doc_files'])} doc files",
+                file=sys.stderr,
+                flush=True,
+            )
     except (ValueError, FileNotFoundError) as exc:
         state["errors"] = state.get("errors", []) + [str(exc)]
 

--- a/src/gh_link_auditor/pipeline/nodes/n1_scan.py
+++ b/src/gh_link_auditor/pipeline/nodes/n1_scan.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from pathlib import Path
 
 from gh_link_auditor.network import check_url as network_check_url
@@ -223,6 +224,14 @@ def n1_scan(state: PipelineState) -> PipelineState:
     target_type = state.get("target_type", "local")
     repo_owner = state.get("repo_owner", "")
     repo_name_short = state.get("repo_name_short", "")
+    verbose = state.get("verbose", False)
+
+    if verbose:
+        print(
+            f"[N1] Scanning {len(doc_files)} doc files for URLs...",
+            file=sys.stderr,
+            flush=True,
+        )
 
     try:
         dead_links = run_link_scan(
@@ -236,6 +245,13 @@ def n1_scan(state: PipelineState) -> PipelineState:
     except Exception as exc:
         state["errors"] = state.get("errors", []) + [f"Scan error: {exc}"]
         state["dead_links"] = state.get("dead_links", [])
+
+    if verbose:
+        print(
+            f"[N1] Scan complete: {len(state.get('dead_links', []))} dead links found",
+            file=sys.stderr,
+            flush=True,
+        )
 
     state["scan_complete"] = True
     return state

--- a/src/gh_link_auditor/pipeline/nodes/n2_investigate.py
+++ b/src/gh_link_auditor/pipeline/nodes/n2_investigate.py
@@ -8,6 +8,7 @@ See LLD #22 §2.4 for n2_investigate specification.
 from __future__ import annotations
 
 import logging
+import sys
 
 from gh_link_auditor.pipeline.state import (
     DeadLink,
@@ -81,13 +82,25 @@ def n2_investigate(state: PipelineState) -> PipelineState:
     """
     dead_links = state.get("dead_links", [])
     candidates: dict[str, list[ReplacementCandidate]] = {}
+    verbose = state.get("verbose", False)
 
     if state.get("cost_limit_reached", False):
         state["candidates"] = candidates
         return state
 
-    for dead_link in dead_links:
+    if verbose:
+        print(
+            f"[N2] Investigating {len(dead_links)} dead links...",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    for i, dead_link in enumerate(dead_links, 1):
         url = dead_link["url"]
+
+        if verbose:
+            print(f"[N2] ({i}/{len(dead_links)}) {url}", file=sys.stderr, flush=True)
+
         try:
             found = investigate_dead_link(dead_link)
             candidates[url] = found

--- a/src/gh_link_auditor/pipeline/nodes/n3_judge.py
+++ b/src/gh_link_auditor/pipeline/nodes/n3_judge.py
@@ -9,6 +9,7 @@ See LLD #22 §2.4 for n3_judge specification.
 from __future__ import annotations
 
 import logging
+import sys
 
 from gh_link_auditor.pipeline.state import (
     DeadLink,
@@ -121,6 +122,10 @@ def n3_judge(state: PipelineState) -> PipelineState:
     dead_links = state.get("dead_links", [])
     candidates = state.get("candidates", {})
     verdicts: list[Verdict] = []
+    verbose = state.get("verbose", False)
+
+    if verbose:
+        print(f"[N3] Scoring {len(dead_links)} verdicts...", file=sys.stderr, flush=True)
 
     for dead_link in dead_links:
         url = dead_link["url"]

--- a/src/gh_link_auditor/pipeline/nodes/n4_human_review.py
+++ b/src/gh_link_auditor/pipeline/nodes/n4_human_review.py
@@ -24,20 +24,23 @@ def format_verdict_for_review(verdict: Verdict) -> str:
     confidence = verdict.get("confidence", 0)
 
     lines = [
-        f"Dead URL: {dead_link['url']}",
-        f"Source:   {dead_link['source_file']}:{dead_link['line_number']}",
-        f"Confidence: {confidence}",
+        "",
+        "-" * 50,
+        f"  Dead URL:  {dead_link['url']}",
+        f"  File:      {dead_link['source_file']}:{dead_link['line_number']}",
+        f"  Confidence: {confidence:.0%}",
     ]
 
     if candidate:
-        lines.append(f"Proposed replacement: {candidate['url']}")
-        lines.append(f"Found via: {candidate['source']}")
+        lines.append(f"  Replace with: {candidate['url']}")
+        lines.append(f"  Found via:    {candidate['source']}")
     else:
-        lines.append("Proposed replacement: None (no candidate found)")
+        lines.append("  Replace with: (no candidate)")
 
     if verdict.get("reasoning"):
-        lines.append(f"Reasoning: {verdict['reasoning']}")
+        lines.append(f"  Reasoning:    {verdict['reasoning']}")
 
+    lines.append("-" * 50)
     return "\n".join(lines)
 
 
@@ -51,7 +54,7 @@ def prompt_user_approval(verdict: Verdict) -> bool:
         True if approved, False if rejected.
     """
     try:
-        response = input("[y]es / [n]o: ").strip().lower()
+        response = input("Approve this replacement? [y]es / [n]o: ").strip().lower()
     except (EOFError, KeyboardInterrupt):
         return False
 


### PR DESCRIPTION
## Summary

- N0-N3: verbose progress logging to stderr so operator knows pipeline is alive
- N4: clearer review prompt with separators and "Approve this replacement?"
- CLI: removed misleading "Using model: gpt-4o-mini" (no LLM is used)

Closes #82

## Test plan

- [x] Lint and format clean
- [x] Verified output in previous dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)