### PR TITLE
fix: treat 401/402 as auth-wall false positives (#120)

### DIFF
--- a/src/gh_link_auditor/false_positives.py
+++ b/src/gh_link_auditor/false_positives.py
@@ -198,6 +198,21 @@ def is_github_auth_required(url: str, http_status: int | None) -> bool:
     return bool(_GITHUB_AUTH_PATHS.match(url))
 
 
+def is_auth_wall(http_status: int | None) -> bool:
+    """Check if an HTTP status indicates an authentication wall.
+
+    401 (Unauthorized) and 402 (Payment Required) mean the content
+    exists behind a login or paywall — not a dead link.
+
+    Args:
+        http_status: HTTP status code.
+
+    Returns:
+        True if the status indicates an auth wall.
+    """
+    return http_status in (401, 402)
+
+
 def is_false_positive(url: str, http_status: int | None = None) -> bool:
     """Master check: is this URL a known false positive?
 
@@ -218,6 +233,8 @@ def is_false_positive(url: str, http_status: int | None = None) -> bool:
         return True
 
     if http_status is not None:
+        if is_auth_wall(http_status):
+            return True
         if is_bot_blocked(url, http_status):
             return True
         if is_github_issue_404(url, http_status):

--- a/tests/unit/test_false_positives.py
+++ b/tests/unit/test_false_positives.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from gh_link_auditor.false_positives import (
     is_api_test_endpoint,
+    is_auth_wall,
     is_bot_blocked,
     is_false_positive,
     is_github_auth_required,
@@ -124,6 +125,28 @@ class TestIsBotBlocked:
 
     def test_investopedia_403(self) -> None:
         assert is_bot_blocked("https://www.investopedia.com/", 403) is True
+
+
+class TestIsAuthWall:
+    """Tests for is_auth_wall()."""
+
+    def test_401_is_auth_wall(self) -> None:
+        assert is_auth_wall(401) is True
+
+    def test_402_is_auth_wall(self) -> None:
+        assert is_auth_wall(402) is True
+
+    def test_403_not_auth_wall(self) -> None:
+        assert is_auth_wall(403) is False
+
+    def test_404_not_auth_wall(self) -> None:
+        assert is_auth_wall(404) is False
+
+    def test_200_not_auth_wall(self) -> None:
+        assert is_auth_wall(200) is False
+
+    def test_none_not_auth_wall(self) -> None:
+        assert is_auth_wall(None) is False
 
 
 class TestIsApiTestEndpoint:
@@ -263,6 +286,12 @@ class TestIsFalsePositive:
 
     def test_github_auth_required(self) -> None:
         assert is_false_positive("https://github.com/org/repo/issues/new", http_status=404) is True
+
+    def test_401_auth_wall(self) -> None:
+        assert is_false_positive("https://any-site.com/protected", http_status=401) is True
+
+    def test_402_paywall(self) -> None:
+        assert is_false_positive("https://journal.com/article", http_status=402) is True
 
     def test_wikimedia_429(self) -> None:
         assert is_false_positive("https://upload.wikimedia.org/image.png", http_status=429) is True


### PR DESCRIPTION
## Summary

401 (Unauthorized) and 402 (Payment Required) now filtered as false positives globally. Content exists behind auth/paywall — not dead.

## Test plan

- [x] 8 new tests, 83 total on false_positives.py
- [x] Lint clean

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)