### PR TITLE
fix: filter GitHub auth URLs + kill trivial url_mutations (#105) (#107)

### DIFF
--- a/src/gh_link_auditor/false_positives.py
+++ b/src/gh_link_auditor/false_positives.py
@@ -51,6 +51,13 @@ _GITHUB_ISSUE_RE = re.compile(
     r"https?://github\.com/[^/]+/[^/]+/(issues|pull)/\d+",
 )
 
+# GitHub paths that require authentication (return 404 when not logged in).
+_GITHUB_AUTH_PATHS = re.compile(
+    r"https?://github\.com/[^/]+/[^/]+/"
+    r"(issues/new|compare|settings|releases/new|invitations"
+    r"|new|edit|delete|import|transfer)",
+)
+
 
 def is_placeholder_url(url: str) -> bool:
     """Check if a URL uses a known placeholder/example domain.
@@ -150,6 +157,25 @@ def is_github_issue_404(url: str, http_status: int | None) -> bool:
     return bool(_GITHUB_ISSUE_RE.match(url))
 
 
+def is_github_auth_required(url: str, http_status: int | None) -> bool:
+    """Check if a GitHub URL requires authentication.
+
+    URLs like /issues/new, /compare, /settings return 404 when not logged in
+    but are valid authenticated endpoints.
+
+    Args:
+        url: URL to check.
+        http_status: HTTP status code.
+
+    Returns:
+        True if this is a GitHub auth-required URL.
+    """
+    if http_status != 404:
+        return False
+
+    return bool(_GITHUB_AUTH_PATHS.match(url))
+
+
 def is_false_positive(url: str, http_status: int | None = None) -> bool:
     """Master check: is this URL a known false positive?
 
@@ -173,6 +199,8 @@ def is_false_positive(url: str, http_status: int | None = None) -> bool:
         if is_bot_blocked(url, http_status):
             return True
         if is_github_issue_404(url, http_status):
+            return True
+        if is_github_auth_required(url, http_status):
             return True
 
     return False

--- a/src/gh_link_auditor/link_detective.py
+++ b/src/gh_link_auditor/link_detective.py
@@ -185,10 +185,14 @@ class LinkDetective:
         except SSRFBlocked as e:
             log.append(f"SSRF blocked: {e}")
 
-        # 5. URL MUTATIONS
+        # 5. URL MUTATIONS (excluding trivial www/slash changes)
+        _trivial_mutations = {"add_www", "remove_www", "add_trailing_slash", "remove_trailing_slash"}
         try:
             mutations = self._redirect_resolver.test_url_mutations(dead_url)
             for live_url, mutation_type in mutations:
+                if mutation_type in _trivial_mutations:
+                    log.append(f"URL mutation skipped (trivial): {mutation_type} -> {live_url}")
+                    continue
                 candidates.append(
                     CandidateReplacement(
                         url=live_url,

--- a/tests/unit/test_false_positives.py
+++ b/tests/unit/test_false_positives.py
@@ -9,6 +9,7 @@ from gh_link_auditor.false_positives import (
     is_api_test_endpoint,
     is_bot_blocked,
     is_false_positive,
+    is_github_auth_required,
     is_github_issue_404,
     is_placeholder_path,
     is_placeholder_url,
@@ -183,6 +184,32 @@ class TestIsGithubIssue404:
         assert is_github_issue_404("https://github.com/org/repo/issues/1", None) is False
 
 
+class TestIsGithubAuthRequired:
+    """Tests for is_github_auth_required()."""
+
+    def test_issues_new(self) -> None:
+        assert is_github_auth_required("https://github.com/encode/httpx/issues/new", 404) is True
+
+    def test_compare(self) -> None:
+        assert is_github_auth_required("https://github.com/org/repo/compare", 404) is True
+
+    def test_settings(self) -> None:
+        assert is_github_auth_required("https://github.com/org/repo/settings", 404) is True
+
+    def test_releases_new(self) -> None:
+        assert is_github_auth_required("https://github.com/org/repo/releases/new", 404) is True
+
+    def test_not_404(self) -> None:
+        assert is_github_auth_required("https://github.com/org/repo/issues/new", 200) is False
+
+    def test_regular_issue_not_auth(self) -> None:
+        # Regular issue paths are handled by is_github_issue_404, not this
+        assert is_github_auth_required("https://github.com/org/repo/issues/123", 404) is False
+
+    def test_non_github(self) -> None:
+        assert is_github_auth_required("https://gitlab.com/org/repo/issues/new", 404) is False
+
+
 class TestIsFalsePositive:
     """Tests for is_false_positive() master check."""
 
@@ -209,6 +236,9 @@ class TestIsFalsePositive:
 
     def test_bot_blocked_without_status(self) -> None:
         assert is_false_positive("https://stackoverflow.com/q/1") is False
+
+    def test_github_auth_required(self) -> None:
+        assert is_false_positive("https://github.com/org/repo/issues/new", http_status=404) is True
 
     def test_github_repo_404_not_filtered(self) -> None:
         # Deleted repos ARE real dead links


### PR DESCRIPTION
## Summary

- **#105**: GitHub auth-required paths (`/issues/new`, `/compare`, `/settings`, `/releases/new`) returning 404 are now filtered as false positives — these work fine when logged in.
- **#107**: `url_mutation` no longer suggests `www.` prefix or trailing slash changes. These trivial mutations were the biggest source of garbage suggestions (15+ per scan). Only meaningful mutations like `http→https` remain.

## Test plan

- [x] 8 new tests for auth-required URLs
- [x] Full unit suite: 1314 passed
- [x] Lint clean

Closes #105
Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)