### PR TITLE
feat: repo quality scoring + CONTRIBUTING.md reader (#98) (#99)

### DIFF
--- a/src/gh_link_auditor/cli/run.py
+++ b/src/gh_link_auditor/cli/run.py
@@ -87,6 +87,24 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"Pipeline error: {exc}", file=sys.stderr)
         return 1
 
+    # Show repo quality info if available
+    stars = result.get("repo_stars", 0)
+    contributors = result.get("repo_contributors", 0)
+    pushed_at = result.get("repo_pushed_at", "")
+    if stars or contributors:
+        parts = []
+        if stars:
+            parts.append(f"{stars:,} stars")
+        if contributors:
+            parts.append(f"{contributors} contributors")
+        if pushed_at:
+            parts.append(f"last push {pushed_at[:10]}")
+        print(f"  Repo: {' | '.join(parts)}")
+
+    contributing_warnings = result.get("contributing_warnings", [])
+    for warning in contributing_warnings:
+        print(f"  Warning: {warning}")
+
     # Determine exit code
     if result.get("circuit_breaker_triggered"):
         count = len(result.get("dead_links", []))

--- a/src/gh_link_auditor/pipeline/nodes/n0_load_target.py
+++ b/src/gh_link_auditor/pipeline/nodes/n0_load_target.py
@@ -168,6 +168,31 @@ def n0_load_target(state: PipelineState) -> PipelineState:
             owner, repo = _extract_owner_repo(normalized)
             state["repo_owner"] = owner
             state["repo_name_short"] = repo
+
+            # Fetch repo quality and contributing guidelines
+            from gh_link_auditor.repo_quality import (
+                analyze_contributing_guidelines,
+                fetch_contributing_guidelines,
+                fetch_repo_metadata,
+                format_quality_summary,
+            )
+
+            quality = fetch_repo_metadata(owner, repo)
+            state["repo_stars"] = quality.stars
+            state["repo_pushed_at"] = quality.pushed_at
+            state["repo_contributors"] = quality.contributors
+
+            contributing = fetch_contributing_guidelines(owner, repo)
+            state["contributing_guidelines"] = contributing
+            warnings = analyze_contributing_guidelines(contributing)
+            state["contributing_warnings"] = warnings
+
+            if verbose:
+                summary = format_quality_summary(quality)
+                print(f"[N0] Repo quality: {summary}", file=sys.stderr, flush=True)
+                if warnings:
+                    for w in warnings:
+                        print(f"[N0] Warning: {w}", file=sys.stderr, flush=True)
         else:
             state["repo_owner"] = ""
             state["repo_name_short"] = ""

--- a/src/gh_link_auditor/pipeline/state.py
+++ b/src/gh_link_auditor/pipeline/state.py
@@ -84,6 +84,11 @@ class PipelineState(TypedDict, total=False):
 
     # N0 Output
     doc_files: list[str]
+    repo_stars: int
+    repo_pushed_at: str
+    repo_contributors: int
+    contributing_guidelines: str
+    contributing_warnings: list[str]
 
     # N1 Output
     dead_links: list[DeadLink]

--- a/src/gh_link_auditor/repo_quality.py
+++ b/src/gh_link_auditor/repo_quality.py
@@ -1,0 +1,189 @@
+"""Repo quality assessment and contributing guidelines reader.
+
+Fetches repo metadata (stars, recency, contributors) and contribution
+guidelines to assess whether a repo is a good PR target.
+
+See Issues #98, #99 for specification.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RepoQuality:
+    """Quality metrics for a target repository."""
+
+    stars: int = 0
+    pushed_at: str = ""
+    contributors: int = 0
+    contributing_text: str = ""
+    warnings: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.warnings is None:
+            self.warnings = []
+
+
+def fetch_repo_metadata(owner: str, repo: str) -> RepoQuality:
+    """Fetch repo quality metrics from GitHub API.
+
+    Args:
+        owner: Repository owner.
+        repo: Repository name.
+
+    Returns:
+        RepoQuality with stars, pushed_at, and contributor count.
+    """
+    quality = RepoQuality()
+
+    # Fetch repo details
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{owner}/{repo}",
+                "--jq",
+                "{stars: .stargazers_count, pushed_at: .pushed_at}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode == 0:
+            import json
+
+            data = json.loads(result.stdout)
+            quality.stars = data.get("stars", 0)
+            quality.pushed_at = data.get("pushed_at", "")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        logger.warning("Failed to fetch repo metadata for %s/%s", owner, repo)
+
+    # Fetch contributor count (from pagination header)
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{owner}/{repo}/contributors",
+                "--jq",
+                "length",
+                "-q",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode == 0:
+            count_str = result.stdout.strip()
+            if count_str.isdigit():
+                quality.contributors = int(count_str)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    return quality
+
+
+def fetch_contributing_guidelines(owner: str, repo: str) -> str:
+    """Fetch CONTRIBUTING.md content from common locations.
+
+    Checks: root, .github/, docs/.
+
+    Args:
+        owner: Repository owner.
+        repo: Repository name.
+
+    Returns:
+        Contributing guidelines text, or empty string if not found.
+    """
+    paths = ["CONTRIBUTING.md", ".github/CONTRIBUTING.md", "docs/CONTRIBUTING.md"]
+
+    for path in paths:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{owner}/{repo}/contents/{path}",
+                    "--jq",
+                    ".content",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                import base64
+
+                content = base64.b64decode(result.stdout.strip()).decode("utf-8", errors="replace")
+                return content
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
+    return ""
+
+
+def analyze_contributing_guidelines(text: str) -> list[str]:
+    """Analyze contributing guidelines for potential issues.
+
+    Flags patterns that suggest our automated PR approach may be rejected.
+
+    Args:
+        text: Contributing guidelines text.
+
+    Returns:
+        List of warning strings.
+    """
+    if not text:
+        return []
+
+    warnings: list[str] = []
+    text_lower = text.lower()
+
+    # Discussion-first requirement
+    if re.search(r"start.{0,20}(with|as).{0,20}discussion", text_lower):
+        warnings.append("Repo prefers discussion before PRs")
+
+    if "discussion" in text_lower and "before" in text_lower:
+        if "Repo prefers discussion before PRs" not in warnings:
+            warnings.append("Repo prefers discussion before PRs")
+
+    # No bot/automated contributions
+    if re.search(r"no.{0,10}(bot|automated|auto)", text_lower):
+        warnings.append("Repo may reject automated contributions")
+
+    # CLA requirement
+    if re.search(r"(contributor.{0,10}license|cla|sign.{0,10}agreement)", text_lower):
+        warnings.append("Repo requires CLA signing")
+
+    return warnings
+
+
+def format_quality_summary(quality: RepoQuality) -> str:
+    """Format repo quality as a brief summary line.
+
+    Args:
+        quality: RepoQuality data.
+
+    Returns:
+        Human-readable summary string.
+    """
+    parts = []
+    if quality.stars:
+        parts.append(f"{quality.stars:,} stars")
+    if quality.contributors:
+        parts.append(f"{quality.contributors} contributors")
+    if quality.pushed_at:
+        parts.append(f"last push {quality.pushed_at[:10]}")
+
+    return " | ".join(parts) if parts else "no metadata available"

--- a/tests/unit/test_repo_quality.py
+++ b/tests/unit/test_repo_quality.py
@@ -1,0 +1,153 @@
+"""Tests for repo quality assessment and contributing guidelines.
+
+See Issues #98, #99 for specification.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from gh_link_auditor.repo_quality import (
+    RepoQuality,
+    analyze_contributing_guidelines,
+    fetch_contributing_guidelines,
+    fetch_repo_metadata,
+    format_quality_summary,
+)
+
+
+class _MockCompleted:
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+class TestFetchRepoMetadata:
+    """Tests for fetch_repo_metadata()."""
+
+    def test_fetches_stars_and_pushed_at(self) -> None:
+        repo_data = _MockCompleted('{"stars": 15000, "pushed_at": "2026-03-01T12:00:00Z"}')
+        contrib_data = _MockCompleted("30")
+
+        with patch("subprocess.run", side_effect=[repo_data, contrib_data]):
+            quality = fetch_repo_metadata("encode", "httpx")
+
+        assert quality.stars == 15000
+        assert quality.pushed_at == "2026-03-01T12:00:00Z"
+        assert quality.contributors == 30
+
+    def test_handles_api_failure(self) -> None:
+        failed = _MockCompleted("", returncode=1)
+
+        with patch("subprocess.run", return_value=failed):
+            quality = fetch_repo_metadata("org", "repo")
+
+        assert quality.stars == 0
+        assert quality.contributors == 0
+
+    def test_handles_gh_not_found(self) -> None:
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            quality = fetch_repo_metadata("org", "repo")
+
+        assert quality.stars == 0
+
+
+class TestFetchContributingGuidelines:
+    """Tests for fetch_contributing_guidelines()."""
+
+    def test_finds_root_contributing(self) -> None:
+        import base64
+
+        content = base64.b64encode(b"# Contributing\nPlease open a discussion first.").decode()
+
+        def fake_run(cmd, **kwargs):
+            if "CONTRIBUTING.md" in str(cmd) and ".github" not in str(cmd):
+                return _MockCompleted(content)
+            return _MockCompleted("", returncode=1)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            text = fetch_contributing_guidelines("org", "repo")
+
+        assert "Contributing" in text
+        assert "discussion" in text
+
+    def test_finds_github_contributing(self) -> None:
+        import base64
+
+        content = base64.b64encode(b"# Contributing to HTTPX").decode()
+
+        def fake_run(cmd, **kwargs):
+            if ".github/CONTRIBUTING.md" in str(cmd):
+                return _MockCompleted(content)
+            return _MockCompleted("", returncode=1)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            text = fetch_contributing_guidelines("org", "repo")
+
+        assert "HTTPX" in text
+
+    def test_returns_empty_when_not_found(self) -> None:
+        with patch("subprocess.run", return_value=_MockCompleted("", returncode=1)):
+            text = fetch_contributing_guidelines("org", "repo")
+
+        assert text == ""
+
+
+class TestAnalyzeContributingGuidelines:
+    """Tests for analyze_contributing_guidelines()."""
+
+    def test_detects_discussion_first(self) -> None:
+        text = "Contributions should generally start out with a discussion."
+        warnings = analyze_contributing_guidelines(text)
+        assert any("discussion" in w.lower() for w in warnings)
+
+    def test_detects_discussion_before(self) -> None:
+        text = "Please open a discussion before submitting a pull request."
+        warnings = analyze_contributing_guidelines(text)
+        assert any("discussion" in w.lower() for w in warnings)
+
+    def test_detects_no_bots(self) -> None:
+        text = "No bot or automated contributions accepted."
+        warnings = analyze_contributing_guidelines(text)
+        assert any("automated" in w.lower() for w in warnings)
+
+    def test_detects_cla(self) -> None:
+        text = "You must sign a Contributor License Agreement before contributing."
+        warnings = analyze_contributing_guidelines(text)
+        assert any("CLA" in w for w in warnings)
+
+    def test_no_warnings_for_clean_contributing(self) -> None:
+        text = "We welcome contributions! Fork the repo and submit a PR."
+        warnings = analyze_contributing_guidelines(text)
+        assert warnings == []
+
+    def test_empty_text_returns_empty(self) -> None:
+        assert analyze_contributing_guidelines("") == []
+
+    def test_no_duplicate_warnings(self) -> None:
+        text = "Please start with a discussion. Start as a discussion before PRs."
+        warnings = analyze_contributing_guidelines(text)
+        discussion_warnings = [w for w in warnings if "discussion" in w.lower()]
+        assert len(discussion_warnings) == 1
+
+
+class TestFormatQualitySummary:
+    """Tests for format_quality_summary()."""
+
+    def test_full_summary(self) -> None:
+        quality = RepoQuality(stars=15000, pushed_at="2026-03-01T12:00:00Z", contributors=247)
+        summary = format_quality_summary(quality)
+        assert "15,000 stars" in summary
+        assert "247 contributors" in summary
+        assert "2026-03-01" in summary
+
+    def test_partial_data(self) -> None:
+        quality = RepoQuality(stars=500)
+        summary = format_quality_summary(quality)
+        assert "500 stars" in summary
+
+    def test_no_data(self) -> None:
+        quality = RepoQuality()
+        summary = format_quality_summary(quality)
+        assert "no metadata" in summary


### PR DESCRIPTION
## Summary

- **Repo quality scoring (#98)**: N0 now fetches stars, last push date, and contributor count from GitHub API. Displayed in CLI output after scan.
- **CONTRIBUTING.md reader (#99)**: N0 reads CONTRIBUTING.md from root, .github/, or docs/. Analyzes for discussion-first requirements, no-bot restrictions, and CLA requirements. Warnings displayed before PR submission.
- New PipelineState fields: repo_stars, repo_pushed_at, repo_contributors, contributing_guidelines, contributing_warnings

## Test plan

- [x] 16 new tests for repo_quality.py
- [x] Full unit suite: 1350 passed
- [x] Lint clean

Closes #98
Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)