### PR TITLE
fix: add Medium, Quora, ScienceDirect to bot-blocked (#118)

### DIFF
--- a/src/gh_link_auditor/false_positives.py
+++ b/src/gh_link_auditor/false_positives.py
@@ -34,6 +34,12 @@ BOT_BLOCKED_DOMAINS: set[str] = {
     "upload.wikimedia.org",
     "wikimedia.org",
     "wikipedia.org",
+    "medium.com",
+    "quora.com",
+    "sciencedirect.com",
+    "investopedia.com",
+    "community.cadence.com",
+    "sinaimg.cn",
 }
 
 # Domain parking / marketplace domains (expired domains redirect here).

--- a/tests/unit/test_false_positives.py
+++ b/tests/unit/test_false_positives.py
@@ -113,6 +113,18 @@ class TestIsBotBlocked:
     def test_random_site_429_not_blocked(self) -> None:
         assert is_bot_blocked("https://random-site.com/page", 429) is False
 
+    def test_medium_403(self) -> None:
+        assert is_bot_blocked("https://medium.com/@user/article-123", 403) is True
+
+    def test_quora_403(self) -> None:
+        assert is_bot_blocked("https://www.quora.com/What-is-something", 403) is True
+
+    def test_sciencedirect_403(self) -> None:
+        assert is_bot_blocked("https://www.sciencedirect.com/topics/computer-science/x", 403) is True
+
+    def test_investopedia_403(self) -> None:
+        assert is_bot_blocked("https://www.investopedia.com/", 403) is True
+
 
 class TestIsApiTestEndpoint:
     """Tests for is_api_test_endpoint()."""


### PR DESCRIPTION
## Summary

Add Medium, Quora, ScienceDirect, Investopedia, sinaimg.cn, and community.cadence.com to bot-blocked domains. All return 403 to automated requests but work in browsers.

Found during system-design-primer dry-run — these were the biggest source of noise in a 66-finding scan.

## Test plan

- [x] 4 new tests, 75 total on false_positives.py
- [x] Lint clean

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)