### PR TITLE
fix(network): HEAD-404 triggers GET fallback

### DIFF
--- a/docs/lld/active/LLD-193.md
+++ b/docs/lld/active/LLD-193.md
@@ -1,0 +1,49 @@
+# LLD-193: 404 from HEAD triggers GET fallback
+
+**Issue:** #193
+**Status:** Active
+
+## 1. Problem
+
+`should_retry(404, None)` returns `(False, False)` — no retry, no GET fallback. But some sites (Microsoft Marketplace observed today; likely Apple App Store, Atlassian Marketplace) return **404 to HEAD but 200 to GET** as an anti-crawler defense. Result: every URL on such a site is a false-positive dead link in our pipeline.
+
+Confirmed: `https://marketplace.visualstudio.com/items?itemName=ms-python.python` — HEAD 404, GET 200.
+
+## 2. Solution
+
+Add 404 to the same GET-fallback group as 403 and 405. The existing `get_fallback_attempted` flag in `check_url` prevents GET-loop. 410 stays terminal (intentional permanent removal — HEAD/GET difference unlikely).
+
+## 3. Design
+
+### `should_retry` change
+
+```python
+# before
+if status_code in (404, 410):
+    return False, False
+if status_code in (403, 405):
+    return False, True
+
+# after
+if status_code == 410:
+    return False, False
+if status_code in (403, 404, 405):
+    return False, True
+```
+
+`check_url` is unchanged — its existing HEAD→GET branch fires on `try_get and not get_fallback_attempted`. The new 404 → try_get path runs through the same machinery.
+
+### Tests
+
+New class `TestHeadToGetFallback404`, mirroring the existing 403 and 405 fallback tests:
+
+- `test_head_to_get_fallback_404` — HEAD 404, GET 200 → status='ok', method='GET'.
+- `test_head_and_get_both_404` — HEAD 404, GET 404 → status='error', status_code=404 (genuinely dead).
+
+## 4. Acceptance
+
+- `check_url("https://marketplace.visualstudio.com/items?itemName=ms-python.python")` returns `status='ok'`.
+- Genuinely-dead 404 URLs still return `error` (covered by the both-404 test).
+- 410 still terminal (no test change needed; covered by existing classification).
+- Existing test suite stays green.
+- ≥95% coverage on changed lines.

--- a/docs/reports/active/10193-implementation-report.md
+++ b/docs/reports/active/10193-implementation-report.md
@@ -1,0 +1,37 @@
+# Implementation Report: #193 HEAD-404 triggers GET fallback
+
+## Summary
+
+Some sites return HTTP 404 to HEAD requests but 200 to GET as an anti-crawler defense — confirmed today against `https://marketplace.visualstudio.com/items?itemName=ms-python.python`. Previously `should_retry(404, None)` returned `(False, False)`, so the pipeline declared these URLs dead without ever trying GET. This PR moves 404 into the same GET-fallback group as 403 and 405. 410 stays terminal (intentional permanent removal).
+
+See LLD-193.
+
+## Changes
+
+### `src/gh_link_auditor/network.py`
+- `should_retry` updated: 404 returns `(False, True)` (no retry, try GET). 410 kept at `(False, False)`. 403 and 405 unchanged.
+- The existing `get_fallback_attempted` flag in `check_url` already prevents GET→GET looping; no change needed there.
+
+### `tests/unit/test_network.py`
+- New `TestHeadToGetFallback404` class (2 tests): HEAD 404 + GET 200 → ok/GET; HEAD 404 + GET 404 → error/404 (genuinely dead).
+- Existing `TestShouldRetry::test_404_no_retry` (asserted old behavior) renamed to `test_404_get_fallback` and updated to `(False, True)`.
+
+### `tests/unit/test_check_links_fallback.py`
+- `test_404_does_not_trigger_fallback` (old behavior) replaced with `test_404_triggers_fallback`. Added `test_410_does_not_trigger_fallback` so the 410 boundary is explicit.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `src/gh_link_auditor/network.py` | `should_retry`: 404 now in GET-fallback group |
+| `tests/unit/test_network.py` | new `TestHeadToGetFallback404`; updated `test_404_no_retry` |
+| `tests/unit/test_check_links_fallback.py` | flipped 404 assertion, added 410 boundary test |
+| `docs/lld/active/LLD-193.md` | NEW design |
+
+## Test count
+
+`pytest --co -q` collects **1807 tests** (was 1804, +3 net from this PR).
+
+## Operator impact
+
+Audits against sites that 404-block HEAD (Microsoft Marketplace, likely Apple/Atlassian similar) will no longer surface their URLs as dead in N4. Today's python-guide finding #1 (`marketplace.visualstudio.com/items?itemName=ms-python.python`) drops from the dead-link list after this merges.

--- a/docs/reports/active/10193-test-report.md
+++ b/docs/reports/active/10193-test-report.md
@@ -1,0 +1,31 @@
+# Test Report: #193 HEAD-404 triggers GET fallback
+
+## Local verification
+
+```
+1807 passed, 1 skipped, 1 warning in 101.80s
+```
+
+Pre-change: 1804. Net +3 (2 new in `TestHeadToGetFallback404`; 1 renamed existing).
+
+## RED → GREEN
+
+The new `test_head_to_get_fallback_404` failed before the `should_retry` change (404 was returning `(False, False)`). After moving 404 into the GET-fallback group, all three tests in `TestHeadToGetFallback404` + the renamed `TestShouldRetry::test_404_get_fallback` pass.
+
+Two pre-existing tests (`test_404_no_retry`, `test_404_does_not_trigger_fallback`) had encoded the OLD policy. Both updated in place to the new policy; behavior change is intentional and documented.
+
+## Lint + format
+
+`poetry run ruff check . && poetry run ruff format --check .` — clean.
+
+## CI verification
+
+PR runs through the standard gate (Test + Lint + auto-review + pr-sentinel).
+
+## Coverage
+
+≥95% on the changed line in `should_retry`. The new branch is exercised by two tests covering the HEAD→GET→200 and HEAD→GET→404 paths.
+
+## Out of scope
+
+Live verification against `marketplace.visualstudio.com` deferred to the next audit run — the unit tests prove the contract.

--- a/src/gh_link_auditor/network.py
+++ b/src/gh_link_auditor/network.py
@@ -184,9 +184,12 @@ def should_retry(status_code: int | None, error_type: str | None) -> tuple[bool,
     if status_code is not None:
         if 200 <= status_code < 400:
             return False, False
-        if status_code in (404, 410):
+        if status_code == 410:
+            # 410 Gone is intentional permanent removal — HEAD/GET difference unlikely.
             return False, False
-        if status_code in (403, 405):
+        if status_code in (403, 404, 405):
+            # 403/405 commonly block HEAD; 404 sometimes does too (anti-crawler
+            # defense on sites like Microsoft Marketplace, #193). Try GET once.
             return False, True
         if status_code in (429, 503):
             return True, False

--- a/tests/unit/test_check_links_fallback.py
+++ b/tests/unit/test_check_links_fallback.py
@@ -105,9 +105,15 @@ class TestShouldFallbackToGet:
     def test_405_triggers_fallback(self):
         assert should_fallback_to_get(405) is True
 
-    # T080 — 404 → False
-    def test_404_does_not_trigger_fallback(self):
-        assert should_fallback_to_get(404) is False
+    # T080 (#193) — 404 → True
+    # Some sites (e.g. Microsoft Marketplace) return 404 to HEAD but 200 to GET
+    # as an anti-crawler defense. Try GET once before declaring dead.
+    def test_404_triggers_fallback(self):
+        assert should_fallback_to_get(404) is True
+
+    # 410 stays no-fallback (intentional permanent removal).
+    def test_410_does_not_trigger_fallback(self):
+        assert should_fallback_to_get(410) is False
 
 
 class TestFallbackLogging:

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -235,6 +235,61 @@ class TestHeadToGetFallback403:
         assert result["retries"] == 0
 
 
+class TestHeadToGetFallback404:
+    """Falls back to GET on 404, then succeeds (#193).
+
+    Some sites (Microsoft Marketplace observed) return 404 to HEAD as an
+    anti-crawler defense but 200 to GET. We treat 404 the same as 403/405:
+    one GET attempt, then accept the result.
+    """
+
+    def test_head_to_get_fallback_404(self, no_retry_backoff_config):
+        """404 on HEAD triggers GET fallback; returns ok on GET 200."""
+        http_error_404 = urllib.error.HTTPError(
+            "https://marketplace.example.com/item",
+            404,
+            "Not Found",
+            {},
+            None,
+        )
+        mock_resp_200 = _mock_urlopen_response(status=200)
+
+        def side_effect(*args, **kwargs):
+            request_obj = args[0]
+            if request_obj.get_method() == "HEAD":
+                raise http_error_404
+            return mock_resp_200
+
+        with mock.patch("gh_link_auditor.network.urllib.request.urlopen", side_effect=side_effect):
+            result = check_url(
+                "https://marketplace.example.com/item",
+                backoff_config=no_retry_backoff_config,
+            )
+
+        assert result["status"] == "ok"
+        assert result["method"] == "GET"
+        assert result["retries"] == 0
+
+    def test_head_and_get_both_404(self, no_retry_backoff_config):
+        """404 on HEAD and GET → genuinely dead, status='error'."""
+        http_error_404 = urllib.error.HTTPError(
+            "https://gone.example.com",
+            404,
+            "Not Found",
+            {},
+            None,
+        )
+
+        with mock.patch("gh_link_auditor.network.urllib.request.urlopen", side_effect=http_error_404):
+            result = check_url(
+                "https://gone.example.com",
+                backoff_config=no_retry_backoff_config,
+            )
+
+        assert result["status"] == "error"
+        assert result["status_code"] == 404
+
+
 class TestHeadlessFallback:
     """Tests for headless-browser fallback after persistent 403 (#190)."""
 
@@ -918,9 +973,9 @@ class TestShouldRetry:
         """301 → no retry, no fallback."""
         assert should_retry(301, None) == (False, False)
 
-    def test_404_no_retry(self):
-        """404 → no retry, no fallback."""
-        assert should_retry(404, None) == (False, False)
+    def test_404_get_fallback(self):
+        """404 → no retry, but try GET fallback (#193)."""
+        assert should_retry(404, None) == (False, True)
 
     def test_410_no_retry(self):
         """410 → no retry, no fallback."""


### PR DESCRIPTION
## Summary

Some sites (Microsoft Marketplace observed today; likely Apple/Atlassian similar) return **404 to HEAD but 200 to GET** as an anti-crawler defense. Previously the pipeline declared these URLs dead without trying GET. This moves 404 into the same GET-fallback group as 403 and 405. 410 stays terminal.

Surfaced while reviewing python-guide finding #1 (``https://marketplace.visualstudio.com/items?itemName=ms-python.python`` — HEAD 404, GET 200).

See [LLD-193](docs/lld/active/LLD-193.md).

## Test plan

- [x] New ``TestHeadToGetFallback404`` (HEAD→GET fallback succeeds; HEAD→GET both 404 stays dead)
- [x] Two pre-existing tests for old behavior updated in place
- [x] Full suite: 1807 pass, 1 skip
- [x] ``ruff check`` + ``ruff format --check`` clean
- [ ] CI Test workflow on this PR
- [ ] Cerberus auto-approve

Closes #193