### PR TITLE
fix(network): stealth fallback for CDN-fronted None status

### DIFF
--- a/docs/lld/active/LLD-198.md
+++ b/docs/lld/active/LLD-198.md
@@ -1,0 +1,87 @@
+# LLD-198: stealth fallback on None status when domain is CDN-fronted
+
+**Issue:** #198
+**Status:** Active
+
+## Problem
+
+Today's finding #7 in python-guide (``https://www.pythonjobshq.com``): probe returned status ``None`` (transport-level error). Pipeline declared dead. Site is actually live — Cloudflare-protected (104.17.x.x), serves real Python job board to browsers.
+
+#190 added stealth fallback but only fires on ``status_code == 403``. ``None`` status (connection reset / timeout) bypasses stealth entirely.
+
+## Solution
+
+Add a second stealth-fallback branch in ``check_url`` for the None-status case, gated by:
+
+- ``status_code is None``
+- ``error_type in {"connection_reset", "timeout"}`` — transport errors typical of Cloudflare bot-block.
+- ``request_config.get("allow_headless")`` — same opt-in flag as #190.
+- ``_resolves_to_cdn(url)`` — only spend ~10s on stealth when the domain looks bot-fronted, not on genuinely dead domains.
+
+## Design
+
+### New helper: ``_resolves_to_cdn``
+
+```python
+_CDN_RANGES = (
+    ipaddress.ip_network("104.16.0.0/12"),    # Cloudflare main
+    ipaddress.ip_network("172.64.0.0/13"),    # Cloudflare
+    ipaddress.ip_network("151.101.0.0/16"),   # Fastly
+    ipaddress.ip_network("199.232.0.0/16"),   # Fastly
+    # Akamai is hard — vast and frequently changing. Skipped for now.
+)
+
+def _resolves_to_cdn(url: str) -> bool:
+    try:
+        host = urlparse(url).hostname
+        if not host:
+            return False
+        _, _, ips = socket.gethostbyname_ex(host)
+    except (socket.gaierror, ValueError):
+        return False
+    for ip_str in ips:
+        try:
+            ip = ipaddress.ip_address(ip_str)
+            if any(ip in net for net in _CDN_RANGES):
+                return True
+        except ValueError:
+            continue
+    return False
+```
+
+Cost: one synchronous DNS lookup. ~5-50ms typical, cached by the OS resolver.
+
+### Integration into ``check_url``
+
+After the existing 403-stealth branch at ``network.py:447-460``:
+
+```python
+# CDN-fronted None status — also try stealth (#198)
+if (
+    status_code is None
+    and error_type in {"connection_reset", "timeout"}
+    and request_config.get("allow_headless")
+    and _resolves_to_cdn(url)
+):
+    return _headless_browser_get(url, timeout_s=request_config["timeout"] * 2)
+```
+
+Only triggers when the DNS check confirms CDN. Genuinely dead URLs (DNS failure, non-CDN host) skip stealth and return error immediately — no wasted browser time.
+
+## Tests
+
+- ``_resolves_to_cdn``: positive case (mock gethostbyname_ex → Cloudflare IP), negative (mock → non-CDN IP), DNS failure (mock raises gaierror), no-hostname URL.
+- ``check_url`` ladder: None status + connection_reset + allow_headless + CDN → ``_headless_browser_get`` called; same setup without allow_headless or without CDN → not called.
+
+## Acceptance
+
+- ``pythonjobshq.com`` (resolves 104.17.x.x): None status path now invokes stealth.
+- A genuinely-dead non-CDN URL: stealth NOT invoked.
+- Existing 403-stealth path unchanged.
+- ≥95% coverage on the new branch and helper.
+
+## Out of scope
+
+- Reverse-DNS / SNI-based CDN detection (heavier).
+- Akamai (vast IP space; needs separate research).
+- Configurable CDN ranges (hardcoded list is fine for now; updated as we learn).

--- a/docs/reports/active/10198-implementation-report.md
+++ b/docs/reports/active/10198-implementation-report.md
@@ -1,0 +1,49 @@
+# Implementation Report: #198 stealth fallback for CDN-fronted None status
+
+## Summary
+
+Today's python-guide finding #7 (`https://www.pythonjobshq.com`): probe returned status `None` (transport-level error), pipeline declared dead. The site is actually live — Cloudflare-protected (resolves to 104.17.x.x), serves real content to browsers.
+
+`#190` shipped stealth fallback only for `status_code == 403`. The `None` status path bypassed stealth entirely. This PR adds a second branch: when `status_code is None` AND `error_type in {"connection_reset", "timeout"}` AND the host resolves to a known CDN range, invoke `_headless_browser_get`.
+
+See LLD-198.
+
+## Changes
+
+### `src/gh_link_auditor/network.py`
+
+- New imports: `ipaddress`, `urlparse`.
+- New module-level tuple `_CDN_RANGES` covering Cloudflare main blocks (`104.16.0.0/12`, `172.64.0.0/13`) and Fastly (`151.101.0.0/16`, `199.232.0.0/16`). Akamai deliberately excluded — vast and frequently changing.
+- New helper `_resolves_to_cdn(url) -> bool`: parses hostname, resolves via `socket.gethostbyname_ex`, checks each returned IP against `_CDN_RANGES`. Returns `False` on DNS failure / no hostname / non-CDN IP. ~5-50ms typical (OS resolver cache).
+- New stealth-fallback branch in `check_url` after the existing 403-stealth branch: fires only when `status_code is None`, error is transport-class, opt-in flag set, AND host is CDN-fronted.
+
+The new branch is bounded by the same `request_config.get("allow_headless")` flag that gates #190 — N1 enables it; N2's per-candidate probes leave it off.
+
+### `tests/unit/test_network.py`
+
+- New `TestResolvesToCDN` (5 tests): Cloudflare IP, Fastly IP, non-CDN IP, DNS failure, no-hostname URL.
+- New `TestHeadlessFallbackOnNone` (3 tests): fires on `ConnectionResetError` when CDN; skips when not CDN; skips when `allow_headless=False`.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `src/gh_link_auditor/network.py` | `_resolves_to_cdn` helper + None-status branch in `check_url` |
+| `tests/unit/test_network.py` | 8 new tests across 2 new classes |
+| `docs/lld/active/LLD-198.md` | NEW design |
+
+## Test count
+
+`pytest --co -q` collects **1828 tests** post-change (was 1820, +8 net).
+
+## Operator impact
+
+`pythonjobshq.com` and similar Cloudflare-fronted URLs that get connection-reset on bot probes will now be verified via real browser. False-positive class closed.
+
+Cost: one extra DNS lookup per dead-link probe (~5-50ms cached). Stealth itself (~10-20s) only fires when the lookup confirms CDN — non-CDN dead URLs short-circuit immediately.
+
+## Out of scope
+
+- Akamai range coverage (separate research).
+- Reverse-DNS / SNI-based CDN detection.
+- Configurable CDN ranges via env or config file (hardcoded list is fine for now; update as we learn).

--- a/docs/reports/active/10198-test-report.md
+++ b/docs/reports/active/10198-test-report.md
@@ -1,0 +1,28 @@
+# Test Report: #198 CDN-None stealth fallback
+
+## Local verification
+
+`poetry run python -m pytest --timeout=120 -q` → **1828 passed, 1 skipped**.
+
+Pre-change baseline: 1820. Net +8 tests.
+
+## RED → GREEN
+
+Tests added first failed with `AttributeError: module 'gh_link_auditor.network' does not have the attribute '_resolves_to_cdn'`. After adding the helper + the new conditional in `check_url`, all 8 tests pass in 0.09s.
+
+## Lint + format
+
+`ruff check . && ruff format --check .` clean, no reformat needed.
+
+## Coverage
+
+- `_resolves_to_cdn` happy paths (Cloudflare + Fastly), miss path (non-CDN), failure paths (DNS error, no hostname). 5 tests.
+- `check_url` new branch: fires when conditions met, skipped when CDN check fails, skipped when opt-in flag off. 3 tests.
+
+Existing tests unaffected.
+
+≥95% on changed lines.
+
+## Out of scope
+
+Real-world verification against `pythonjobshq.com` happens at the next Phase 4 run.

--- a/src/gh_link_auditor/network.py
+++ b/src/gh_link_auditor/network.py
@@ -10,6 +10,7 @@ See: LLD-009 (Issue #9) for design rationale.
 from __future__ import annotations
 
 import http.client
+import ipaddress
 import random
 import socket
 import ssl
@@ -18,6 +19,7 @@ import urllib.error
 import urllib.request
 from email.utils import parsedate_to_datetime
 from typing import TypedDict
+from urllib.parse import urlparse
 
 # ---------------------------------------------------------------------------
 # Configuration data structures (LLD §2.3)
@@ -370,6 +372,49 @@ def _build_error_message(status_code: int | None, error_type: str | None) -> str
 
 
 # ---------------------------------------------------------------------------
+# CDN detection (#198) — used to gate the None-status stealth fallback
+# ---------------------------------------------------------------------------
+
+_CDN_RANGES = (
+    ipaddress.ip_network("104.16.0.0/12"),  # Cloudflare main
+    ipaddress.ip_network("172.64.0.0/13"),  # Cloudflare
+    ipaddress.ip_network("151.101.0.0/16"),  # Fastly
+    ipaddress.ip_network("199.232.0.0/16"),  # Fastly
+)
+
+
+def _resolves_to_cdn(url: str) -> bool:
+    """Return True if the URL's hostname resolves to a known-bot-fronting CDN.
+
+    Used to gate the expensive stealth-browser fallback: only fire it for hosts
+    that are likely returning bot-block errors (Cloudflare / Fastly), not for
+    genuinely dead hosts. Lookups go through the OS resolver and are typically
+    cached. Failure modes (DNS error, missing hostname) return False so we
+    don't accidentally trigger stealth for a broken URL.
+
+    See LLD-198.
+    """
+    try:
+        host = urlparse(url).hostname
+    except ValueError:
+        return False
+    if not host:
+        return False
+    try:
+        _, _, ip_list = socket.gethostbyname_ex(host)
+    except (socket.gaierror, OSError):
+        return False
+    for ip_str in ip_list:
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if any(ip in net for net in _CDN_RANGES):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
 # Headless-browser fallback (#190)
 # ---------------------------------------------------------------------------
 
@@ -540,6 +585,23 @@ def check_url(
         # Only triggers after the modern-UA retry has also failed with 403.
         if (
             status_code == 403 and browser_ua_attempted and request_config.get("allow_headless")  # type: ignore[typeddict-item]
+        ):
+            return _headless_browser_get(
+                url,
+                timeout_s=request_config["timeout"] * 2,
+            )
+
+        # CDN-fronted None status — also try stealth (#198).
+        # Cloudflare / Fastly often block bot probes at the transport layer
+        # (connection reset / timeout) rather than returning 403. When the
+        # host resolves to a known CDN, the real-browser path is worth the
+        # cost; for genuinely unreachable hosts, the _resolves_to_cdn check
+        # short-circuits to False and we avoid spending 10-20s on stealth.
+        if (
+            status_code is None
+            and error_type in {"connection_reset", "timeout"}
+            and request_config.get("allow_headless")  # type: ignore[typeddict-item]
+            and _resolves_to_cdn(url)
         ):
             return _headless_browser_get(
                 url,

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -393,6 +393,146 @@ class TestHeadlessFallback:
         assert not mock_headless.called
 
 
+class TestResolvesToCDN:
+    """Tests for _resolves_to_cdn() — DNS-based CDN heuristic (#198)."""
+
+    def test_cloudflare_ip_returns_true(self):
+        from gh_link_auditor.network import _resolves_to_cdn
+
+        with mock.patch(
+            "gh_link_auditor.network.socket.gethostbyname_ex",
+            return_value=("host", [], ["104.17.249.70"]),
+        ):
+            assert _resolves_to_cdn("https://example.com") is True
+
+    def test_fastly_ip_returns_true(self):
+        from gh_link_auditor.network import _resolves_to_cdn
+
+        with mock.patch(
+            "gh_link_auditor.network.socket.gethostbyname_ex",
+            return_value=("host", [], ["151.101.65.140"]),
+        ):
+            assert _resolves_to_cdn("https://example.com") is True
+
+    def test_non_cdn_ip_returns_false(self):
+        from gh_link_auditor.network import _resolves_to_cdn
+
+        with mock.patch(
+            "gh_link_auditor.network.socket.gethostbyname_ex",
+            return_value=("host", [], ["8.8.8.8"]),
+        ):
+            assert _resolves_to_cdn("https://example.com") is False
+
+    def test_dns_failure_returns_false(self):
+        from gh_link_auditor.network import _resolves_to_cdn
+
+        with mock.patch(
+            "gh_link_auditor.network.socket.gethostbyname_ex",
+            side_effect=socket.gaierror("nodename nor servname provided"),
+        ):
+            assert _resolves_to_cdn("https://nonexistent.example") is False
+
+    def test_no_hostname_returns_false(self):
+        from gh_link_auditor.network import _resolves_to_cdn
+
+        assert _resolves_to_cdn("not-a-url") is False
+
+
+class TestHeadlessFallbackOnNone:
+    """Tests for None-status + CDN headless fallback (#198)."""
+
+    def test_fires_on_connection_reset_when_cdn(self, no_retry_backoff_config):
+        from gh_link_auditor.network import RequestResult
+
+        fake_ok = RequestResult(
+            url="https://cdn.example.com",
+            status="ok",
+            status_code=200,
+            method="HEADLESS",
+            response_time_ms=8000,
+            retries=0,
+            error=None,
+        )
+
+        with (
+            mock.patch(
+                "gh_link_auditor.network.urllib.request.urlopen",
+                side_effect=ConnectionResetError("connection reset"),
+            ),
+            mock.patch(
+                "gh_link_auditor.network._resolves_to_cdn",
+                return_value=True,
+            ),
+            mock.patch(
+                "gh_link_auditor.network._headless_browser_get",
+                return_value=fake_ok,
+            ) as mock_headless,
+        ):
+            result = check_url(
+                "https://cdn.example.com",
+                request_config={
+                    "timeout": 10.0,
+                    "verify_ssl": True,
+                    "user_agent": "test",
+                    "allow_headless": True,
+                },
+                backoff_config=no_retry_backoff_config,
+            )
+
+        assert result["status"] == "ok"
+        assert mock_headless.called
+
+    def test_skips_when_not_cdn(self, no_retry_backoff_config):
+        with (
+            mock.patch(
+                "gh_link_auditor.network.urllib.request.urlopen",
+                side_effect=ConnectionResetError("connection reset"),
+            ),
+            mock.patch(
+                "gh_link_auditor.network._resolves_to_cdn",
+                return_value=False,
+            ),
+            mock.patch(
+                "gh_link_auditor.network._headless_browser_get",
+            ) as mock_headless,
+        ):
+            result = check_url(
+                "https://genuinely-dead.example.com",
+                request_config={
+                    "timeout": 10.0,
+                    "verify_ssl": True,
+                    "user_agent": "test",
+                    "allow_headless": True,
+                },
+                backoff_config=no_retry_backoff_config,
+            )
+
+        assert result["status"] != "ok"
+        assert not mock_headless.called
+
+    def test_skips_when_allow_headless_false(self, no_retry_backoff_config):
+        with (
+            mock.patch(
+                "gh_link_auditor.network.urllib.request.urlopen",
+                side_effect=ConnectionResetError("connection reset"),
+            ),
+            mock.patch(
+                "gh_link_auditor.network._resolves_to_cdn",
+                return_value=True,
+            ),
+            mock.patch(
+                "gh_link_auditor.network._headless_browser_get",
+            ) as mock_headless,
+        ):
+            result = check_url(
+                "https://cdn.example.com",
+                backoff_config=no_retry_backoff_config,
+            )
+
+        assert result["status"] != "ok"
+        assert not mock_headless.called
+
+
 class TestHeadlessBrowserGet:
     """Tests for _headless_browser_get() — the helper itself (#190)."""
 


### PR DESCRIPTION
## Summary

Today's python-guide finding #7 (``pythonjobshq.com``): probe returned ``None`` status (transport-level error), pipeline declared dead. The site is alive — Cloudflare-protected, serves real content to browsers.

#190 added stealth fallback for ``status_code == 403``. The ``None`` status path bypassed it. This PR adds a second branch: ``None`` status + transport error + CDN-fronted host → invoke ``_headless_browser_get``.

New helper ``_resolves_to_cdn()`` does a cheap DNS check against Cloudflare (``104.16/12``, ``172.64/13``) and Fastly (``151.101/16``, ``199.232/16``) ranges. Non-CDN dead URLs short-circuit so we don't waste stealth on genuinely dead hosts.

See [LLD-198](docs/lld/active/LLD-198.md).

## Test plan

- [x] 5 ``TestResolvesToCDN`` tests (CDN positive, non-CDN, DNS failure, no-host)
- [x] 3 ``TestHeadlessFallbackOnNone`` tests (fires when CDN, skips when not, skips when opt-in off)
- [x] Full suite: 1828 pass, 1 skip
- [x] ``ruff check`` + ``ruff format --check`` clean
- [ ] CI Test workflow
- [ ] Cerberus auto-approve

Closes #198