### PR TITLE
fix: add startup banner, suppress Pydantic V1 warning (#91)

### DIFF
--- a/src/gh_link_auditor/cli/main.py
+++ b/src/gh_link_auditor/cli/main.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+import warnings
 
 from gh_link_auditor.cli.batch_cmd import build_batch_parser
 from gh_link_auditor.cli.metrics_cmd import build_metrics_parser
@@ -41,6 +42,9 @@ def main(argv: list[str] | None = None) -> int:
     Returns:
         Exit code.
     """
+    # Suppress Pydantic V1 compatibility warning from langchain-core on Python 3.14+
+    warnings.filterwarnings("ignore", message="Core Pydantic V1 functionality")
+
     from dotenv import load_dotenv
 
     load_dotenv()

--- a/src/gh_link_auditor/cli/run.py
+++ b/src/gh_link_auditor/cli/run.py
@@ -66,6 +66,11 @@ def cmd_run(args: argparse.Namespace) -> int:
     Returns:
         Exit code.
     """
+    mode = "dry-run" if args.dry_run else "live"
+    print(f"ghla: scanning {args.target} ({mode})")
+    print(f"      max-links={args.max_links}  max-cost=${args.max_cost:.2f}  confidence={args.confidence}")
+    print()
+
     state = create_initial_state(
         target=args.target,
         max_links=args.max_links,


### PR DESCRIPTION
## Summary

- Print target, mode, and config immediately on launch so the user gets instant feedback
- Suppress the `Core Pydantic V1 functionality` UserWarning from langchain-core on Python 3.14+

## Test plan

- [x] Lint clean
- [x] CLI tests pass (32 passed)

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)