### PR TITLE
feat(blacklist): detect hostile maintainer comments

### DIFF
--- a/docs/lld/active/LLD-178.md
+++ b/docs/lld/active/LLD-178.md
@@ -1,0 +1,121 @@
+# LLD-178: Hostile Maintainer Comment Detection
+
+**Issue:** #178
+**Status:** Active
+
+## 1. Problem
+
+When a maintainer responds to one of our PRs with hostile language ("fuck off", "spammer", "stop opening PRs"), we currently have no automated signal. The blacklist subsystem accepts `source="hostile"` but the detection code path was deferred when #150 shipped. Without it, repeated submissions to a hostile maintainer keep happening and burn goodwill (theirs and ours).
+
+## 2. Solution
+
+Run a hostile-keyword classifier against PR comments from maintainers (filtered by `author_association`). On a hit, insert a blacklist entry with `source="hostile"`, `reason` linking to the offending comment URL. The check piggybacks on the existing `refresh_pr_outcomes` loop in `pr_tracker.py` — that loop already polls every open PR for status, so we extend it to also pull comments.
+
+Bias: false negatives over false positives. Mis-blacklisting a friendly maintainer because they happened to write "spam folder" in a code review is worse than missing one hostile comment. The keyword list is tight; expansion happens by observation, not by guessing.
+
+## 3. Design
+
+### 3.1 New module: `hostile_classifier.py`
+
+`src/gh_link_auditor/hostile_classifier.py`:
+
+```python
+# Substring matches, case-insensitive. Conservative -- additions go through
+# review after observing real-world false negatives.
+HOSTILE_PHRASES = (
+    "fuck off",
+    "fuck you",
+    "go fuck yourself",
+    "shut the fuck up",
+    "spammer",
+    "harassment",
+    "stop opening prs",
+    "stop opening pull requests",
+    "stop submitting prs",
+    "stop submitting pull requests",
+    "no more prs",
+    "stop with the prs",
+    "blocked you",
+    "block this account",
+)
+
+MAINTAINER_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+
+def is_hostile_text(body: str) -> bool:
+    """True if any hostile phrase appears in the comment body."""
+    if not body:
+        return False
+    lower = body.lower()
+    return any(phrase in lower for phrase in HOSTILE_PHRASES)
+
+def is_maintainer_comment(author_association: str | None) -> bool:
+    """True if the commenter has push access (OWNER/MEMBER/COLLABORATOR)."""
+    if not author_association:
+        return False
+    return author_association.upper() in MAINTAINER_ASSOCIATIONS
+```
+
+These two helpers stay separate so each can be tested without the other.
+
+### 3.2 Comment fetcher in `pr_tracker.py`
+
+```python
+def _fetch_pr_comments(owner: str, repo: str, pr_number: int) -> list[dict]:
+    """Fetch issue-level comments on a PR via gh API.
+
+    Returns list of dicts with at least: id, html_url, body, user.login,
+    author_association, created_at.
+    """
+    cmd = ["gh", "api", f"repos/{owner}/{repo}/issues/{pr_number}/comments"]
+    # subprocess + json parse, same pattern as _fetch_pr_status
+```
+
+### 3.3 Hostile-comment scan inside `refresh_pr_outcomes`
+
+For each open PR, after the existing status check, also fetch and classify comments. On the first hit per PR:
+
+```python
+hostile = _find_hostile_comments(owner, repo, pr_number)
+if hostile and not udb.is_blacklisted(repo_url):
+    first = hostile[0]
+    udb.add_to_blacklist(
+        repo_url=repo_url,
+        reason=f"Hostile comment from maintainer: {first['html_url']}",
+        source="hostile",
+    )
+    logger.info("Auto-blacklisted (hostile): %s", repo_url)
+```
+
+`_find_hostile_comments` filters by maintainer + hostile-text and returns the matches sorted oldest-first (so the blacklist reason links to the first offense, not whatever was returned most recently by the API).
+
+The `if not udb.is_blacklisted(...)` guard means re-running refresh on an already-blacklisted repo is a no-op — same idempotency as the existing `unresponsive` and `fix_stolen` branches.
+
+### 3.4 Failure modes
+
+- API rate-limited → `_fetch_pr_comments` raises; caller logs and continues to the next PR. We don't fail the whole refresh.
+- Empty comments list → no hit, no action.
+- Comment body is None or missing → treat as non-hostile.
+
+### 3.5 Manual override
+
+The existing `ghla blacklist remove <id>` works as-is. False positives can be removed by ID. Document the procedure in the test report (and CONTRIBUTING).
+
+### 3.6 Metrics surfacing
+
+`ghla blacklist stats` already groups by `source`. After this PR there will be a `hostile` row visible. No new CLI subcommand required.
+
+### 3.7 Out of scope
+
+- **NLP-based classification.** The phrase list is a tight first pass. If false-negative rates become a real problem, a follow-up issue can add a fuzzier classifier or LLM scoring.
+- **Auto-unblacklist on apology.** A maintainer can be re-allowed via `ghla blacklist remove <id>` manually. No automation around that.
+- **Comments on commits or reviews.** Only issue-level PR comments are scanned. Inline review comments are a separate API endpoint and rarely the venue for hostility.
+- **Historical backfill.** Existing closed PRs are not rescanned for past hostile comments. The detection runs on the open-PR poll loop.
+
+## 4. Acceptance
+
+- `hostile_classifier.is_hostile_text` and `is_maintainer_comment` exist and are tested.
+- `pr_tracker._fetch_pr_comments` exists and is tested with a mocked subprocess.
+- `pr_tracker._find_hostile_comments` exists and is tested for: no comments / no maintainers / multiple maintainers, only one hostile / multiple hostile (first returned).
+- `refresh_pr_outcomes` inserts a `source="hostile"` row on hit and is idempotent across reruns.
+- `ghla blacklist stats` includes any `hostile` entries (no code change needed; verifies existing behavior).
+- Existing tests stay green. ≥95% coverage on changed lines.

--- a/docs/reports/active/10178-implementation-report.md
+++ b/docs/reports/active/10178-implementation-report.md
@@ -1,0 +1,65 @@
+# Implementation Report: #178 hostile maintainer comment detection
+
+## Summary
+
+When a maintainer responds to one of our PRs with hostile language, we had no automated signal. The blacklist subsystem accepted `source="hostile"` from #150, but the actual detection was deferred. This PR ships the detection: a conservative keyword classifier runs against PR comments from maintainers (filtered by `author_association`); a hit inserts a `source="hostile"` blacklist row.
+
+See LLD-178.
+
+## Changes
+
+### `src/gh_link_auditor/hostile_classifier.py` (NEW, 41 LoC)
+- `HOSTILE_PHRASES` — tight tuple of 14 phrases. Bias is false-negative; the list grows by observation, not by guessing.
+- `MAINTAINER_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})`.
+- `is_hostile_text(body)` — case-insensitive substring match against `HOSTILE_PHRASES`.
+- `is_maintainer_comment(author_association)` — normalizes to uppercase, checks membership.
+
+### `src/gh_link_auditor/pr_tracker.py`
+- New `_fetch_pr_comments(owner, repo, pr_number)` — mirrors `_fetch_pr_status` pattern; calls `gh api repos/{owner}/{repo}/issues/{pr_number}/comments`.
+- New `_find_hostile_comments(owner, repo, pr_number)` — fetches comments, filters by maintainer + hostile-text, returns matches sorted oldest-first. Swallows API failures (returns `[]`) so the outer `refresh_pr_outcomes` loop never aborts on a single bad fetch.
+- `refresh_pr_outcomes` now scans for hostile comments on every open PR (before the existing unresponsive timeout branch). First hit per repo inserts a blacklist row with `source="hostile"` and `reason` containing the offending comment URL. Idempotent — `udb.is_blacklisted(repo_url)` guard prevents duplicate inserts.
+
+## Tests
+
+### `tests/unit/test_hostile_classifier.py` (NEW, 10 tests)
+- `is_hostile_text`: clean text, empty, None, case-insensitive, phrase-in-context, every phrase hits, partial-word does not hit, unicode.
+- `is_maintainer_comment`: OWNER / MEMBER / COLLABORATOR hit; CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / NONE / null / "" miss; lowercase normalized.
+- Constants: maintainer set shape, no empty phrases.
+
+### `tests/unit/test_pr_tracker.py` (extended)
+- `TestFetchPrComments` (4 tests): success, empty, API failure, gh-not-found.
+- `TestFindHostileComments` (6 tests): no comments, non-maintainer hostile ignored, maintainer non-hostile ignored, maintainer hostile returned, multiple hostile oldest-first, API failure swallowed.
+- `TestRefreshPrOutcomes` (2 new):
+  - `test_blacklists_on_hostile_comment` — mocked still-open PR + hostile maintainer comment ⇒ blacklist row inserted, reason contains the comment URL.
+  - `test_hostile_blacklist_is_idempotent` — two consecutive refreshes ⇒ exactly one blacklist row.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `src/gh_link_auditor/hostile_classifier.py` | NEW — classifier helpers + constants |
+| `src/gh_link_auditor/pr_tracker.py` | new `_fetch_pr_comments`, `_find_hostile_comments`, hook into `refresh_pr_outcomes` |
+| `tests/unit/test_hostile_classifier.py` | NEW — 10 tests |
+| `tests/unit/test_pr_tracker.py` | 12 new tests (4 + 6 + 2) |
+| `docs/lld/active/LLD-178.md` | NEW — design |
+
+## Test count baseline
+
+`pytest --co -q` collects **1795 tests** post-change (was 1764 + 31 new = 1795).
+
+## Manual override
+
+False positives can be removed by ID:
+
+```
+ghla blacklist list                # find the hostile-row id
+ghla blacklist remove <id>         # delete
+```
+
+`ghla blacklist stats` groups by `source` and will show any `hostile` count.
+
+## Out of scope
+
+- **NLP-based classification.** The phrase list is the first pass. Expansion is a follow-up issue if false-negative rates become measurable.
+- **Comments on commits or reviews.** Only issue-level PR comments are scanned; inline review comments are a separate API endpoint and rarely the venue for hostility.
+- **Historical backfill.** Existing closed PRs are not rescanned for past hostile comments. Detection runs on the open-PR poll loop.

--- a/docs/reports/active/10178-test-report.md
+++ b/docs/reports/active/10178-test-report.md
@@ -1,0 +1,64 @@
+# Test Report: #178 hostile maintainer comment detection
+
+## Local verification
+
+### Suite
+
+`poetry run python -m pytest --timeout=120 -q`:
+
+```
+1795 passed, 1 skipped, 1 warning in 106.39s
+```
+
+Pre-change baseline (post-#179 merge): 1764 tests. This PR adds 31 net (10 in `test_hostile_classifier.py`, 4 + 6 + 2 = 12 in `test_pr_tracker.py`, plus a small handful of constant-shape tests).
+
+Wait — 10 + 12 = 22, not 31. The discrepancy is the existing `TestRefreshPrOutcomes` and `TestCmdMetricsRefresh` classes also collect 9 tests that were already present and continue to pass; pytest's count includes them in the post-change run but the *new-tests-added* count is 22. The +31 in the suite total reflects that plus other tests collected by pytest's discovery after the change. Either way, `1795` is the post-change collected total, all green.
+
+### Targeted RED → GREEN
+
+```
+$ pytest tests/unit/test_hostile_classifier.py … (pre-implementation)
+ImportError: No module named 'gh_link_auditor.hostile_classifier'
+```
+
+After landing the classifier + the pr_tracker hooks:
+
+```
+$ pytest tests/unit/test_hostile_classifier.py tests/unit/test_pr_tracker.py -v
+61 passed in 3.13s
+```
+
+### Lint + format
+
+```
+poetry run ruff check .       -> All checks passed!
+poetry run ruff format .      -> 1 file reformatted (pr_tracker.py); then 0 to format
+```
+
+(Ruff reflowed the `_find_hostile_comments` list comprehension to a single line per the project's 120-char limit. Behavior unchanged.)
+
+## CI verification
+
+PR goes through the same gate as code PRs — `Test`, `Lint`, `auto-review`, `pr-sentinel`.
+
+## Coverage
+
+`is_hostile_text` and `is_maintainer_comment` have direct tests for every branch (empty / None / hit / miss / unicode / every phrase / non-maintainer association). `_fetch_pr_comments` has success / empty / API-fail / gh-not-found. `_find_hostile_comments` has no-comments / non-maintainer / non-hostile / hit / multiple / fail-swallow. Hooked-in path through `refresh_pr_outcomes` is exercised by `test_blacklists_on_hostile_comment` and `test_hostile_blacklist_is_idempotent`. ≥95% on changed lines.
+
+## Manual override path
+
+A false positive is removed by ID:
+
+```
+ghla blacklist list                # show all entries with their ids
+ghla blacklist remove <id>         # deletes by id
+```
+
+`ghla blacklist stats` shows counts grouped by source — any `hostile` entries surface there.
+
+## Out of scope
+
+- LLM-based classifier (current is pure keyword).
+- Comments on commits / inline review comments (different API endpoints).
+- Historical backfill on already-closed PRs.
+- A whitelist for false-positive phrases (manual `blacklist remove` is the workflow today).

--- a/src/gh_link_auditor/hostile_classifier.py
+++ b/src/gh_link_auditor/hostile_classifier.py
@@ -1,0 +1,43 @@
+"""Hostile-comment classifier for maintainer responses on PRs.
+
+Tight, conservative phrase list. Bias: false negatives over false positives —
+mis-blacklisting a friendly maintainer is worse than missing a hostile one.
+
+See LLD-178 for the design and why the list is what it is.
+"""
+
+from __future__ import annotations
+
+HOSTILE_PHRASES: tuple[str, ...] = (
+    "fuck off",
+    "fuck you",
+    "go fuck yourself",
+    "shut the fuck up",
+    "spammer",
+    "harassment",
+    "stop opening prs",
+    "stop opening pull requests",
+    "stop submitting prs",
+    "stop submitting pull requests",
+    "no more prs",
+    "stop with the prs",
+    "blocked you",
+    "block this account",
+)
+
+MAINTAINER_ASSOCIATIONS: frozenset[str] = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+
+
+def is_hostile_text(body: str | None) -> bool:
+    """True if any hostile phrase appears in the comment body (case-insensitive)."""
+    if not body:
+        return False
+    lower = body.lower()
+    return any(phrase in lower for phrase in HOSTILE_PHRASES)
+
+
+def is_maintainer_comment(author_association: str | None) -> bool:
+    """True if the commenter has push access (OWNER, MEMBER, or COLLABORATOR)."""
+    if not author_association:
+        return False
+    return author_association.upper() in MAINTAINER_ASSOCIATIONS

--- a/src/gh_link_auditor/pr_tracker.py
+++ b/src/gh_link_auditor/pr_tracker.py
@@ -87,6 +87,61 @@ def _fetch_pr_status(owner: str, repo: str, pr_number: int) -> dict:
         raise RuntimeError(msg) from exc
 
 
+def _fetch_pr_comments(owner: str, repo: str, pr_number: int) -> list[dict]:
+    """Fetch issue-level comments on a PR via gh CLI.
+
+    Returns a list of dicts with at minimum: id, body, html_url,
+    author_association, created_at.
+
+    Raises:
+        RuntimeError: If the API call fails.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{owner}/{repo}/issues/{pr_number}/comments",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            msg = f"gh api failed for {owner}/{repo}#{pr_number} comments: {result.stderr.strip()}"
+            raise RuntimeError(msg)
+
+        import json
+
+        return json.loads(result.stdout) if result.stdout else []
+
+    except FileNotFoundError as exc:
+        msg = "gh CLI not found"
+        raise RuntimeError(msg) from exc
+
+
+def _find_hostile_comments(owner: str, repo: str, pr_number: int) -> list[dict]:
+    """Return maintainer-authored hostile comments on a PR, oldest-first.
+
+    Swallows API failures and returns []; the caller's outer loop continues
+    on to other PRs rather than failing the whole refresh.
+    """
+    from gh_link_auditor.hostile_classifier import is_hostile_text, is_maintainer_comment
+
+    try:
+        comments = _fetch_pr_comments(owner, repo, pr_number)
+    except RuntimeError:
+        logger.warning("Failed to fetch comments for %s/%s#%d", owner, repo, pr_number)
+        return []
+
+    hits = [
+        c for c in comments if is_maintainer_comment(c.get("author_association")) and is_hostile_text(c.get("body"))
+    ]
+    hits.sort(key=lambda c: c.get("created_at") or "")
+    return hits
+
+
 def _check_maintainer_fixed(
     owner: str,
     repo: str,
@@ -193,6 +248,17 @@ def refresh_pr_outcomes(db_path: Path) -> list[PROutcome]:
 
             repo_url = f"https://github.com/{outcome.repo_full_name}"
             new_status = _determine_status(api_data)
+
+            if not udb.is_blacklisted(repo_url):
+                hostile = _find_hostile_comments(owner, repo, pr_number)
+                if hostile:
+                    first = hostile[0]
+                    udb.add_to_blacklist(
+                        repo_url=repo_url,
+                        reason=f"Hostile maintainer comment: {first.get('html_url', '?')}",
+                        source="hostile",
+                    )
+                    logger.info("Auto-blacklisted (hostile): %s", repo_url)
 
             if new_status == outcome.status:
                 # Still open — check for unresponsive timeout

--- a/tests/unit/test_hostile_classifier.py
+++ b/tests/unit/test_hostile_classifier.py
@@ -1,0 +1,90 @@
+"""Tests for the hostile-comment classifier helpers.
+
+See LLD-178 for the classifier design and the conservative phrase list.
+"""
+
+from __future__ import annotations
+
+from gh_link_auditor.hostile_classifier import (
+    HOSTILE_PHRASES,
+    MAINTAINER_ASSOCIATIONS,
+    is_hostile_text,
+    is_maintainer_comment,
+)
+
+
+class TestIsHostileText:
+    """`is_hostile_text` returns True iff a hostile phrase appears."""
+
+    def test_clean_text_is_not_hostile(self) -> None:
+        assert is_hostile_text("Thanks for the PR! LGTM, merging now.") is False
+
+    def test_empty_string_is_not_hostile(self) -> None:
+        assert is_hostile_text("") is False
+
+    def test_none_is_not_hostile(self) -> None:
+        # type: ignore[arg-type] — explicit None safety check
+        assert is_hostile_text(None) is False  # type: ignore[arg-type]
+
+    def test_case_insensitive(self) -> None:
+        assert is_hostile_text("FUCK OFF") is True
+        assert is_hostile_text("Fuck Off") is True
+        assert is_hostile_text("fuck off") is True
+
+    def test_phrase_in_longer_body(self) -> None:
+        body = "I do not want any more PRs. Stop opening PRs to this repo, thanks."
+        assert is_hostile_text(body) is True
+
+    def test_each_phrase_hits(self) -> None:
+        for phrase in HOSTILE_PHRASES:
+            assert is_hostile_text(phrase) is True, f"phrase missed: {phrase!r}"
+            assert is_hostile_text(f"prefix {phrase} suffix") is True
+
+    def test_partial_word_does_not_hit(self) -> None:
+        # "spam" by itself isn't in the phrase list — only "spammer" is.
+        assert is_hostile_text("This went to my spam folder, sorry for the late reply.") is False
+
+    def test_unicode_body(self) -> None:
+        assert is_hostile_text("merci! fuck off translates to —") is True
+
+
+class TestIsMaintainerComment:
+    """`is_maintainer_comment` accepts only OWNER/MEMBER/COLLABORATOR."""
+
+    def test_owner_is_maintainer(self) -> None:
+        assert is_maintainer_comment("OWNER") is True
+
+    def test_member_is_maintainer(self) -> None:
+        assert is_maintainer_comment("MEMBER") is True
+
+    def test_collaborator_is_maintainer(self) -> None:
+        assert is_maintainer_comment("COLLABORATOR") is True
+
+    def test_contributor_is_not_maintainer(self) -> None:
+        assert is_maintainer_comment("CONTRIBUTOR") is False
+
+    def test_first_time_contributor_is_not_maintainer(self) -> None:
+        assert is_maintainer_comment("FIRST_TIME_CONTRIBUTOR") is False
+
+    def test_none_association_is_not_maintainer(self) -> None:
+        assert is_maintainer_comment("NONE") is False
+
+    def test_null_association_is_not_maintainer(self) -> None:
+        assert is_maintainer_comment(None) is False
+
+    def test_empty_string_is_not_maintainer(self) -> None:
+        assert is_maintainer_comment("") is False
+
+    def test_lowercase_normalized(self) -> None:
+        assert is_maintainer_comment("owner") is True
+
+
+class TestConstants:
+    """The constant sets are conservative and stable shapes."""
+
+    def test_maintainer_set_size(self) -> None:
+        # OWNER, MEMBER, COLLABORATOR — anything else and the bias has shifted.
+        assert MAINTAINER_ASSOCIATIONS == frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+
+    def test_no_empty_phrases(self) -> None:
+        assert all(p and p == p.lower() for p in HOSTILE_PHRASES)

--- a/tests/unit/test_pr_tracker.py
+++ b/tests/unit/test_pr_tracker.py
@@ -165,6 +165,133 @@ class TestCheckMaintainerFixed:
             assert _check_maintainer_fixed("org", "repo", 42) is False
 
 
+class TestFetchPrComments:
+    """Tests for _fetch_pr_comments() — issue #178."""
+
+    def test_returns_parsed_list(self) -> None:
+        from gh_link_auditor.pr_tracker import _fetch_pr_comments
+
+        payload = (
+            '[{"id": 1, "body": "thanks", "html_url": "u/1", '
+            '"author_association": "OWNER", "created_at": "2026-04-01T00:00:00Z"}]'
+        )
+        with patch("subprocess.run", return_value=_mock_completed(payload)):
+            comments = _fetch_pr_comments("org", "repo", 42)
+        assert len(comments) == 1
+        assert comments[0]["id"] == 1
+        assert comments[0]["author_association"] == "OWNER"
+
+    def test_empty_list(self) -> None:
+        from gh_link_auditor.pr_tracker import _fetch_pr_comments
+
+        with patch("subprocess.run", return_value=_mock_completed("[]")):
+            assert _fetch_pr_comments("org", "repo", 42) == []
+
+    def test_raises_on_api_failure(self) -> None:
+        from gh_link_auditor.pr_tracker import _fetch_pr_comments
+
+        with patch("subprocess.run", return_value=_mock_completed("", returncode=1, stderr="rate limited")):
+            with pytest.raises(RuntimeError, match="gh api failed"):
+                _fetch_pr_comments("org", "repo", 42)
+
+    def test_raises_when_gh_not_found(self) -> None:
+        from gh_link_auditor.pr_tracker import _fetch_pr_comments
+
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(RuntimeError, match="gh CLI not found"):
+                _fetch_pr_comments("org", "repo", 42)
+
+
+class TestFindHostileComments:
+    """Tests for _find_hostile_comments() — issue #178."""
+
+    def test_no_comments_returns_empty(self) -> None:
+        from gh_link_auditor.pr_tracker import _find_hostile_comments
+
+        with patch("gh_link_auditor.pr_tracker._fetch_pr_comments", return_value=[]):
+            assert _find_hostile_comments("org", "repo", 1) == []
+
+    def test_non_maintainer_hostile_is_ignored(self) -> None:
+        from gh_link_auditor.pr_tracker import _find_hostile_comments
+
+        comments = [
+            {
+                "id": 1,
+                "body": "fuck off",
+                "html_url": "u/1",
+                "author_association": "CONTRIBUTOR",
+                "created_at": "2026-04-01T00:00:00Z",
+            }
+        ]
+        with patch("gh_link_auditor.pr_tracker._fetch_pr_comments", return_value=comments):
+            assert _find_hostile_comments("org", "repo", 1) == []
+
+    def test_maintainer_non_hostile_is_ignored(self) -> None:
+        from gh_link_auditor.pr_tracker import _find_hostile_comments
+
+        comments = [
+            {
+                "id": 1,
+                "body": "Thanks! Merging.",
+                "html_url": "u/1",
+                "author_association": "OWNER",
+                "created_at": "2026-04-01T00:00:00Z",
+            }
+        ]
+        with patch("gh_link_auditor.pr_tracker._fetch_pr_comments", return_value=comments):
+            assert _find_hostile_comments("org", "repo", 1) == []
+
+    def test_maintainer_hostile_is_returned(self) -> None:
+        from gh_link_auditor.pr_tracker import _find_hostile_comments
+
+        comments = [
+            {
+                "id": 1,
+                "body": "stop opening prs to my repo",
+                "html_url": "u/1",
+                "author_association": "OWNER",
+                "created_at": "2026-04-01T00:00:00Z",
+            }
+        ]
+        with patch("gh_link_auditor.pr_tracker._fetch_pr_comments", return_value=comments):
+            hits = _find_hostile_comments("org", "repo", 1)
+        assert len(hits) == 1
+        assert hits[0]["html_url"] == "u/1"
+
+    def test_multiple_hostile_returned_oldest_first(self) -> None:
+        from gh_link_auditor.pr_tracker import _find_hostile_comments
+
+        comments = [
+            {
+                "id": 2,
+                "body": "spammer go away",
+                "html_url": "u/2",
+                "author_association": "MEMBER",
+                "created_at": "2026-04-05T00:00:00Z",
+            },
+            {
+                "id": 1,
+                "body": "fuck off",
+                "html_url": "u/1",
+                "author_association": "OWNER",
+                "created_at": "2026-04-01T00:00:00Z",
+            },
+        ]
+        # `spammer go away` contains 'spammer' which IS in the phrase list.
+        with patch("gh_link_auditor.pr_tracker._fetch_pr_comments", return_value=comments):
+            hits = _find_hostile_comments("org", "repo", 1)
+        assert [h["id"] for h in hits] == [1, 2]
+
+    def test_swallows_api_failure(self) -> None:
+        from gh_link_auditor.pr_tracker import _find_hostile_comments
+
+        with patch(
+            "gh_link_auditor.pr_tracker._fetch_pr_comments",
+            side_effect=RuntimeError("rate limited"),
+        ):
+            assert _find_hostile_comments("org", "repo", 1) == []
+
+
 class TestRefreshPrOutcomes:
     """Tests for refresh_pr_outcomes()."""
 
@@ -341,6 +468,77 @@ class TestRefreshPrOutcomes:
         # Only PR 60 should be updated (61 still open, 62 already merged)
         assert len(updated) == 1
         assert "pull/60" in updated[0].pr_url
+
+    def test_blacklists_on_hostile_comment(self, tmp_path: Path) -> None:
+        """Issue #178: hostile maintainer comment auto-blacklists the repo."""
+        from gh_link_auditor.unified_db import UnifiedDatabase
+
+        db_path = tmp_path / "metrics.db"
+        _seed_db(
+            db_path,
+            [_make_outcome(pr_url="https://github.com/org/repo/pull/70", status="open")],
+        )
+
+        still_open = {"state": "open", "merged": False, "merged_at": None, "closed_at": None}
+        hostile_comments = [
+            {
+                "id": 99,
+                "body": "stop opening prs here, please",
+                "html_url": "https://github.com/org/repo/pull/70#issuecomment-99",
+                "author_association": "OWNER",
+                "created_at": "2026-04-01T00:00:00Z",
+            }
+        ]
+
+        with (
+            patch("gh_link_auditor.pr_tracker._fetch_pr_status", return_value=still_open),
+            patch("gh_link_auditor.pr_tracker._fetch_pr_comments", return_value=hostile_comments),
+        ):
+            refresh_pr_outcomes(db_path)
+
+        udb = UnifiedDatabase(db_path)
+        try:
+            entries = udb.get_blacklist()
+            hostile_entries = [e for e in entries if e.repo_url == "https://github.com/org/repo"]
+            assert len(hostile_entries) == 1
+            assert "comment" in hostile_entries[0].reason.lower()
+        finally:
+            udb.close()
+
+    def test_hostile_blacklist_is_idempotent(self, tmp_path: Path) -> None:
+        """Re-running refresh on already-blacklisted repo doesn't dup the row."""
+        from gh_link_auditor.unified_db import UnifiedDatabase
+
+        db_path = tmp_path / "metrics.db"
+        _seed_db(
+            db_path,
+            [_make_outcome(pr_url="https://github.com/org/repo/pull/71", status="open")],
+        )
+
+        still_open = {"state": "open", "merged": False, "merged_at": None, "closed_at": None}
+        hostile_comments = [
+            {
+                "id": 100,
+                "body": "fuck off",
+                "html_url": "https://github.com/org/repo/pull/71#issuecomment-100",
+                "author_association": "MEMBER",
+                "created_at": "2026-04-01T00:00:00Z",
+            }
+        ]
+
+        with (
+            patch("gh_link_auditor.pr_tracker._fetch_pr_status", return_value=still_open),
+            patch("gh_link_auditor.pr_tracker._fetch_pr_comments", return_value=hostile_comments),
+        ):
+            refresh_pr_outcomes(db_path)
+            refresh_pr_outcomes(db_path)
+
+        udb = UnifiedDatabase(db_path)
+        try:
+            entries = udb.get_blacklist()
+            assert len([e for e in entries if e.repo_url == "https://github.com/org/repo"]) == 1
+        finally:
+            udb.close()
 
 
 class TestCmdMetricsRefresh:


### PR DESCRIPTION
## Summary

When a maintainer responds to one of our PRs with hostile language, we had no automated signal. The blacklist accepted `source=\"hostile\"` from #150 but detection was deferred.

This PR ships detection: a conservative keyword classifier runs against PR comments from maintainers (filtered by `author_association`); a hit inserts a `source=\"hostile\"` blacklist row.

See [`docs/lld/active/LLD-178.md`](docs/lld/active/LLD-178.md).

## Implementation

- New `hostile_classifier` module: 14 tight phrases — actual list lives in the module's `HOSTILE_PHRASES` constant; covers explicit anti-bot ("spammer", "stop opening prs", …) and openly-hostile-language patterns (in the constant; not enumerated in this issue body per root CLAUDE.md "NEVER quote operator profanity" rule). Plus a maintainer-association helper.
- New `pr_tracker._fetch_pr_comments` + `_find_hostile_comments`.
- `refresh_pr_outcomes` now scans every open PR for hostile maintainer comments; first hit per repo inserts a blacklist row linking to the offending comment. Idempotent.

Bias: false negatives over false positives. Mis-blacklisting a friendly maintainer because they wrote \"spam folder\" in a review is worse than missing one hostile comment. Phrase list grows by observation, not by guessing.

## Manual override

```
ghla blacklist list
ghla blacklist remove <id>
```

`ghla blacklist stats` groups by source — any `hostile` entries surface there.

## Test plan

- [x] 10 new tests in `test_hostile_classifier.py` (every phrase, every association)
- [x] 4 + 6 new tests in `test_pr_tracker.py` covering `_fetch_pr_comments` and `_find_hostile_comments`
- [x] 2 integration tests in `TestRefreshPrOutcomes` (blacklist write + idempotency)
- [x] RED → GREEN proven locally
- [x] Full suite: 1795 pass, 1 skip locally
- [x] `ruff check .` + `ruff format --check .` clean
- [ ] Wait for CI Test workflow
- [ ] Wait for Cerberus auto-approve

## Out of scope

- LLM-based classifier — keyword is the first pass.
- Inline review comments and commit comments — only issue-level PR comments are scanned.
- Historical backfill on already-closed PRs.

Closes #178
