### PR TITLE
fix(detective): suppress redirect-equivalence candidates

### DIFF
--- a/docs/lld/active/LLD-197.md
+++ b/docs/lld/active/LLD-197.md
@@ -1,0 +1,26 @@
+# LLD-197: suppress redirect-equivalence candidates
+
+**Issue:** #197
+**Status:** Active
+
+## Problem
+
+`link_detective.investigate()` step 4 emits a REDIRECT_CHAIN candidate when `follow_redirects` returns a live final URL. But `follow_redirects` only emits a final_url when the original URL responded with HTTP 30x (the chain started). That means the original URL is reachable — it works. Replacing it with the chain endpoint is a cosmetic canonical-URL change, not a fix.
+
+Confirmed today: `https://stackoverflow.com/a/14638025` is a Stack Overflow short-answer URL that redirects to its long form. Both work in browsers. The pipeline proposed the long form as a "fix" at 0.98 similarity.
+
+## Solution
+
+Suppress the REDIRECT_CHAIN candidate emission. The chain-walking itself remains useful for diagnostics and archive-snapshot decisions, so `follow_redirects` and `verify_live` stay. Only the candidate emission goes.
+
+## Implementation
+
+`link_detective.py` step 4: replace the candidate-append + short-circuit block with a log entry. Pipeline continues to archive, mutations, sitemap, etc. — those methods CAN produce real fixes.
+
+## Acceptance
+
+- No CandidateReplacement with `method=REDIRECT_CHAIN` is emitted for any input where the original URL successfully follows a redirect chain.
+- Investigation log contains a clear "suppressed (#197)" entry for diagnostic visibility.
+- All other investigation methods unaffected.
+- Existing trust-tier classification (REDIRECT_CHAIN = tier 1) and signals scoring continue to compile — they reference the enum, not the emission.
+- ≥95% coverage on the changed branch.

--- a/docs/reports/active/10197-implementation-report.md
+++ b/docs/reports/active/10197-implementation-report.md
@@ -1,0 +1,46 @@
+# Implementation Report: #197 suppress redirect-equivalence candidates
+
+## Summary
+
+When the original URL responds with HTTP 30x and the chain ends at a live page, the URL is **reachable** (just redirects). Replacing it with the final URL is a cosmetic canonical-URL update, not a broken-link fix. Today's case: `https://stackoverflow.com/a/14638025` redirects to `https://stackoverflow.com/questions/.../14638025#14638025`. Both URLs work in any browser — the SO short form is intentional.
+
+Previously the pipeline emitted these as REDIRECT_CHAIN candidates with similarity_score=0.98 and short-circuited the rest of N2. Operators saw them in N4 and had to manually reject. Net: HITL noise + no actual fix value.
+
+## Changes
+
+### `src/gh_link_auditor/link_detective.py`
+
+`investigate()` step 4 (REDIRECT_CHAIN) — when `follow_redirects` returns a live final_url:
+
+- **Before**: append a `CandidateReplacement(method=REDIRECT_CHAIN, similarity_score=0.98)`, short-circuit and return early.
+- **After**: log "Redirect chain to live final … — original is reachable, candidate suppressed (#197)" and continue to the next investigation method (archive, mutations, etc.).
+
+`follow_redirects` and `verify_live` themselves unchanged — they're still useful for archive-fallback decisions and diagnostics.
+
+### `tests/unit/test_link_detective.py`
+
+`TestRedirectCandidate.test_redirect_chain_short_circuits` renamed to `test_redirect_chain_suppressed_when_original_reachable`. Asserts no REDIRECT_CHAIN candidate is emitted and the suppression message appears in the log.
+
+## What we DON'T change
+
+- The `InvestigationMethod.REDIRECT_CHAIN` enum value stays for backward compatibility (existing DB rows reference it, tier-classification tests still pass).
+- `follow_redirects()` still walks chains. Its output is now log-only.
+- All other N2 methods unchanged (archive_only, url_mutation, sitemap_search, etc.).
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `src/gh_link_auditor/link_detective.py` | suppress REDIRECT_CHAIN candidate emission |
+| `tests/unit/test_link_detective.py` | flipped assertion in `TestRedirectCandidate` |
+| `docs/lld/active/LLD-197.md` | NEW (just-in-time short design) |
+
+## Test count
+
+1807 (unchanged net — one test renamed/updated in place).
+
+## Operator impact
+
+- python-guide finding #6 (`stackoverflow.com/a/14638025` → long form) and similar short→long redirect "fixes" disappear from N4 review.
+- Sites that 30x to a working final (most CDNs, URL shorteners, vanity domains) no longer surface bogus candidates.
+- Genuinely-dead URLs unaffected — those don't enter the redirect chain in the first place.

--- a/docs/reports/active/10197-test-report.md
+++ b/docs/reports/active/10197-test-report.md
@@ -1,0 +1,36 @@
+# Test Report: #197 redirect-equivalence suppression
+
+## Local verification
+
+`poetry run python -m pytest --timeout=120 -q` → **1807 passed, 1 skipped**.
+
+Net test count unchanged: one test in `TestRedirectCandidate` was renamed and updated in place (`test_redirect_chain_short_circuits` → `test_redirect_chain_suppressed_when_original_reachable`).
+
+## RED → GREEN
+
+Pre-change: `test_redirect_chain_short_circuits` asserted a REDIRECT_CHAIN candidate was emitted. After the assertion was flipped to "no candidate, log mentions suppression", the test failed (impl still emitted). After the impl change in `link_detective.py`, the test passes.
+
+## Lint + format
+
+`ruff check . && ruff format --check .` — clean after a one-file reformat.
+
+## Coverage
+
+The investigate() step-4 branch is covered by:
+
+- `test_redirect_chain_suppressed_when_original_reachable` — chain present, suppression logged, candidate empty.
+- Other `TestInvestigateReturnsReport` / `TestArchiveMiss` / `TestNoCandidates` tests exercise the surrounding pipeline without depending on REDIRECT_CHAIN emission.
+
+≥95% on changed lines.
+
+## Behavior preserved
+
+Other tests confirm:
+- `TestCandidateSorting.test_candidates_sorted_descending` — sorting still works (uses mutation + archive candidates).
+- `TestArchiveMiss.test_archive_miss_continues_investigation` — archive-miss path unchanged.
+- Trust-tier and signals tests reference `InvestigationMethod.REDIRECT_CHAIN` as an enum, not via emission. Unaffected.
+
+## Out of scope
+
+- Removing REDIRECT_CHAIN from `InvestigationMethod` entirely. Existing DB rows / archived reports reference it. Leave for back-compat.
+- Sites that return 30x to a redirect-to-itself loop. `follow_redirects` already has a visited-set guard.

--- a/src/gh_link_auditor/link_detective.py
+++ b/src/gh_link_auditor/link_detective.py
@@ -296,41 +296,26 @@ class LinkDetective:
         archive_title: str | None = None
         archive_summary: str | None = None
 
-        # 4. REDIRECT DETECTION (highest priority)
+        # 4. REDIRECT DETECTION — informational only (#197)
+        #
+        # If follow_redirects returns a live final_url, the ORIGINAL dead_url
+        # responded with 30x. That means the original URL itself works (it
+        # redirected). Replacing dead_url with final_url would be a cosmetic
+        # canonical-URL update, not a broken-link fix. We log the finding for
+        # diagnostics but emit no candidate.
         try:
             final_url, chain_log = self._redirect_resolver.follow_redirects(dead_url)
             log.extend(chain_log)
 
             if final_url and self._redirect_resolver.verify_live(final_url):
-                # Check if redirect landed on a parking/marketplace domain
                 final_host = (urlparse(final_url).hostname or "").lower()
                 is_parked = any(final_host == d or final_host.endswith(f".{d}") for d in PARKING_DOMAINS)
                 if is_parked:
                     log.append(f"Redirect landed on parking domain: {final_url}")
                 else:
-                    candidate = CandidateReplacement(
-                        url=final_url,
-                        method=InvestigationMethod.REDIRECT_CHAIN,
-                        similarity_score=0.98,
-                        verified_live=True,
+                    log.append(
+                        f"Redirect chain to live final {final_url} — original is reachable, candidate suppressed (#197)"
                     )
-                    candidates.append(candidate)
-
-                # Short-circuit on high-confidence redirect (only if not parked)
-                if not is_parked and candidates and candidates[-1].similarity_score >= 0.95:
-                    report = ForensicReport(
-                        dead_url=dead_url,
-                        http_status=http_status,
-                        investigation=Investigation(
-                            archive_snapshot=None,
-                            archive_title=None,
-                            archive_content_summary=None,
-                            candidate_replacements=candidates,
-                            investigation_log=log,
-                        ),
-                    )
-                    self._cache_result(report)
-                    return report
         except SSRFBlocked as e:
             log.append(f"SSRF blocked: {e}")
 

--- a/tests/unit/test_link_detective.py
+++ b/tests/unit/test_link_detective.py
@@ -81,8 +81,13 @@ class TestInvalidScheme:
 
 
 class TestRedirectCandidate:
-    def test_redirect_chain_short_circuits(self):
-        """High-confidence redirect produces early return."""
+    def test_redirect_chain_suppressed_when_original_reachable(self):
+        """#197: a successful redirect chain proves the original URL works.
+
+        When dead_url responds with 30x leading to a live final_url, the
+        original is reachable — replacing it would be cosmetic, not a fix.
+        No candidate emitted; finding logged for diagnostics.
+        """
         detective = _make_detective()
         detective._redirect_resolver = FakeRedirectResolver(
             redirect_map={"https://old.com/page": ("https://new.com/page", ["301 -> https://new.com/page"])},
@@ -94,10 +99,11 @@ class TestRedirectCandidate:
 
         report = detective.investigate("https://old.com/page", 301)
 
-        candidates = report.investigation.candidate_replacements
-        assert len(candidates) >= 1
-        assert candidates[0].method == InvestigationMethod.REDIRECT_CHAIN
-        assert candidates[0].verified_live is True
+        redirect_candidates = [
+            c for c in report.investigation.candidate_replacements if c.method == InvestigationMethod.REDIRECT_CHAIN
+        ]
+        assert redirect_candidates == []
+        assert any("candidate suppressed (#197)" in line for line in report.investigation.investigation_log)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When the original URL responds with 30x and the chain ends at a live page, the URL is reachable — just redirects. Replacing it with the chain endpoint is a cosmetic canonical-URL update, not a broken-link fix.

Today's case (python-guide finding #6): ``stackoverflow.com/a/14638025`` → ``stackoverflow.com/questions/…/14638025#14638025``. Both work in any browser. The pipeline proposed the long form as a 0.98-confidence "fix".

Now: when ``follow_redirects`` returns a live final_url, we log the finding and continue. No CandidateReplacement emitted. The REDIRECT_CHAIN enum stays for back-compat.

See [LLD-197](docs/lld/active/LLD-197.md).

## Test plan

- [x] ``TestRedirectCandidate`` test updated: asserts no candidate emitted + suppression message in log
- [x] Full suite: 1807 pass (unchanged; one test renamed/updated in place)
- [x] ``ruff check`` + ``ruff format --check`` clean
- [ ] CI Test workflow
- [ ] Cerberus auto-approve

Closes #197