### PR TITLE
fix: Wikimedia 429 rate-limit + parking domain detection (#111)

### DIFF
--- a/src/gh_link_auditor/false_positives.py
+++ b/src/gh_link_auditor/false_positives.py
@@ -22,7 +22,7 @@ SKIP_DOMAINS: set[str] = {
     "0.0.0.0",
 }
 
-# Domains that return 403 to bots but work fine in browsers.
+# Domains that return 403/429 to bots but work fine in browsers.
 BOT_BLOCKED_DOMAINS: set[str] = {
     "stackoverflow.com",
     "stackexchange.com",
@@ -31,6 +31,22 @@ BOT_BLOCKED_DOMAINS: set[str] = {
     "superuser.com",
     "askubuntu.com",
     "mathoverflow.net",
+    "upload.wikimedia.org",
+    "wikimedia.org",
+    "wikipedia.org",
+}
+
+# Domain parking / marketplace domains (expired domains redirect here).
+PARKING_DOMAINS: set[str] = {
+    "aftermarket.com",
+    "godaddy.com",
+    "sedo.com",
+    "dan.com",
+    "parkingcrew.net",
+    "sedoparking.com",
+    "hugedomains.com",
+    "buydomains.com",
+    "bodis.com",
 }
 
 # Domains where non-200 responses are by design (API test services).
@@ -84,12 +100,12 @@ def is_bot_blocked(url: str, http_status: int | None) -> bool:
 
     Args:
         url: The URL that was checked.
-        http_status: HTTP status code returned (e.g. 403).
+        http_status: HTTP status code returned (e.g. 403, 429).
 
     Returns:
         True if the failure is likely bot blocking.
     """
-    if http_status != 403:
+    if http_status not in (403, 429):
         return False
 
     hostname = (urlparse(url).hostname or "").lower()

--- a/src/gh_link_auditor/link_detective.py
+++ b/src/gh_link_auditor/link_detective.py
@@ -16,6 +16,7 @@ from enum import Enum
 from urllib.parse import urlparse
 
 from gh_link_auditor.archive_client import ArchiveClient
+from gh_link_auditor.false_positives import PARKING_DOMAINS
 from gh_link_auditor.github_resolver import GitHubResolver
 from gh_link_auditor.redirect_resolver import RedirectResolver, SSRFBlocked
 from gh_link_auditor.similarity import compute_similarity
@@ -161,16 +162,22 @@ class LinkDetective:
             log.extend(chain_log)
 
             if final_url and self._redirect_resolver.verify_live(final_url):
-                candidate = CandidateReplacement(
-                    url=final_url,
-                    method=InvestigationMethod.REDIRECT_CHAIN,
-                    similarity_score=0.98,
-                    verified_live=True,
-                )
-                candidates.append(candidate)
+                # Check if redirect landed on a parking/marketplace domain
+                final_host = (urlparse(final_url).hostname or "").lower()
+                is_parked = any(final_host == d or final_host.endswith(f".{d}") for d in PARKING_DOMAINS)
+                if is_parked:
+                    log.append(f"Redirect landed on parking domain: {final_url}")
+                else:
+                    candidate = CandidateReplacement(
+                        url=final_url,
+                        method=InvestigationMethod.REDIRECT_CHAIN,
+                        similarity_score=0.98,
+                        verified_live=True,
+                    )
+                    candidates.append(candidate)
 
-                # Short-circuit on high-confidence redirect
-                if candidate.similarity_score >= 0.95:
+                # Short-circuit on high-confidence redirect (only if not parked)
+                if not is_parked and candidates and candidates[-1].similarity_score >= 0.95:
                     report = ForensicReport(
                         dead_url=dead_url,
                         http_status=http_status,

--- a/tests/unit/test_false_positives.py
+++ b/tests/unit/test_false_positives.py
@@ -101,6 +101,18 @@ class TestIsBotBlocked:
     def test_malformed_url(self) -> None:
         assert is_bot_blocked("://broken", 403) is False
 
+    def test_wikimedia_429(self) -> None:
+        assert is_bot_blocked("https://upload.wikimedia.org/wikipedia/commons/image.png", 429) is True
+
+    def test_wikipedia_429(self) -> None:
+        assert is_bot_blocked("https://en.wikipedia.org/wiki/Python", 429) is True
+
+    def test_stackoverflow_429(self) -> None:
+        assert is_bot_blocked("https://stackoverflow.com/q/1", 429) is True
+
+    def test_random_site_429_not_blocked(self) -> None:
+        assert is_bot_blocked("https://random-site.com/page", 429) is False
+
 
 class TestIsApiTestEndpoint:
     """Tests for is_api_test_endpoint()."""
@@ -239,6 +251,9 @@ class TestIsFalsePositive:
 
     def test_github_auth_required(self) -> None:
         assert is_false_positive("https://github.com/org/repo/issues/new", http_status=404) is True
+
+    def test_wikimedia_429(self) -> None:
+        assert is_false_positive("https://upload.wikimedia.org/image.png", http_status=429) is True
 
     def test_github_repo_404_not_filtered(self) -> None:
         # Deleted repos ARE real dead links


### PR DESCRIPTION
## Summary

- Bot-blocked check now accepts 429 (rate limit) in addition to 403
- Wikimedia/Wikipedia domains added to bot-blocked list
- Parking/marketplace domains (aftermarket.com, godaddy.com, sedo.com, etc.) detected in redirect chains — not suggested as replacement URLs
- httpx scan: 31 → 6 → now 4 real results after all false positive improvements

## Test plan

- [x] 5 new tests
- [x] Full unit suite: 1355 passed
- [x] Lint clean

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)