### PR TITLE
feat: sitemap-based same-site page discovery (#106)

### DIFF
--- a/src/gh_link_auditor/link_detective.py
+++ b/src/gh_link_auditor/link_detective.py
@@ -19,6 +19,7 @@ from gh_link_auditor.archive_client import ArchiveClient
 from gh_link_auditor.github_resolver import GitHubResolver
 from gh_link_auditor.redirect_resolver import RedirectResolver, SSRFBlocked
 from gh_link_auditor.similarity import compute_similarity
+from gh_link_auditor.sitemap_searcher import fetch_sitemap, search_sitemap_for_match
 from gh_link_auditor.url_heuristic import URLHeuristic
 from src.logging_config import setup_logging
 
@@ -36,6 +37,7 @@ class InvestigationMethod(Enum):
     REDIRECT_CHAIN = "redirect_chain"
     URL_MUTATION = "url_mutation"
     URL_HEURISTIC = "url_heuristic"
+    SITEMAP_SEARCH = "sitemap_search"
     GITHUB_API_REDIRECT = "github_api_redirect"
     ARCHIVE_ONLY = "archive_only"
 
@@ -221,10 +223,42 @@ class LinkDetective:
         except Exception as e:
             log.append(f"Archive lookup failed: {e}")
 
-        # 7. URL PATTERN HEURISTICS (requires archive title)
+        # 7. SITEMAP SEARCH (same-site page discovery)
+        domain = parsed.hostname or ""
+        if domain and archive_title:
+            try:
+                sitemap_urls = fetch_sitemap(domain)
+                if sitemap_urls:
+                    log.append(f"Sitemap found: {len(sitemap_urls)} URLs")
+                    matches = search_sitemap_for_match(sitemap_urls, parsed.path, archive_title)
+                    for match_url in matches:
+                        if self._redirect_resolver.verify_live(match_url):
+                            if archive_summary:
+                                page_content = _fetch_page_content(match_url)
+                                if page_content:
+                                    score = compute_similarity(archive_summary, page_content)
+                                else:
+                                    score = 0.5
+                            else:
+                                score = 0.5
+
+                            candidates.append(
+                                CandidateReplacement(
+                                    url=match_url,
+                                    method=InvestigationMethod.SITEMAP_SEARCH,
+                                    similarity_score=score,
+                                    verified_live=True,
+                                )
+                            )
+                            log.append(f"Sitemap match: {match_url} (score={score:.2f})")
+                else:
+                    log.append("No sitemap found")
+            except Exception as e:
+                log.append(f"Sitemap search failed: {e}")
+
+        # 8. URL PATTERN HEURISTICS (requires archive title)
         if archive_title:
             try:
-                domain = parsed.hostname or ""
                 original_path = parsed.path
                 candidate_urls = self._url_heuristic.generate_candidates(domain, archive_title, original_path)
                 live_urls = self._url_heuristic.probe_candidates(candidate_urls, max_results=3)
@@ -252,7 +286,7 @@ class LinkDetective:
             except Exception as e:
                 log.append(f"URL heuristic check failed: {e}")
 
-        # 8. GITHUB-SPECIFIC RESOLUTION
+        # 9. GITHUB-SPECIFIC RESOLUTION
         if self._github_resolver.is_github_url(dead_url):
             try:
                 owner, repo, file_path = self._github_resolver._parse_github_url(dead_url)
@@ -272,7 +306,7 @@ class LinkDetective:
             except Exception as e:
                 log.append(f"GitHub resolution failed: {e}")
 
-        # 9. Archive-only fallback
+        # 10. Archive-only fallback
         if archive_snapshot and not any(c.verified_live for c in candidates):
             candidates.append(
                 CandidateReplacement(
@@ -284,10 +318,10 @@ class LinkDetective:
             )
             log.append(f"Archive-only fallback: {archive_snapshot}")
 
-        # 10. Sort candidates by similarity_score descending
+        # 11. Sort candidates by similarity_score descending
         candidates.sort(key=lambda c: c.similarity_score, reverse=True)
 
-        # 11. Build report
+        # 12. Build report
         report = ForensicReport(
             dead_url=dead_url,
             http_status=http_status,
@@ -300,7 +334,7 @@ class LinkDetective:
             ),
         )
 
-        # 12. Cache result
+        # 13. Cache result
         self._cache_result(report)
 
         return report

--- a/src/gh_link_auditor/sitemap_searcher.py
+++ b/src/gh_link_auditor/sitemap_searcher.py
@@ -1,0 +1,187 @@
+"""Sitemap-based same-site page discovery.
+
+When a page 404s but the domain is alive, searches the site's sitemap.xml
+for pages that likely match the archived content.
+
+See Issue #106 for specification.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import urllib.error
+import urllib.request
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_sitemap(domain: str) -> list[str]:
+    """Fetch and parse sitemap.xml from a domain.
+
+    Tries common sitemap locations: /sitemap.xml, /sitemap_index.xml.
+
+    Args:
+        domain: Domain to fetch sitemap from (e.g. "www.python-httpx.org").
+
+    Returns:
+        List of URLs found in the sitemap.
+    """
+    sitemap_paths = ["/sitemap.xml", "/sitemap_index.xml"]
+    urls: list[str] = []
+
+    for path in sitemap_paths:
+        sitemap_url = f"https://{domain}{path}"
+        content = _fetch_url(sitemap_url)
+        if content is None:
+            continue
+
+        # Check if this is a sitemap index (contains other sitemaps)
+        if "<sitemapindex" in content:
+            child_urls = _extract_sitemap_urls(content)
+            for child_url in child_urls:
+                child_content = _fetch_url(child_url)
+                if child_content:
+                    urls.extend(_extract_loc_urls(child_content))
+        else:
+            urls.extend(_extract_loc_urls(content))
+
+        if urls:
+            break
+
+    return urls
+
+
+def search_sitemap_for_match(
+    sitemap_urls: list[str],
+    original_path: str,
+    archive_title: str | None = None,
+    max_candidates: int = 5,
+) -> list[str]:
+    """Search sitemap URLs for pages that likely match the dead page.
+
+    Scoring is based on:
+    - Shared path segments with the original URL
+    - Slug similarity to the archive title
+    - Path depth similarity
+
+    Args:
+        sitemap_urls: URLs from the sitemap.
+        original_path: Original dead URL path (e.g. "/advanced/").
+        archive_title: Title from archive.org snapshot.
+        max_candidates: Maximum candidates to return.
+
+    Returns:
+        List of candidate URLs, best matches first.
+    """
+    if not sitemap_urls:
+        return []
+
+    original_segments = _path_segments(original_path)
+    title_slug = _slugify(archive_title) if archive_title else ""
+
+    scored: list[tuple[float, str]] = []
+
+    for url in sitemap_urls:
+        parsed = urlparse(url)
+        candidate_path = parsed.path
+        candidate_segments = _path_segments(candidate_path)
+
+        score = 0.0
+
+        # Shared path segments (strongest signal)
+        shared = set(original_segments) & set(candidate_segments)
+        if original_segments:
+            score += len(shared) / len(original_segments) * 0.5
+
+        # Title slug appears in candidate path
+        if title_slug and title_slug in candidate_path.lower():
+            score += 0.3
+
+        # Partial slug match (individual words from title)
+        if title_slug:
+            title_words = set(title_slug.split("-"))
+            path_lower = candidate_path.lower()
+            matching_words = sum(1 for w in title_words if w in path_lower and len(w) > 2)
+            if title_words:
+                score += (matching_words / len(title_words)) * 0.2
+
+        # Skip exact original path (it's the dead one)
+        if candidate_path.rstrip("/") == original_path.rstrip("/"):
+            continue
+
+        if score > 0:
+            scored.append((score, url))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [url for _, url in scored[:max_candidates]]
+
+
+def _fetch_url(url: str) -> str | None:
+    """Fetch URL content as string.
+
+    Args:
+        url: URL to fetch.
+
+    Returns:
+        Content string, or None on failure.
+    """
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "gh-link-auditor/1.0"})
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            return resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, OSError, TimeoutError):
+        return None
+
+
+def _extract_loc_urls(xml_content: str) -> list[str]:
+    """Extract <loc> URLs from sitemap XML.
+
+    Args:
+        xml_content: Sitemap XML string.
+
+    Returns:
+        List of URLs found in <loc> tags.
+    """
+    return re.findall(r"<loc>(.*?)</loc>", xml_content)
+
+
+def _extract_sitemap_urls(xml_content: str) -> list[str]:
+    """Extract child sitemap URLs from a sitemap index.
+
+    Args:
+        xml_content: Sitemap index XML string.
+
+    Returns:
+        List of child sitemap URLs.
+    """
+    return re.findall(r"<loc>(.*?)</loc>", xml_content)
+
+
+def _path_segments(path: str) -> list[str]:
+    """Split a URL path into non-empty segments.
+
+    Args:
+        path: URL path (e.g. "/docs/advanced/usage").
+
+    Returns:
+        List of path segments (e.g. ["docs", "advanced", "usage"]).
+    """
+    return [s for s in path.strip("/").split("/") if s]
+
+
+def _slugify(text: str) -> str:
+    """Convert text to a URL-friendly slug.
+
+    Args:
+        text: Text to slugify.
+
+    Returns:
+        Lowercased, hyphen-separated slug.
+    """
+    slug = text.lower().strip()
+    slug = re.sub(r"[^a-z0-9\s-]", "", slug)
+    slug = re.sub(r"[\s]+", "-", slug)
+    slug = re.sub(r"-{2,}", "-", slug)
+    return slug.strip("-")

--- a/tests/unit/test_sitemap_searcher.py
+++ b/tests/unit/test_sitemap_searcher.py
@@ -1,0 +1,174 @@
+"""Tests for sitemap-based same-site page discovery.
+
+See Issue #106 for specification.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from gh_link_auditor.sitemap_searcher import (
+    _extract_loc_urls,
+    _path_segments,
+    _slugify,
+    fetch_sitemap,
+    search_sitemap_for_match,
+)
+
+
+class TestPathSegments:
+    """Tests for _path_segments()."""
+
+    def test_simple_path(self) -> None:
+        assert _path_segments("/docs/advanced/usage") == ["docs", "advanced", "usage"]
+
+    def test_trailing_slash(self) -> None:
+        assert _path_segments("/advanced/") == ["advanced"]
+
+    def test_root(self) -> None:
+        assert _path_segments("/") == []
+
+    def test_empty(self) -> None:
+        assert _path_segments("") == []
+
+
+class TestSlugify:
+    """Tests for _slugify()."""
+
+    def test_basic_title(self) -> None:
+        assert _slugify("Advanced Usage") == "advanced-usage"
+
+    def test_special_characters(self) -> None:
+        assert _slugify("HTTP/2 — The Basics!") == "http2-the-basics"
+
+    def test_empty(self) -> None:
+        assert _slugify("") == ""
+
+
+class TestExtractLocUrls:
+    """Tests for _extract_loc_urls()."""
+
+    def test_extracts_urls(self) -> None:
+        xml = """<?xml version="1.0"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url><loc>https://example.com/page1</loc></url>
+            <url><loc>https://example.com/page2</loc></url>
+        </urlset>"""
+        urls = _extract_loc_urls(xml)
+        assert urls == ["https://example.com/page1", "https://example.com/page2"]
+
+    def test_empty_sitemap(self) -> None:
+        assert _extract_loc_urls("<urlset></urlset>") == []
+
+
+class TestSearchSitemapForMatch:
+    """Tests for search_sitemap_for_match()."""
+
+    def test_finds_matching_path_segments(self) -> None:
+        urls = [
+            "https://example.com/docs/quickstart",
+            "https://example.com/docs/advanced/usage",
+            "https://example.com/about",
+        ]
+        matches = search_sitemap_for_match(urls, "/docs/advanced/", archive_title="Advanced Usage")
+        assert len(matches) > 0
+        assert "https://example.com/docs/advanced/usage" in matches
+
+    def test_title_slug_match(self) -> None:
+        urls = [
+            "https://example.com/guide/advanced-usage",
+            "https://example.com/guide/installation",
+        ]
+        matches = search_sitemap_for_match(urls, "/old/path/", archive_title="Advanced Usage")
+        assert "https://example.com/guide/advanced-usage" in matches
+
+    def test_excludes_exact_original(self) -> None:
+        urls = [
+            "https://example.com/advanced/",
+            "https://example.com/advanced/new-location",
+        ]
+        matches = search_sitemap_for_match(urls, "/advanced/", archive_title="Advanced")
+        # Should NOT include the original path
+        assert "https://example.com/advanced/" not in matches
+
+    def test_empty_sitemap_returns_empty(self) -> None:
+        assert search_sitemap_for_match([], "/path/", archive_title="Title") == []
+
+    def test_no_title_uses_path_only(self) -> None:
+        urls = [
+            "https://example.com/docs/advanced/usage",
+            "https://example.com/about",
+        ]
+        matches = search_sitemap_for_match(urls, "/docs/advanced/")
+        # Should still find path-segment matches
+        assert len(matches) > 0
+
+    def test_respects_max_candidates(self) -> None:
+        urls = [f"https://example.com/docs/page{i}" for i in range(20)]
+        matches = search_sitemap_for_match(urls, "/docs/something", max_candidates=3)
+        assert len(matches) <= 3
+
+    def test_best_match_first(self) -> None:
+        urls = [
+            "https://example.com/unrelated",
+            "https://example.com/docs/advanced-usage",
+            "https://example.com/docs/something-else",
+        ]
+        matches = search_sitemap_for_match(urls, "/docs/advanced/", archive_title="Advanced Usage")
+        if matches:
+            # The one with both path segment and title match should rank highest
+            assert "advanced-usage" in matches[0]
+
+
+class TestFetchSitemap:
+    """Tests for fetch_sitemap()."""
+
+    def test_fetches_and_parses(self) -> None:
+        sitemap_xml = """<?xml version="1.0"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url><loc>https://example.com/page1</loc></url>
+            <url><loc>https://example.com/page2</loc></url>
+        </urlset>"""
+
+        def fake_fetch(url):
+            if "sitemap.xml" in url:
+                return sitemap_xml
+            return None
+
+        with patch("gh_link_auditor.sitemap_searcher._fetch_url", side_effect=fake_fetch):
+            urls = fetch_sitemap("example.com")
+
+        assert urls == ["https://example.com/page1", "https://example.com/page2"]
+
+    def test_handles_sitemap_index(self) -> None:
+        index_xml = """<?xml version="1.0"?>
+        <sitemapindex>
+            <sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap>
+        </sitemapindex>"""
+
+        child_xml = """<?xml version="1.0"?>
+        <urlset>
+            <url><loc>https://example.com/child-page</loc></url>
+        </urlset>"""
+
+        def fake_fetch(url):
+            if "sitemap.xml" in url and "sitemap1" not in url:
+                return index_xml
+            if "sitemap1.xml" in url:
+                return child_xml
+            return None
+
+        with patch("gh_link_auditor.sitemap_searcher._fetch_url", side_effect=fake_fetch):
+            urls = fetch_sitemap("example.com")
+
+        assert "https://example.com/child-page" in urls
+
+    def test_returns_empty_on_no_sitemap(self) -> None:
+        with patch("gh_link_auditor.sitemap_searcher._fetch_url", return_value=None):
+            urls = fetch_sitemap("example.com")
+        assert urls == []
+
+    def test_handles_fetch_failure(self) -> None:
+        with patch("gh_link_auditor.sitemap_searcher._fetch_url", return_value=None):
+            urls = fetch_sitemap("nonexistent.example.com")
+        assert urls == []


### PR DESCRIPTION
## Summary

When a page 404s but the domain is alive (docs reorganization), the pipeline now searches the site's sitemap.xml to find where the content moved:

1. Fetch sitemap.xml (handles both flat sitemaps and sitemap indexes)
2. Score sitemap URLs by path segment overlap + archive title slug match
3. Verify top candidates are live
4. Compare content against archive snapshot for similarity scoring

This addresses the python-httpx.org case: `/advanced/` → 404, but the content exists at a new path. The sitemap search finds it.

Pipeline integration: new step 7 in LinkDetective, between archive lookup and URL pattern heuristics.

## Test plan

- [x] 20 new tests for sitemap_searcher.py (92% coverage)
- [x] All link_detective tests pass
- [x] Full unit suite: 1334 passed
- [x] Lint clean

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)