### PR TITLE
feat: false positive knowledge store (#94)

### DIFF
--- a/src/gh_link_auditor/false_positives.py
+++ b/src/gh_link_auditor/false_positives.py
@@ -1,0 +1,94 @@
+"""False positive knowledge store.
+
+Filters out URLs that are known to produce false dead-link reports.
+Extensible: add new rules to SKIP_DOMAINS or BOT_BLOCKED_DOMAINS.
+
+See Issue #94 for specification.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+# Domains that are intentionally fake / placeholder — never real links.
+SKIP_DOMAINS: set[str] = {
+    "example.com",
+    "example.org",
+    "example.net",
+    "example.edu",
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+}
+
+# Domains that return 403 to bots but work fine in browsers.
+BOT_BLOCKED_DOMAINS: set[str] = {
+    "stackoverflow.com",
+    "stackexchange.com",
+    "security.stackexchange.com",
+    "serverfault.com",
+    "superuser.com",
+    "askubuntu.com",
+    "mathoverflow.net",
+}
+
+
+def is_placeholder_url(url: str) -> bool:
+    """Check if a URL uses a known placeholder/example domain.
+
+    These URLs are intentionally fake and should never be reported as dead.
+
+    Args:
+        url: URL to check.
+
+    Returns:
+        True if the URL is a placeholder.
+    """
+    hostname = (urlparse(url).hostname or "").lower()
+
+    for domain in SKIP_DOMAINS:
+        if hostname == domain or hostname.endswith(f".{domain}"):
+            return True
+
+    return False
+
+
+def is_bot_blocked(url: str, http_status: int | None) -> bool:
+    """Check if a URL failure is likely due to bot blocking, not a dead link.
+
+    Args:
+        url: The URL that was checked.
+        http_status: HTTP status code returned (e.g. 403).
+
+    Returns:
+        True if the failure is likely bot blocking.
+    """
+    if http_status != 403:
+        return False
+
+    hostname = (urlparse(url).hostname or "").lower()
+
+    for domain in BOT_BLOCKED_DOMAINS:
+        if hostname == domain or hostname.endswith(f".{domain}"):
+            return True
+
+    return False
+
+
+def is_false_positive(url: str, http_status: int | None = None) -> bool:
+    """Master check: is this URL a known false positive?
+
+    Args:
+        url: URL to check.
+        http_status: HTTP status code (optional, needed for bot-blocked check).
+
+    Returns:
+        True if the URL should be filtered out.
+    """
+    if is_placeholder_url(url):
+        return True
+
+    if http_status is not None and is_bot_blocked(url, http_status):
+        return True
+
+    return False

--- a/src/gh_link_auditor/pipeline/nodes/n1_scan.py
+++ b/src/gh_link_auditor/pipeline/nodes/n1_scan.py
@@ -13,6 +13,7 @@ import re
 import sys
 from pathlib import Path
 
+from gh_link_auditor.false_positives import is_bot_blocked, is_placeholder_url
 from gh_link_auditor.network import check_url as network_check_url
 from gh_link_auditor.pipeline.state import DeadLink, PipelineState
 
@@ -192,8 +193,14 @@ def run_link_scan(
                 continue
             seen_urls.add(url)
 
+            if is_placeholder_url(url):
+                continue
+
             result = _check_single_url(url)
             if _is_dead(result):
+                status_code = result.get("status_code")
+                if is_bot_blocked(url, status_code):
+                    continue
                 dead_links.append(
                     DeadLink(
                         url=url,

--- a/tests/unit/test_false_positives.py
+++ b/tests/unit/test_false_positives.py
@@ -1,0 +1,120 @@
+"""Tests for false positive knowledge store.
+
+See Issue #94 for specification.
+"""
+
+from __future__ import annotations
+
+from gh_link_auditor.false_positives import (
+    is_bot_blocked,
+    is_false_positive,
+    is_placeholder_url,
+)
+
+
+class TestIsPlaceholderUrl:
+    """Tests for is_placeholder_url()."""
+
+    def test_example_com(self) -> None:
+        assert is_placeholder_url("https://example.com/myapp/") is True
+
+    def test_example_org(self) -> None:
+        assert is_placeholder_url("http://example.org/page") is True
+
+    def test_example_net(self) -> None:
+        assert is_placeholder_url("https://example.net") is True
+
+    def test_example_edu(self) -> None:
+        assert is_placeholder_url("https://example.edu/course") is True
+
+    def test_subdomain_of_example(self) -> None:
+        assert is_placeholder_url("https://www.example.com/page") is True
+
+    def test_deep_subdomain(self) -> None:
+        assert is_placeholder_url("https://api.v2.example.com/data") is True
+
+    def test_localhost(self) -> None:
+        assert is_placeholder_url("http://localhost:8080/api") is True
+
+    def test_127_0_0_1(self) -> None:
+        assert is_placeholder_url("http://127.0.0.1/test") is True
+
+    def test_real_domain_not_placeholder(self) -> None:
+        assert is_placeholder_url("https://flask.palletsprojects.com/") is False
+
+    def test_github_not_placeholder(self) -> None:
+        assert is_placeholder_url("https://github.com/pallets/flask") is False
+
+    def test_empty_string(self) -> None:
+        assert is_placeholder_url("") is False
+
+    def test_not_a_url(self) -> None:
+        assert is_placeholder_url("not-a-url") is False
+
+    def test_domain_containing_example_but_not_matching(self) -> None:
+        assert is_placeholder_url("https://myexample.com/page") is False
+
+    def test_example_in_path_not_domain(self) -> None:
+        assert is_placeholder_url("https://docs.python.org/example") is False
+
+    def test_malformed_url(self) -> None:
+        assert is_placeholder_url("://broken") is False
+
+
+class TestIsBotBlocked:
+    """Tests for is_bot_blocked()."""
+
+    def test_stackoverflow_403(self) -> None:
+        assert is_bot_blocked("https://stackoverflow.com/q/12345", 403) is True
+
+    def test_stackexchange_403(self) -> None:
+        assert is_bot_blocked("https://security.stackexchange.com/q/39118", 403) is True
+
+    def test_serverfault_403(self) -> None:
+        assert is_bot_blocked("https://serverfault.com/q/100", 403) is True
+
+    def test_askubuntu_403(self) -> None:
+        assert is_bot_blocked("https://askubuntu.com/q/200", 403) is True
+
+    def test_stackoverflow_404_not_blocked(self) -> None:
+        assert is_bot_blocked("https://stackoverflow.com/q/12345", 404) is False
+
+    def test_stackoverflow_200_not_blocked(self) -> None:
+        assert is_bot_blocked("https://stackoverflow.com/q/12345", 200) is False
+
+    def test_unknown_domain_403(self) -> None:
+        assert is_bot_blocked("https://random-site.com/page", 403) is False
+
+    def test_github_403(self) -> None:
+        assert is_bot_blocked("https://github.com/repo", 403) is False
+
+    def test_none_status(self) -> None:
+        assert is_bot_blocked("https://stackoverflow.com/q/1", None) is False
+
+    def test_subdomain_match(self) -> None:
+        assert is_bot_blocked("https://meta.stackoverflow.com/q/1", 403) is True
+
+    def test_malformed_url(self) -> None:
+        assert is_bot_blocked("://broken", 403) is False
+
+
+class TestIsFalsePositive:
+    """Tests for is_false_positive() master check."""
+
+    def test_placeholder_is_false_positive(self) -> None:
+        assert is_false_positive("https://example.com/page") is True
+
+    def test_placeholder_without_status(self) -> None:
+        assert is_false_positive("https://example.com/page", http_status=None) is True
+
+    def test_bot_blocked_is_false_positive(self) -> None:
+        assert is_false_positive("https://stackoverflow.com/q/1", http_status=403) is True
+
+    def test_real_dead_link_not_false_positive(self) -> None:
+        assert is_false_positive("https://old-dead-site.com/page", http_status=404) is False
+
+    def test_real_site_403_not_false_positive(self) -> None:
+        assert is_false_positive("https://some-api.com/endpoint", http_status=403) is False
+
+    def test_bot_blocked_without_status_not_triggered(self) -> None:
+        assert is_false_positive("https://stackoverflow.com/q/1") is False


### PR DESCRIPTION
## Summary

- **Placeholder URLs** (`example.com`, `example.org`, `localhost`, etc.) skipped before the network check — no wasted requests
- **Bot-blocked domains** (StackExchange family returning 403) filtered after check — these work fine in browsers
- Wired into `run_link_scan()` in N1: placeholders skipped pre-check, bot-blocked filtered post-check

Discovered during live run on `pallets/flask` — all 3 "dead links" were false positives.

## Test plan

- [x] 32 new tests, 100% coverage on `false_positives.py`
- [x] Full unit suite: 1270 passed
- [x] Lint clean

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)