### PR TITLE
feat: campaign dashboard with contribution stats (#87)

### DIFF
--- a/src/gh_link_auditor/campaign_dashboard.py
+++ b/src/gh_link_auditor/campaign_dashboard.py
@@ -1,0 +1,228 @@
+"""Campaign dashboard — terminal display of contribution stats.
+
+Formats campaign metrics and recent PR outcomes into a human-readable
+terminal dashboard.
+
+See Issue #87 for specification.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from gh_link_auditor.metrics.models import CampaignMetrics, PROutcome
+
+
+def format_dashboard(
+    metrics: CampaignMetrics,
+    recent_prs: list[PROutcome],
+    now: datetime | None = None,
+) -> str:
+    """Format the full campaign dashboard.
+
+    Args:
+        metrics: Aggregate campaign metrics.
+        recent_prs: List of recent PR outcomes (sorted newest first).
+        now: Current time (defaults to UTC now, injectable for testing).
+
+    Returns:
+        Multi-line formatted dashboard string.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    lines: list[str] = []
+
+    # Header
+    lines.append("Campaign Summary")
+    lines.append("=" * 40)
+
+    # Aggregate stats
+    lines.append(f"Repos scanned:    {metrics.total_repos_processed:>5}")
+
+    total_prs = metrics.total_prs_submitted
+    lines.append(f"PRs submitted:    {total_prs:>5}")
+
+    # Merged with percentage
+    merged_pct = _pct(metrics.total_prs_merged, total_prs)
+    lines.append(f"PRs merged:       {metrics.total_prs_merged:>5}  ({merged_pct})")
+
+    # Closed with annotation
+    closed = metrics.total_prs_rejected
+    closed_pct = _pct(closed, total_prs)
+    lines.append(f"PRs closed:       {closed:>5}  ({closed_pct})")
+
+    # Open
+    open_prs = metrics.total_prs_open
+    open_pct = _pct(open_prs, total_prs)
+    lines.append(f"PRs open:         {open_prs:>5}  ({open_pct})")
+
+    # Acceptance rate
+    lines.append(f"Acceptance rate:  {metrics.acceptance_rate:>5.1%}")
+
+    # Avg time to merge
+    if metrics.avg_time_to_merge_hours > 0:
+        lines.append(f"Avg time to merge: {_format_duration(metrics.avg_time_to_merge_hours)}")
+
+    # Rejection reasons
+    if metrics.rejection_reasons:
+        lines.append("")
+        lines.append("Rejection reasons:")
+        for reason, count in sorted(metrics.rejection_reasons.items(), key=lambda x: -x[1]):
+            lines.append(f"  {reason}: {count}")
+
+    # Recent PRs
+    if recent_prs:
+        lines.append("")
+        lines.append("Recent PRs:")
+        for pr in recent_prs[:10]:  # Show at most 10
+            line = _format_pr_line(pr, now)
+            lines.append(f"  {line}")
+
+    return "\n".join(lines)
+
+
+def _pct(part: int, total: int) -> str:
+    """Format a percentage string.
+
+    Args:
+        part: Numerator.
+        total: Denominator.
+
+    Returns:
+        Formatted string like "62.5%" or "0.0%".
+    """
+    if total == 0:
+        return "0.0%"
+    return f"{part / total * 100:.1f}%"
+
+
+def _format_duration(hours: float) -> str:
+    """Format hours into a human-readable duration.
+
+    Args:
+        hours: Duration in hours.
+
+    Returns:
+        Formatted string like "2d 5h" or "3h".
+    """
+    if hours >= 24:
+        days = int(hours // 24)
+        remaining_hours = int(hours % 24)
+        if remaining_hours > 0:
+            return f"{days}d {remaining_hours}h"
+        return f"{days}d"
+    return f"{hours:.0f}h"
+
+
+def _format_pr_line(pr: PROutcome, now: datetime) -> str:
+    """Format a single PR outcome as a dashboard line.
+
+    Args:
+        pr: PR outcome to format.
+        now: Current time for relative timestamp.
+
+    Returns:
+        Formatted string like "pallets/flask #123  MERGED  2d ago".
+    """
+    repo = pr.repo_full_name
+    # Extract PR number from URL
+    pr_number = _extract_number(pr.pr_url)
+    number_str = f"#{pr_number}" if pr_number else ""
+
+    status = pr.status.upper()
+    age = _relative_time(pr.submitted_at, now)
+
+    # Build the line
+    repo_part = f"{repo} {number_str}".ljust(35)
+    status_part = status.ljust(8)
+
+    line = f"{repo_part} {status_part} {age}"
+
+    # Add annotation for closed PRs
+    if pr.status == "closed" and pr.rejection_reason:
+        line += f"  ({pr.rejection_reason})"
+
+    return line
+
+
+def _extract_number(pr_url: str) -> int:
+    """Extract PR number from URL.
+
+    Args:
+        pr_url: GitHub PR URL.
+
+    Returns:
+        PR number, or 0 if parsing fails.
+    """
+    try:
+        parts = pr_url.rstrip("/").split("/")
+        return int(parts[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
+def _relative_time(dt: datetime, now: datetime) -> str:
+    """Format a datetime as relative time (e.g., "2d ago").
+
+    Args:
+        dt: The datetime to format.
+        now: Current time.
+
+    Returns:
+        Relative time string.
+    """
+    delta = now - dt
+    total_seconds = delta.total_seconds()
+
+    if total_seconds < 0:
+        return "just now"
+    if total_seconds < 60:
+        return "just now"
+    if total_seconds < 3600:
+        minutes = int(total_seconds // 60)
+        return f"{minutes}m ago"
+    if total_seconds < 86400:
+        hours = int(total_seconds // 3600)
+        return f"{hours}h ago"
+    days = int(total_seconds // 86400)
+    return f"{days}d ago"
+
+
+def format_dashboard_json(
+    metrics: CampaignMetrics,
+    recent_prs: list[PROutcome],
+) -> dict:
+    """Format dashboard data as a JSON-serializable dict.
+
+    Args:
+        metrics: Aggregate campaign metrics.
+        recent_prs: List of recent PR outcomes.
+
+    Returns:
+        Dictionary suitable for JSON serialization.
+    """
+    return {
+        "total_runs": metrics.total_runs,
+        "total_repos_processed": metrics.total_repos_processed,
+        "total_prs_submitted": metrics.total_prs_submitted,
+        "total_prs_merged": metrics.total_prs_merged,
+        "total_prs_rejected": metrics.total_prs_rejected,
+        "total_prs_open": metrics.total_prs_open,
+        "acceptance_rate": metrics.acceptance_rate,
+        "avg_time_to_merge_hours": metrics.avg_time_to_merge_hours,
+        "rejection_reasons": metrics.rejection_reasons,
+        "recent_prs": [
+            {
+                "repo": pr.repo_full_name,
+                "pr_url": pr.pr_url,
+                "status": pr.status,
+                "submitted_at": pr.submitted_at.isoformat(),
+                "merged_at": pr.merged_at.isoformat() if pr.merged_at else None,
+                "closed_at": pr.closed_at.isoformat() if pr.closed_at else None,
+                "rejection_reason": pr.rejection_reason,
+                "time_to_merge_hours": pr.time_to_merge_hours,
+            }
+            for pr in recent_prs
+        ],
+    }

--- a/src/gh_link_auditor/cli/metrics_cmd.py
+++ b/src/gh_link_auditor/cli/metrics_cmd.py
@@ -9,11 +9,6 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from gh_link_auditor.metrics.reporter import (
-    format_campaign_text,
-    generate_campaign_metrics,
-)
-
 DEFAULT_DB_PATH = Path("data/metrics/metrics.db")
 
 
@@ -39,7 +34,7 @@ def build_metrics_parser(subparsers: argparse._SubParsersAction) -> None:
 
 
 def cmd_metrics_campaign(args: argparse.Namespace) -> int:
-    """Display campaign metrics.
+    """Display campaign dashboard with aggregate stats and recent PRs.
 
     Args:
         args: Parsed CLI arguments.
@@ -47,26 +42,33 @@ def cmd_metrics_campaign(args: argparse.Namespace) -> int:
     Returns:
         Exit code.
     """
+    from gh_link_auditor.campaign_dashboard import (
+        format_dashboard,
+        format_dashboard_json,
+    )
+    from gh_link_auditor.metrics.collector import MetricsCollector
+    from gh_link_auditor.metrics.reporter import generate_campaign_metrics
+
     db_path = Path(args.db_path)
     metrics = generate_campaign_metrics(db_path)
 
+    # Fetch recent PRs for the dashboard
+    collector = MetricsCollector(db_path)
+    try:
+        recent_prs = collector.get_all_pr_outcomes()
+    finally:
+        collector.close()
+
+    # Sort by submitted_at descending (newest first)
+    recent_prs.sort(key=lambda p: p.submitted_at, reverse=True)
+
     fmt = getattr(args, "format", "text")
     if fmt == "text":
-        print(format_campaign_text(metrics))
+        print(format_dashboard(metrics, recent_prs))
     else:
         import json as json_mod
 
-        data = {
-            "total_runs": metrics.total_runs,
-            "total_repos_processed": metrics.total_repos_processed,
-            "total_prs_submitted": metrics.total_prs_submitted,
-            "total_prs_merged": metrics.total_prs_merged,
-            "total_prs_rejected": metrics.total_prs_rejected,
-            "total_prs_open": metrics.total_prs_open,
-            "acceptance_rate": metrics.acceptance_rate,
-            "avg_time_to_merge_hours": metrics.avg_time_to_merge_hours,
-            "rejection_reasons": metrics.rejection_reasons,
-        }
+        data = format_dashboard_json(metrics, recent_prs)
         print(json_mod.dumps(data, indent=2))
 
     return 0

--- a/tests/unit/test_campaign_dashboard.py
+++ b/tests/unit/test_campaign_dashboard.py
@@ -1,0 +1,308 @@
+"""Tests for campaign dashboard formatting.
+
+See Issue #87 for specification.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from gh_link_auditor.campaign_dashboard import (
+    _extract_number,
+    _format_duration,
+    _format_pr_line,
+    _pct,
+    _relative_time,
+    format_dashboard,
+    format_dashboard_json,
+)
+from gh_link_auditor.metrics.models import CampaignMetrics, PROutcome
+
+
+def _make_metrics(
+    total_runs: int = 5,
+    total_repos: int = 12,
+    total_prs: int = 8,
+    merged: int = 5,
+    rejected: int = 2,
+    open_prs: int = 1,
+    acceptance_rate: float = 0.625,
+    avg_ttm: float = 48.0,
+    rejection_reasons: dict | None = None,
+) -> CampaignMetrics:
+    return CampaignMetrics(
+        total_runs=total_runs,
+        total_repos_processed=total_repos,
+        total_prs_submitted=total_prs,
+        total_prs_merged=merged,
+        total_prs_rejected=rejected,
+        total_prs_open=open_prs,
+        acceptance_rate=acceptance_rate,
+        avg_time_to_merge_hours=avg_ttm,
+        rejection_reasons=rejection_reasons or {},
+    )
+
+
+def _make_pr(
+    repo: str = "pallets/flask",
+    pr_url: str = "https://github.com/pallets/flask/pull/1234",
+    status: str = "merged",
+    submitted_at: datetime | None = None,
+    rejection_reason: str | None = None,
+    merged_at: datetime | None = None,
+    closed_at: datetime | None = None,
+    ttm: float | None = None,
+) -> PROutcome:
+    return PROutcome(
+        repo_full_name=repo,
+        pr_url=pr_url,
+        status=status,
+        submitted_at=submitted_at or datetime(2026, 3, 17, tzinfo=timezone.utc),
+        merged_at=merged_at,
+        closed_at=closed_at,
+        rejection_reason=rejection_reason,
+        time_to_merge_hours=ttm,
+    )
+
+
+NOW = datetime(2026, 3, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class TestPct:
+    """Tests for _pct()."""
+
+    def test_nonzero(self) -> None:
+        assert _pct(5, 8) == "62.5%"
+
+    def test_zero_total(self) -> None:
+        assert _pct(0, 0) == "0.0%"
+
+    def test_hundred_percent(self) -> None:
+        assert _pct(10, 10) == "100.0%"
+
+    def test_zero_part(self) -> None:
+        assert _pct(0, 5) == "0.0%"
+
+
+class TestFormatDuration:
+    """Tests for _format_duration()."""
+
+    def test_hours_only(self) -> None:
+        assert _format_duration(3.5) == "4h"
+
+    def test_days_and_hours(self) -> None:
+        assert _format_duration(50) == "2d 2h"
+
+    def test_exact_days(self) -> None:
+        assert _format_duration(48) == "2d"
+
+    def test_less_than_day(self) -> None:
+        assert _format_duration(23.5) == "24h"
+
+
+class TestRelativeTime:
+    """Tests for _relative_time()."""
+
+    def test_just_now(self) -> None:
+        dt = NOW - timedelta(seconds=30)
+        assert _relative_time(dt, NOW) == "just now"
+
+    def test_minutes(self) -> None:
+        dt = NOW - timedelta(minutes=15)
+        assert _relative_time(dt, NOW) == "15m ago"
+
+    def test_hours(self) -> None:
+        dt = NOW - timedelta(hours=5)
+        assert _relative_time(dt, NOW) == "5h ago"
+
+    def test_days(self) -> None:
+        dt = NOW - timedelta(days=3)
+        assert _relative_time(dt, NOW) == "3d ago"
+
+    def test_future_shows_just_now(self) -> None:
+        dt = NOW + timedelta(hours=1)
+        assert _relative_time(dt, NOW) == "just now"
+
+
+class TestExtractNumber:
+    """Tests for _extract_number()."""
+
+    def test_standard_url(self) -> None:
+        assert _extract_number("https://github.com/owner/repo/pull/123") == 123
+
+    def test_invalid_url(self) -> None:
+        assert _extract_number("not-a-url") == 0
+
+    def test_empty(self) -> None:
+        assert _extract_number("") == 0
+
+
+class TestFormatPrLine:
+    """Tests for _format_pr_line()."""
+
+    def test_merged_pr(self) -> None:
+        pr = _make_pr(status="merged", submitted_at=NOW - timedelta(days=2))
+        line = _format_pr_line(pr, NOW)
+        assert "pallets/flask" in line
+        assert "#1234" in line
+        assert "MERGED" in line
+        assert "2d ago" in line
+
+    def test_closed_with_reason(self) -> None:
+        pr = _make_pr(
+            status="closed",
+            rejection_reason="maintainer committed fix directly",
+            submitted_at=NOW - timedelta(days=5),
+        )
+        line = _format_pr_line(pr, NOW)
+        assert "CLOSED" in line
+        assert "maintainer committed fix directly" in line
+
+    def test_open_pr(self) -> None:
+        pr = _make_pr(status="open", submitted_at=NOW - timedelta(hours=12))
+        line = _format_pr_line(pr, NOW)
+        assert "OPEN" in line
+        assert "12h ago" in line
+
+
+class TestFormatDashboard:
+    """Tests for format_dashboard()."""
+
+    def test_header(self) -> None:
+        metrics = _make_metrics()
+        text = format_dashboard(metrics, [], now=NOW)
+        assert "Campaign Summary" in text
+        assert "=" * 40 in text
+
+    def test_aggregate_stats(self) -> None:
+        metrics = _make_metrics()
+        text = format_dashboard(metrics, [], now=NOW)
+        assert "Repos scanned:" in text
+        assert "12" in text
+        assert "PRs submitted:" in text
+        assert "8" in text
+        assert "PRs merged:" in text
+        assert "62.5%" in text
+
+    def test_acceptance_rate(self) -> None:
+        metrics = _make_metrics(acceptance_rate=0.625)
+        text = format_dashboard(metrics, [], now=NOW)
+        assert "62.5%" in text
+
+    def test_avg_time_to_merge(self) -> None:
+        metrics = _make_metrics(avg_ttm=48.0)
+        text = format_dashboard(metrics, [], now=NOW)
+        assert "2d" in text
+
+    def test_rejection_reasons(self) -> None:
+        metrics = _make_metrics(rejection_reasons={"maintainer fixed": 2, "stale PR": 1})
+        text = format_dashboard(metrics, [], now=NOW)
+        assert "Rejection reasons:" in text
+        assert "maintainer fixed: 2" in text
+        assert "stale PR: 1" in text
+
+    def test_recent_prs_section(self) -> None:
+        metrics = _make_metrics()
+        prs = [
+            _make_pr(
+                repo="pallets/flask",
+                pr_url="https://github.com/pallets/flask/pull/1234",
+                status="merged",
+                submitted_at=NOW - timedelta(days=2),
+            ),
+            _make_pr(
+                repo="psf/requests",
+                pr_url="https://github.com/psf/requests/pull/567",
+                status="closed",
+                rejection_reason="maintainer committed fix directly",
+                submitted_at=NOW - timedelta(days=5),
+            ),
+            _make_pr(
+                repo="fastapi/fastapi",
+                pr_url="https://github.com/fastapi/fastapi/pull/89",
+                status="open",
+                submitted_at=NOW - timedelta(days=1),
+            ),
+        ]
+        text = format_dashboard(metrics, prs, now=NOW)
+        assert "Recent PRs:" in text
+        assert "pallets/flask" in text
+        assert "psf/requests" in text
+        assert "fastapi/fastapi" in text
+        assert "MERGED" in text
+        assert "CLOSED" in text
+        assert "OPEN" in text
+
+    def test_no_recent_prs(self) -> None:
+        metrics = _make_metrics()
+        text = format_dashboard(metrics, [], now=NOW)
+        assert "Recent PRs:" not in text
+
+    def test_limits_to_10_prs(self) -> None:
+        metrics = _make_metrics()
+        prs = [
+            _make_pr(
+                pr_url=f"https://github.com/org/repo/pull/{i}",
+                submitted_at=NOW - timedelta(days=i),
+            )
+            for i in range(15)
+        ]
+        text = format_dashboard(metrics, prs, now=NOW)
+        # Count PR lines (lines under "Recent PRs:")
+        in_prs = False
+        pr_lines = 0
+        for line in text.splitlines():
+            if line.strip() == "Recent PRs:":
+                in_prs = True
+                continue
+            if in_prs and line.strip():
+                pr_lines += 1
+        assert pr_lines == 10
+
+    def test_zero_prs_no_division_error(self) -> None:
+        metrics = _make_metrics(total_prs=0, merged=0, rejected=0, open_prs=0, acceptance_rate=0.0)
+        text = format_dashboard(metrics, [], now=NOW)
+        assert "0.0%" in text
+
+    def test_skips_avg_ttm_when_zero(self) -> None:
+        metrics = _make_metrics(avg_ttm=0.0)
+        text = format_dashboard(metrics, [], now=NOW)
+        assert "Avg time to merge" not in text
+
+
+class TestFormatDashboardJson:
+    """Tests for format_dashboard_json()."""
+
+    def test_returns_dict(self) -> None:
+        metrics = _make_metrics()
+        data = format_dashboard_json(metrics, [])
+        assert isinstance(data, dict)
+        assert data["total_runs"] == 5
+        assert data["total_prs_submitted"] == 8
+
+    def test_includes_recent_prs(self) -> None:
+        metrics = _make_metrics()
+        prs = [_make_pr()]
+        data = format_dashboard_json(metrics, prs)
+        assert len(data["recent_prs"]) == 1
+        assert data["recent_prs"][0]["repo"] == "pallets/flask"
+
+    def test_pr_fields(self) -> None:
+        metrics = _make_metrics()
+        prs = [
+            _make_pr(
+                merged_at=datetime(2026, 3, 18, tzinfo=timezone.utc),
+                ttm=24.0,
+            )
+        ]
+        data = format_dashboard_json(metrics, prs)
+        pr = data["recent_prs"][0]
+        assert pr["status"] == "merged"
+        assert pr["merged_at"] is not None
+        assert pr["time_to_merge_hours"] == 24.0
+
+    def test_empty_recent_prs(self) -> None:
+        metrics = _make_metrics()
+        data = format_dashboard_json(metrics, [])
+        assert data["recent_prs"] == []
+        assert data["rejection_reasons"] == {}


### PR DESCRIPTION
## Summary

- **Campaign dashboard** (`campaign_dashboard.py`): Terminal-formatted display showing repos scanned, PRs submitted/merged/closed/open with percentages, acceptance rate, avg time to merge, rejection reasons, and recent PRs with relative timestamps and close annotations.
- **CLI enhancement**: `ghla metrics campaign` now shows the full dashboard with recent PRs list. Both `--format text` and `--format json` output formats supported.

Example output:
```
Campaign Summary
========================================
Repos scanned:       12
PRs submitted:        8
PRs merged:           5  (62.5%)
PRs closed:           2  (25.0%)
PRs open:             1  (12.5%)
Acceptance rate:  62.5%
Avg time to merge: 2d

Recent PRs:
  pallets/flask #1234              MERGED   2d ago
  psf/requests #567                CLOSED   5d ago  (maintainer committed fix directly)
  fastapi/fastapi #89              OPEN     1d ago
```

## Test plan

- [x] 33 new tests covering all formatting functions
- [x] Full unit suite passes: 1240 tests, 0 failures
- [x] Lint clean (ruff check + ruff format)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)