### PR TITLE
fix: trailing quote parser bug + expanded false positive rules (#96) (#97)

### DIFF
--- a/src/gh_link_auditor/false_positives.py
+++ b/src/gh_link_auditor/false_positives.py
@@ -1,13 +1,14 @@
 """False positive knowledge store.
 
 Filters out URLs that are known to produce false dead-link reports.
-Extensible: add new rules to SKIP_DOMAINS or BOT_BLOCKED_DOMAINS.
+Extensible: add new rules to the domain sets or pattern lists.
 
-See Issue #94 for specification.
+See Issues #94, #97 for specification.
 """
 
 from __future__ import annotations
 
+import re
 from urllib.parse import urlparse
 
 # Domains that are intentionally fake / placeholder — never real links.
@@ -31,6 +32,24 @@ BOT_BLOCKED_DOMAINS: set[str] = {
     "askubuntu.com",
     "mathoverflow.net",
 }
+
+# Domains where non-200 responses are by design (API test services).
+API_TEST_DOMAINS: set[str] = {
+    "httpbin.org",
+    "httpbin.com",
+}
+
+# Placeholder path segments that indicate template/example URLs.
+_PLACEHOLDER_PATH_RE = re.compile(
+    r"(YOUR[_-]USERNAME|YOUR[_-]ORG|YOUR[_-]REPO|YOUR[_-]TOKEN"
+    r"|USERNAME|OWNER|ORG_NAME|REPO_NAME)",
+    re.IGNORECASE,
+)
+
+# GitHub issue/PR URL pattern.
+_GITHUB_ISSUE_RE = re.compile(
+    r"https?://github\.com/[^/]+/[^/]+/(issues|pull)/\d+",
+)
 
 
 def is_placeholder_url(url: str) -> bool:
@@ -75,12 +94,68 @@ def is_bot_blocked(url: str, http_status: int | None) -> bool:
     return False
 
 
+def is_api_test_endpoint(url: str) -> bool:
+    """Check if a URL is an API test service endpoint.
+
+    Sites like httpbin.org return non-200 by design — auth endpoints
+    return 401, method-specific endpoints return 405, etc.
+
+    Args:
+        url: URL to check.
+
+    Returns:
+        True if the URL is a known API test endpoint.
+    """
+    hostname = (urlparse(url).hostname or "").lower()
+
+    for domain in API_TEST_DOMAINS:
+        if hostname == domain or hostname.endswith(f".{domain}"):
+            return True
+
+    return False
+
+
+def is_placeholder_path(url: str) -> bool:
+    """Check if a URL contains placeholder path segments.
+
+    Template URLs like https://github.com/YOUR-USERNAME/repo are
+    examples in documentation, not real links.
+
+    Args:
+        url: URL to check.
+
+    Returns:
+        True if the URL contains placeholder segments.
+    """
+    path = urlparse(url).path
+    return bool(_PLACEHOLDER_PATH_RE.search(path))
+
+
+def is_github_issue_404(url: str, http_status: int | None) -> bool:
+    """Check if a GitHub issue/PR URL returning 404 is likely private or transferred.
+
+    GitHub returns 404 for private, transferred, or deleted issues.
+    These are not dead links — the content exists but is access-controlled.
+
+    Args:
+        url: URL to check.
+        http_status: HTTP status code.
+
+    Returns:
+        True if this is a GitHub issue/PR 404.
+    """
+    if http_status != 404:
+        return False
+
+    return bool(_GITHUB_ISSUE_RE.match(url))
+
+
 def is_false_positive(url: str, http_status: int | None = None) -> bool:
     """Master check: is this URL a known false positive?
 
     Args:
         url: URL to check.
-        http_status: HTTP status code (optional, needed for bot-blocked check).
+        http_status: HTTP status code (optional, needed for status-based checks).
 
     Returns:
         True if the URL should be filtered out.
@@ -88,7 +163,16 @@ def is_false_positive(url: str, http_status: int | None = None) -> bool:
     if is_placeholder_url(url):
         return True
 
-    if http_status is not None and is_bot_blocked(url, http_status):
+    if is_placeholder_path(url):
         return True
+
+    if is_api_test_endpoint(url):
+        return True
+
+    if http_status is not None:
+        if is_bot_blocked(url, http_status):
+            return True
+        if is_github_issue_404(url, http_status):
+            return True
 
     return False

--- a/src/gh_link_auditor/pipeline/nodes/n1_scan.py
+++ b/src/gh_link_auditor/pipeline/nodes/n1_scan.py
@@ -13,7 +13,7 @@ import re
 import sys
 from pathlib import Path
 
-from gh_link_auditor.false_positives import is_bot_blocked, is_placeholder_url
+from gh_link_auditor.false_positives import is_api_test_endpoint, is_false_positive, is_placeholder_url
 from gh_link_auditor.network import check_url as network_check_url
 from gh_link_auditor.pipeline.state import DeadLink, PipelineState
 
@@ -85,7 +85,7 @@ def _extract_urls_from_file(
 
     for line_num, line in enumerate(text.splitlines(), start=1):
         for match in _URL_RE.finditer(line):
-            url = match.group(0).rstrip(".,;:!?)")
+            url = match.group(0).rstrip(".,;:!?)'\"`")
             results.append((url, line_num, url))
 
     return results
@@ -193,13 +193,14 @@ def run_link_scan(
                 continue
             seen_urls.add(url)
 
-            if is_placeholder_url(url):
+            # Pre-check: skip URLs that are false positives without status
+            if is_placeholder_url(url) or is_api_test_endpoint(url):
                 continue
 
             result = _check_single_url(url)
             if _is_dead(result):
                 status_code = result.get("status_code")
-                if is_bot_blocked(url, status_code):
+                if is_false_positive(url, status_code):
                     continue
                 dead_links.append(
                     DeadLink(

--- a/tests/unit/test_false_positives.py
+++ b/tests/unit/test_false_positives.py
@@ -1,13 +1,16 @@
 """Tests for false positive knowledge store.
 
-See Issue #94 for specification.
+See Issues #94, #97 for specification.
 """
 
 from __future__ import annotations
 
 from gh_link_auditor.false_positives import (
+    is_api_test_endpoint,
     is_bot_blocked,
     is_false_positive,
+    is_github_issue_404,
+    is_placeholder_path,
     is_placeholder_url,
 )
 
@@ -98,23 +101,115 @@ class TestIsBotBlocked:
         assert is_bot_blocked("://broken", 403) is False
 
 
+class TestIsApiTestEndpoint:
+    """Tests for is_api_test_endpoint()."""
+
+    def test_httpbin_org(self) -> None:
+        assert is_api_test_endpoint("https://httpbin.org/get") is True
+
+    def test_httpbin_org_auth(self) -> None:
+        assert is_api_test_endpoint("https://httpbin.org/basic-auth/user/pass") is True
+
+    def test_httpbin_org_status(self) -> None:
+        assert is_api_test_endpoint("https://httpbin.org/status/404") is True
+
+    def test_httpbin_com(self) -> None:
+        assert is_api_test_endpoint("https://httpbin.com/get") is True
+
+    def test_real_api_not_test(self) -> None:
+        assert is_api_test_endpoint("https://api.github.com/events") is False
+
+    def test_empty(self) -> None:
+        assert is_api_test_endpoint("") is False
+
+
+class TestIsPlaceholderPath:
+    """Tests for is_placeholder_path()."""
+
+    def test_your_username(self) -> None:
+        assert is_placeholder_path("https://github.com/YOUR-USERNAME/httpx") is True
+
+    def test_your_username_underscore(self) -> None:
+        assert is_placeholder_path("https://github.com/YOUR_USERNAME/repo") is True
+
+    def test_your_org(self) -> None:
+        assert is_placeholder_path("https://github.com/YOUR-ORG/repo") is True
+
+    def test_your_repo(self) -> None:
+        assert is_placeholder_path("https://example.com/YOUR-REPO/path") is True
+
+    def test_your_token(self) -> None:
+        assert is_placeholder_path("https://api.example.com/YOUR-TOKEN/data") is True
+
+    def test_username_placeholder(self) -> None:
+        assert is_placeholder_path("https://github.com/USERNAME/repo") is True
+
+    def test_owner_placeholder(self) -> None:
+        assert is_placeholder_path("https://github.com/OWNER/repo") is True
+
+    def test_case_insensitive(self) -> None:
+        assert is_placeholder_path("https://github.com/your-username/repo") is True
+
+    def test_real_username_not_placeholder(self) -> None:
+        assert is_placeholder_path("https://github.com/pallets/flask") is False
+
+    def test_real_path(self) -> None:
+        assert is_placeholder_path("https://docs.python.org/3/library/") is False
+
+
+class TestIsGithubIssue404:
+    """Tests for is_github_issue_404()."""
+
+    def test_issue_404(self) -> None:
+        assert is_github_issue_404("https://github.com/encode/httpx/issues/1434", 404) is True
+
+    def test_pr_404(self) -> None:
+        assert is_github_issue_404("https://github.com/org/repo/pull/123", 404) is True
+
+    def test_issue_200(self) -> None:
+        assert is_github_issue_404("https://github.com/encode/httpx/issues/1", 200) is False
+
+    def test_issue_403(self) -> None:
+        assert is_github_issue_404("https://github.com/encode/httpx/issues/1", 403) is False
+
+    def test_not_github(self) -> None:
+        assert is_github_issue_404("https://gitlab.com/org/repo/issues/1", 404) is False
+
+    def test_github_repo_404(self) -> None:
+        # Repo-level 404 is NOT an issue/PR — could be genuinely deleted
+        assert is_github_issue_404("https://github.com/org/deleted-repo", 404) is False
+
+    def test_none_status(self) -> None:
+        assert is_github_issue_404("https://github.com/org/repo/issues/1", None) is False
+
+
 class TestIsFalsePositive:
     """Tests for is_false_positive() master check."""
 
-    def test_placeholder_is_false_positive(self) -> None:
+    def test_placeholder_domain(self) -> None:
         assert is_false_positive("https://example.com/page") is True
 
-    def test_placeholder_without_status(self) -> None:
-        assert is_false_positive("https://example.com/page", http_status=None) is True
+    def test_placeholder_path(self) -> None:
+        assert is_false_positive("https://github.com/YOUR-USERNAME/repo") is True
 
-    def test_bot_blocked_is_false_positive(self) -> None:
+    def test_api_test_endpoint(self) -> None:
+        assert is_false_positive("https://httpbin.org/get") is True
+
+    def test_bot_blocked(self) -> None:
         assert is_false_positive("https://stackoverflow.com/q/1", http_status=403) is True
 
-    def test_real_dead_link_not_false_positive(self) -> None:
+    def test_github_issue_404(self) -> None:
+        assert is_false_positive("https://github.com/org/repo/issues/999", http_status=404) is True
+
+    def test_real_dead_link(self) -> None:
         assert is_false_positive("https://old-dead-site.com/page", http_status=404) is False
 
-    def test_real_site_403_not_false_positive(self) -> None:
+    def test_real_site_403(self) -> None:
         assert is_false_positive("https://some-api.com/endpoint", http_status=403) is False
 
-    def test_bot_blocked_without_status_not_triggered(self) -> None:
+    def test_bot_blocked_without_status(self) -> None:
         assert is_false_positive("https://stackoverflow.com/q/1") is False
+
+    def test_github_repo_404_not_filtered(self) -> None:
+        # Deleted repos ARE real dead links
+        assert is_false_positive("https://github.com/org/deleted-repo", http_status=404) is False


### PR DESCRIPTION
## Summary

- **URL parser fix (#96)**: Strip trailing `'`, `"`, backtick from extracted URLs. These were being included as part of the URL from markdown/rst code blocks, causing ~15 false positives in encode/httpx scan alone.
- **Expanded false positive rules (#97)**:
  - `httpbin.org/com` endpoints skipped pre-check (API test service, non-200 by design)
  - GitHub issue/PR URLs returning 404 filtered (private/transferred, not dead)
  - Placeholder path segments (`YOUR-USERNAME`, `OWNER`, `REPO_NAME`, etc.) filtered
- N1 scan now uses unified `is_false_positive()` for all post-check filtering

## Test plan

- [x] 58 tests on false_positives.py, 100% coverage
- [x] Full unit suite: 1298 passed
- [x] Lint clean

Closes #96
Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)