### PR TITLE
fix: HITL prompt adds skip/exit options, Ctrl+C aborts (#101)

### DIFF
--- a/src/gh_link_auditor/pipeline/nodes/n4_human_review.py
+++ b/src/gh_link_auditor/pipeline/nodes/n4_human_review.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 
 from gh_link_auditor.pipeline.state import PipelineState, Verdict
 
+# Sentinel to signal "exit review, reject all remaining"
+_EXIT = "exit"
+_SKIP = "skip"
+
 
 def format_verdict_for_review(verdict: Verdict) -> str:
     """Format a verdict for terminal display.
@@ -44,21 +48,28 @@ def format_verdict_for_review(verdict: Verdict) -> str:
     return "\n".join(lines)
 
 
-def prompt_user_approval(verdict: Verdict) -> bool:
-    """Interactive prompt for user to approve/reject a verdict.
+def prompt_user_approval(verdict: Verdict) -> bool | str:
+    """Interactive prompt for user to approve/reject/skip/exit.
 
     Args:
         verdict: Verdict to review.
 
     Returns:
-        True if approved, False if rejected.
-    """
-    try:
-        response = input("Approve this replacement? [y]es / [n]o: ").strip().lower()
-    except (EOFError, KeyboardInterrupt):
-        return False
+        True if approved, False if rejected, "skip" to skip, "exit" to abort.
 
-    return response in ("y", "yes")
+    Raises:
+        KeyboardInterrupt: If user presses Ctrl+C (aborts pipeline).
+    """
+    response = input("[y]es / [n]o / [s]kip / e[x]it: ").strip().lower()
+
+    if response in ("y", "yes"):
+        return True
+    if response in ("s", "skip"):
+        return _SKIP
+    if response in ("x", "exit", "q", "quit"):
+        return _EXIT
+
+    return False
 
 
 def n4_human_review(state: PipelineState) -> PipelineState:
@@ -78,6 +89,7 @@ def n4_human_review(state: PipelineState) -> PipelineState:
     dry_run = state.get("dry_run", False)
 
     reviewed: list[Verdict] = []
+    exit_review = False
 
     for verdict in verdicts:
         confidence = verdict.get("confidence", 0)
@@ -87,13 +99,29 @@ def n4_human_review(state: PipelineState) -> PipelineState:
             updated = dict(verdict)
             updated["approved"] = True
             reviewed.append(updated)  # type: ignore[arg-type]
+        elif exit_review:
+            # User chose exit — reject all remaining
+            updated = dict(verdict)
+            updated["approved"] = False
+            reviewed.append(updated)  # type: ignore[arg-type]
         else:
             # Present to user for review
             print(format_verdict_for_review(verdict))
-            approved = prompt_user_approval(verdict)
-            updated = dict(verdict)
-            updated["approved"] = approved
-            reviewed.append(updated)  # type: ignore[arg-type]
+            result = prompt_user_approval(verdict)
+
+            if result is _EXIT:
+                exit_review = True
+                updated = dict(verdict)
+                updated["approved"] = False
+                reviewed.append(updated)  # type: ignore[arg-type]
+            elif result is _SKIP:
+                updated = dict(verdict)
+                updated["approved"] = False
+                reviewed.append(updated)  # type: ignore[arg-type]
+            else:
+                updated = dict(verdict)
+                updated["approved"] = bool(result)
+                reviewed.append(updated)  # type: ignore[arg-type]
 
     state["reviewed_verdicts"] = reviewed
     return state

--- a/tests/unit/pipeline/test_n4.py
+++ b/tests/unit/pipeline/test_n4.py
@@ -1,6 +1,7 @@
 """Tests for N4 Human Review node.
 
 See LLD #22 §10.0 T140/T150/T240/T250: HITL routing and input.
+Updated in Issue #101 for exit/skip options.
 """
 
 from __future__ import annotations
@@ -8,6 +9,8 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from gh_link_auditor.pipeline.nodes.n4_human_review import (
+    _EXIT,
+    _SKIP,
     format_verdict_for_review,
     n4_human_review,
     prompt_user_approval,
@@ -113,11 +116,45 @@ class TestPromptUserApproval:
             result = prompt_user_approval(verdict)
         assert result is False
 
-    def test_handles_eof(self) -> None:
+    def test_skip_with_s(self) -> None:
         verdict = _make_verdict()
-        with patch("builtins.input", side_effect=EOFError):
+        with patch("builtins.input", return_value="s"):
             result = prompt_user_approval(verdict)
-        assert result is False
+        assert result is _SKIP
+
+    def test_skip_with_skip(self) -> None:
+        verdict = _make_verdict()
+        with patch("builtins.input", return_value="skip"):
+            result = prompt_user_approval(verdict)
+        assert result is _SKIP
+
+    def test_exit_with_x(self) -> None:
+        verdict = _make_verdict()
+        with patch("builtins.input", return_value="x"):
+            result = prompt_user_approval(verdict)
+        assert result is _EXIT
+
+    def test_exit_with_exit(self) -> None:
+        verdict = _make_verdict()
+        with patch("builtins.input", return_value="exit"):
+            result = prompt_user_approval(verdict)
+        assert result is _EXIT
+
+    def test_exit_with_q(self) -> None:
+        verdict = _make_verdict()
+        with patch("builtins.input", return_value="q"):
+            result = prompt_user_approval(verdict)
+        assert result is _EXIT
+
+    def test_ctrl_c_propagates(self) -> None:
+        """Ctrl+C should propagate as KeyboardInterrupt to abort pipeline."""
+        verdict = _make_verdict()
+        with patch("builtins.input", side_effect=KeyboardInterrupt):
+            try:
+                prompt_user_approval(verdict)
+                assert False, "Should have raised KeyboardInterrupt"
+            except KeyboardInterrupt:
+                pass  # Expected
 
 
 class TestN4HumanReview:
@@ -153,10 +190,8 @@ class TestN4HumanReview:
         ):
             result = n4_human_review(state)
         assert len(result["reviewed_verdicts"]) == 2
-        # High confidence auto-approved
         high = [v for v in result["reviewed_verdicts"] if v["dead_link"]["url"] == "https://a.com"]
         assert high[0]["approved"] is True
-        # Low confidence rejected
         low = [v for v in result["reviewed_verdicts"] if v["dead_link"]["url"] == "https://b.com"]
         assert low[0]["approved"] is False
 
@@ -164,7 +199,6 @@ class TestN4HumanReview:
         state = create_initial_state(target="t", dry_run=True)
         state["verdicts"] = [_make_verdict(confidence=0.5)]
         result = n4_human_review(state)
-        # In dry run, reviewed_verdicts should equal verdicts (no review)
         assert len(result["reviewed_verdicts"]) == len(state["verdicts"])
 
     def test_empty_verdicts(self) -> None:
@@ -172,3 +206,57 @@ class TestN4HumanReview:
         state["verdicts"] = []
         result = n4_human_review(state)
         assert result["reviewed_verdicts"] == []
+
+    def test_exit_rejects_remaining(self) -> None:
+        """Exit should reject current and all remaining verdicts."""
+        state = create_initial_state(target="t", confidence_threshold=0.8)
+        state["verdicts"] = [
+            _make_verdict(confidence=0.3, url="https://a.com"),
+            _make_verdict(confidence=0.3, url="https://b.com"),
+            _make_verdict(confidence=0.3, url="https://c.com"),
+        ]
+        with patch(
+            "gh_link_auditor.pipeline.nodes.n4_human_review.prompt_user_approval",
+            return_value=_EXIT,
+        ):
+            result = n4_human_review(state)
+        assert len(result["reviewed_verdicts"]) == 3
+        assert all(v["approved"] is False for v in result["reviewed_verdicts"])
+
+    def test_skip_rejects_one(self) -> None:
+        """Skip should reject one verdict, continue to next."""
+        state = create_initial_state(target="t", confidence_threshold=0.8)
+        state["verdicts"] = [
+            _make_verdict(confidence=0.3, url="https://a.com"),
+            _make_verdict(confidence=0.3, url="https://b.com"),
+        ]
+        # First call: skip, second call: approve
+        with patch(
+            "gh_link_auditor.pipeline.nodes.n4_human_review.prompt_user_approval",
+            side_effect=[_SKIP, True],
+        ):
+            result = n4_human_review(state)
+        a = [v for v in result["reviewed_verdicts"] if v["dead_link"]["url"] == "https://a.com"]
+        b = [v for v in result["reviewed_verdicts"] if v["dead_link"]["url"] == "https://b.com"]
+        assert a[0]["approved"] is False
+        assert b[0]["approved"] is True
+
+    def test_exit_after_approve_preserves_earlier(self) -> None:
+        """Approve first, exit second — first stays approved."""
+        state = create_initial_state(target="t", confidence_threshold=0.8)
+        state["verdicts"] = [
+            _make_verdict(confidence=0.3, url="https://a.com"),
+            _make_verdict(confidence=0.3, url="https://b.com"),
+            _make_verdict(confidence=0.3, url="https://c.com"),
+        ]
+        with patch(
+            "gh_link_auditor.pipeline.nodes.n4_human_review.prompt_user_approval",
+            side_effect=[True, _EXIT],
+        ):
+            result = n4_human_review(state)
+        a = [v for v in result["reviewed_verdicts"] if v["dead_link"]["url"] == "https://a.com"]
+        b = [v for v in result["reviewed_verdicts"] if v["dead_link"]["url"] == "https://b.com"]
+        c = [v for v in result["reviewed_verdicts"] if v["dead_link"]["url"] == "https://c.com"]
+        assert a[0]["approved"] is True
+        assert b[0]["approved"] is False
+        assert c[0]["approved"] is False


### PR DESCRIPTION
## Summary

- **[s]kip**: reject current verdict, continue reviewing next
- **e[x]it / [q]uit**: reject current and all remaining verdicts
- **Ctrl+C**: propagates KeyboardInterrupt to abort the entire pipeline
- Prompt now shows: `[y]es / [n]o / [s]kip / e[x]it`

Previously Ctrl+C silently rejected the current verdict but kept looping — user couldn't bail out.

## Test plan

- [x] 24 tests (up from 16)
- [x] Full unit suite: 1306 passed
- [x] Lint clean

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)