### PR TITLE
feat(blacklist): anti-AI maintainer-comment classifier

### DIFF
--- a/docs/lld/active/LLD-200.md
+++ b/docs/lld/active/LLD-200.md
@@ -1,0 +1,34 @@
+# LLD-200: anti-AI phrase classifier
+
+**Issue:** #200
+**Status:** Active
+
+## Problem
+
+Pallets/flask PR #6019 was closed by maintainer davidism: "Happy to update this, but please do not use genAI to generate or submit a PR." Our `hostile_classifier` (#178) phrases (`fuck off`, `spammer`, `stop opening prs`) don't match this polite-but-firm rejection. Auto-detection missed it; operator manually blacklisted with `source="policy"`.
+
+## Solution
+
+Mirror `hostile_classifier` for the anti-AI class. New phrase list, new helper, new finder in `pr_tracker.py`, new blacklist source `anti_ai`. `refresh_pr_outcomes` checks both classes; hostile wins if both hit.
+
+## Design
+
+### `hostile_classifier.py`
+- `ANTI_AI_PHRASES` — 20 conservative phrases.
+- `is_anti_ai_text(body) -> bool` — case-insensitive substring match.
+
+### `pr_tracker.py`
+- `_find_anti_ai_comments(owner, repo, pr_number) -> list[dict]` — mirrors `_find_hostile_comments`. Maintainer-only filter; oldest-first sort.
+- `refresh_pr_outcomes` — after the existing hostile block, an `else` branch calls `_find_anti_ai_comments`. On hit, blacklist with `source="anti_ai"`.
+
+### Why distinct from `hostile`
+
+Different signals: `hostile` = "don't engage with this person", `anti_ai` = "don't engage with AI tools at all". Different source values let `ghla blacklist stats` separate them and help future maintainer-pref learning (#186).
+
+## Acceptance
+
+- `is_anti_ai_text("Happy to update this, but please do not use genAI to generate or submit a PR.")` returns True.
+- `_find_anti_ai_comments` returns the maintainer's comment on the pallets-style scenario.
+- `refresh_pr_outcomes` inserts a `source="anti_ai"` blacklist row on hit.
+- Idempotency preserved via existing `udb.is_blacklisted` guard.
+- ≥95% coverage on new code.

--- a/docs/reports/active/10200-implementation-report.md
+++ b/docs/reports/active/10200-implementation-report.md
@@ -1,0 +1,53 @@
+# Implementation Report: #200 anti-AI phrase classifier
+
+## Summary
+
+Pallets/flask PR #6019 was closed by maintainer davidism (MEMBER) with:
+
+> "Happy to update this, but please do not use genAI to generate or submit a PR."
+
+This is a polite-but-firm anti-AI policy stated in a PR comment. The existing `hostile_classifier` (#178) matches only openly hostile language (`fuck off`, `spammer`, `stop opening prs`). The polite phrasing here didn't match anything — auto-detection missed it. The operator had to manually blacklist with `source="policy"` after reading the comment.
+
+This PR adds a parallel `anti_ai` classifier so future cases get caught automatically. Distinct from `hostile` because the text class is different (rejection-with-civility vs. abuse), and `source="anti_ai"` lets the metrics dashboard distinguish.
+
+## Changes
+
+### `src/gh_link_auditor/hostile_classifier.py`
+
+- New `ANTI_AI_PHRASES` tuple (20 entries). Seed from real maintainer language: `do not use genai`, `please don't use ai`, `no ai-generated`, `no llm`, `no automated pr`, `don't automate`, etc. Bias: false negatives over false positives (same as hostile).
+- New `is_anti_ai_text(body) -> bool`. Mirrors `is_hostile_text`. Case-insensitive substring match.
+- Module docstring updated to mention #200.
+
+### `src/gh_link_auditor/pr_tracker.py`
+
+- New `_find_anti_ai_comments(owner, repo, pr_number) -> list[dict]`. Mirrors `_find_hostile_comments`: maintainer-filter, oldest-first sort, swallow-API-failure.
+- `refresh_pr_outcomes` updated: after the hostile-check, if no hostile hits, also try anti-AI. On match, blacklist with `source="anti_ai"` and a reason linking to the offending comment URL.
+
+The else-branch ensures we don't double-blacklist when a comment is both hostile AND anti-AI (rare, but possible). Hostile wins (more severe signal).
+
+### Tests
+
+- `tests/unit/test_hostile_classifier.py` — new `TestIsAntiAiText` class (8 tests) + 1 new constant-shape test. Covers clean text, empty, None, the real pallets/flask comment, case-insensitivity, every phrase hits, and orthogonality with `is_hostile_text`.
+- `tests/unit/test_pr_tracker.py` — new `TestFindAntiAiComments` class (4 tests) + `test_blacklists_on_anti_ai_comment` integration test using the actual pallets/flask wording.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `src/gh_link_auditor/hostile_classifier.py` | `ANTI_AI_PHRASES` + `is_anti_ai_text` |
+| `src/gh_link_auditor/pr_tracker.py` | `_find_anti_ai_comments` + integration in `refresh_pr_outcomes` |
+| `tests/unit/test_hostile_classifier.py` | new TestIsAntiAiText (8 tests) + constant-shape |
+| `tests/unit/test_pr_tracker.py` | new TestFindAntiAiComments (4 tests) + integration (1 test) |
+| `docs/lld/active/LLD-200.md` | NEW design (concise) |
+
+## Test count
+
+`pytest --co -q` collects **1842 tests** post-change (was 1828, +14 net).
+
+## Operator impact
+
+Future audits where the maintainer responds with anti-AI language will auto-blacklist the repo without operator action. The `ghla blacklist stats` output now distinguishes between `hostile` (rude rejection) and `anti_ai` (polite policy rejection) sources, giving the operator clearer triage signal.
+
+## Companion to #178 and the closed-PR-scan gap (#201)
+
+#178 catches rude rejection. #200 catches polite rejection. Both still only fire on **open** PRs today — closed PRs aren't rescanned. That gap is tracked separately as #201 and would have caught the pallets/flask case in real time.

--- a/docs/reports/active/10200-test-report.md
+++ b/docs/reports/active/10200-test-report.md
@@ -1,0 +1,32 @@
+# Test Report: #200 anti-AI phrase classifier
+
+## Local verification
+
+`poetry run python -m pytest --timeout=120 -q` → **1842 passed, 1 skipped**.
+
+Pre-change baseline: 1828. Net +14 (8 in `TestIsAntiAiText`, 4 in `TestFindAntiAiComments`, 1 integration test in `TestRefreshPrOutcomes`, 1 new constant-shape test).
+
+## RED → GREEN
+
+The new tests failed with `ImportError: cannot import name 'is_anti_ai_text' / 'ANTI_AI_PHRASES'` before the classifier was added. After landing the phrase list + helper + `_find_anti_ai_comments` + `refresh_pr_outcomes` integration, all 75 tests in `test_hostile_classifier.py` + `test_pr_tracker.py` pass in 5.5s.
+
+## Real-world coverage
+
+The integration test (`test_blacklists_on_anti_ai_comment`) uses davidism's exact wording from pallets/flask #6019 — "Happy to update this, but please do not use genAI to generate or submit a PR." — and asserts the resulting blacklist row has `source="anti_ai"`. If we'd had this classifier yesterday, the operator wouldn't have needed to blacklist manually.
+
+## Lint + format
+
+`ruff check . && ruff format .` clean.
+
+## Coverage
+
+- `is_anti_ai_text`: every phrase hits, clean-text/None/empty paths, case-insensitivity, orthogonality with `is_hostile_text` (both directions). 8 tests.
+- `_find_anti_ai_comments`: empty / non-maintainer / hit / API-failure swallow. 4 tests.
+- `refresh_pr_outcomes` integration: 1 test confirming the full flow inserts the right blacklist row with the right source.
+
+≥95% on changed lines.
+
+## Out of scope
+
+- Closed-PR scanning (tracked as #201) — anti-AI detection still only fires on open PRs. The pallets/flask comment came after PR close.
+- Surfacing `anti_ai` in `ghla metrics campaign` dashboard with a friendly label.

--- a/src/gh_link_auditor/hostile_classifier.py
+++ b/src/gh_link_auditor/hostile_classifier.py
@@ -1,9 +1,9 @@
-"""Hostile-comment classifier for maintainer responses on PRs.
+"""Maintainer-comment classifiers for hostile and anti-AI signals.
 
-Tight, conservative phrase list. Bias: false negatives over false positives —
-mis-blacklisting a friendly maintainer is worse than missing a hostile one.
+Tight, conservative phrase lists. Bias: false negatives over false positives —
+mis-blacklisting a friendly maintainer is worse than missing one.
 
-See LLD-178 for the design and why the list is what it is.
+See LLD-178 (hostile) and #200 (anti-AI) for the design.
 """
 
 from __future__ import annotations
@@ -25,6 +25,31 @@ HOSTILE_PHRASES: tuple[str, ...] = (
     "block this account",
 )
 
+ANTI_AI_PHRASES: tuple[str, ...] = (
+    # Seed list from real maintainer rejections (pallets/flask #6019, davidism:
+    # "Happy to update this, but please do not use genAI to generate or submit a PR.")
+    "do not use genai",
+    "do not use ai",
+    "don't use genai",
+    "don't use ai",
+    "please don't use ai",
+    "please do not use ai",
+    "no ai-generated",
+    "no ai generated",
+    "ai-generated pr",
+    "ai generated pr",
+    "no llm",
+    "don't use llm",
+    "no bot pr",
+    "no bot prs",
+    "no automated pr",
+    "no automated prs",
+    "don't automate",
+    "do not automate",
+    "no ai contributions",
+    "no ai-assisted",
+)
+
 MAINTAINER_ASSOCIATIONS: frozenset[str] = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 
 
@@ -34,6 +59,19 @@ def is_hostile_text(body: str | None) -> bool:
         return False
     lower = body.lower()
     return any(phrase in lower for phrase in HOSTILE_PHRASES)
+
+
+def is_anti_ai_text(body: str | None) -> bool:
+    """True if any anti-AI phrase appears in the comment body (case-insensitive).
+
+    Polite-but-firm rejection class. Distinct from hostile (#178) because the
+    text is typically not abusive — the signal is "this maintainer doesn't
+    want AI-generated PRs", not "this maintainer is rude". See #200.
+    """
+    if not body:
+        return False
+    lower = body.lower()
+    return any(phrase in lower for phrase in ANTI_AI_PHRASES)
 
 
 def is_maintainer_comment(author_association: str | None) -> bool:

--- a/src/gh_link_auditor/pr_tracker.py
+++ b/src/gh_link_auditor/pr_tracker.py
@@ -142,6 +142,28 @@ def _find_hostile_comments(owner: str, repo: str, pr_number: int) -> list[dict]:
     return hits
 
 
+def _find_anti_ai_comments(owner: str, repo: str, pr_number: int) -> list[dict]:
+    """Return maintainer-authored anti-AI-policy comments on a PR, oldest-first.
+
+    Mirrors :func:`_find_hostile_comments` but for the polite-but-firm
+    rejection class (#200). Same maintainer-filter; same oldest-first sort;
+    same swallow-on-failure behavior.
+    """
+    from gh_link_auditor.hostile_classifier import is_anti_ai_text, is_maintainer_comment
+
+    try:
+        comments = _fetch_pr_comments(owner, repo, pr_number)
+    except RuntimeError:
+        logger.warning("Failed to fetch comments for %s/%s#%d", owner, repo, pr_number)
+        return []
+
+    hits = [
+        c for c in comments if is_maintainer_comment(c.get("author_association")) and is_anti_ai_text(c.get("body"))
+    ]
+    hits.sort(key=lambda c: c.get("created_at") or "")
+    return hits
+
+
 def _check_maintainer_fixed(
     owner: str,
     repo: str,
@@ -259,6 +281,16 @@ def refresh_pr_outcomes(db_path: Path) -> list[PROutcome]:
                         source="hostile",
                     )
                     logger.info("Auto-blacklisted (hostile): %s", repo_url)
+                else:
+                    anti_ai = _find_anti_ai_comments(owner, repo, pr_number)
+                    if anti_ai:
+                        first = anti_ai[0]
+                        udb.add_to_blacklist(
+                            repo_url=repo_url,
+                            reason=f"Anti-AI policy comment from maintainer: {first.get('html_url', '?')}",
+                            source="anti_ai",
+                        )
+                        logger.info("Auto-blacklisted (anti_ai): %s", repo_url)
 
             if new_status == outcome.status:
                 # Still open — check for unresponsive timeout

--- a/tests/unit/test_hostile_classifier.py
+++ b/tests/unit/test_hostile_classifier.py
@@ -6,8 +6,10 @@ See LLD-178 for the classifier design and the conservative phrase list.
 from __future__ import annotations
 
 from gh_link_auditor.hostile_classifier import (
+    ANTI_AI_PHRASES,
     HOSTILE_PHRASES,
     MAINTAINER_ASSOCIATIONS,
+    is_anti_ai_text,
     is_hostile_text,
     is_maintainer_comment,
 )
@@ -88,3 +90,40 @@ class TestConstants:
 
     def test_no_empty_phrases(self) -> None:
         assert all(p and p == p.lower() for p in HOSTILE_PHRASES)
+
+    def test_no_empty_anti_ai_phrases(self) -> None:
+        assert all(p and p == p.lower() for p in ANTI_AI_PHRASES)
+
+
+class TestIsAntiAiText:
+    """`is_anti_ai_text` returns True iff an anti-AI phrase appears (#200)."""
+
+    def test_clean_text_is_not_anti_ai(self) -> None:
+        assert is_anti_ai_text("Thanks for the PR! Merging.") is False
+
+    def test_empty_string_is_not_anti_ai(self) -> None:
+        assert is_anti_ai_text("") is False
+
+    def test_none_is_not_anti_ai(self) -> None:
+        assert is_anti_ai_text(None) is False
+
+    def test_pallets_flask_rejection_text(self) -> None:
+        """Real-world: davidism's pallets/flask #6019 comment hits."""
+        body = "Happy to update this, but please do not use genAI to generate or submit a PR."
+        assert is_anti_ai_text(body) is True
+
+    def test_case_insensitive(self) -> None:
+        assert is_anti_ai_text("NO AI-GENERATED PR PLEASE") is True
+
+    def test_each_phrase_hits(self) -> None:
+        for phrase in ANTI_AI_PHRASES:
+            assert is_anti_ai_text(phrase) is True, f"phrase missed: {phrase!r}"
+            assert is_anti_ai_text(f"prefix {phrase} suffix") is True
+
+    def test_hostile_text_is_not_anti_ai(self) -> None:
+        """Bias: anti-AI and hostile are disjoint signals."""
+        assert is_anti_ai_text("fuck off") is False
+
+    def test_anti_ai_text_is_not_hostile(self) -> None:
+        """Bias: anti-AI text doesn't trigger the rude classifier."""
+        assert is_hostile_text("please do not use AI to generate PRs") is False

--- a/tests/unit/test_pr_tracker.py
+++ b/tests/unit/test_pr_tracker.py
@@ -292,6 +292,58 @@ class TestFindHostileComments:
             assert _find_hostile_comments("org", "repo", 1) == []
 
 
+class TestFindAntiAiComments:
+    """Tests for _find_anti_ai_comments() — issue #200."""
+
+    def test_no_comments_returns_empty(self) -> None:
+        from gh_link_auditor.pr_tracker import _find_anti_ai_comments
+
+        with patch("gh_link_auditor.pr_tracker._fetch_pr_comments", return_value=[]):
+            assert _find_anti_ai_comments("org", "repo", 1) == []
+
+    def test_non_maintainer_anti_ai_is_ignored(self) -> None:
+        from gh_link_auditor.pr_tracker import _find_anti_ai_comments
+
+        comments = [
+            {
+                "id": 1,
+                "body": "please do not use genAI to generate or submit a PR",
+                "html_url": "u/1",
+                "author_association": "CONTRIBUTOR",
+                "created_at": "2026-04-01T00:00:00Z",
+            }
+        ]
+        with patch("gh_link_auditor.pr_tracker._fetch_pr_comments", return_value=comments):
+            assert _find_anti_ai_comments("org", "repo", 1) == []
+
+    def test_pallets_style_polite_rejection_caught(self) -> None:
+        """Real-world: davidism's pallets/flask #6019 maintainer comment."""
+        from gh_link_auditor.pr_tracker import _find_anti_ai_comments
+
+        comments = [
+            {
+                "id": 99,
+                "body": "Happy to update this, but please do not use genAI to generate or submit a PR.",
+                "html_url": "https://github.com/pallets/flask/pull/6019#issuecomment-99",
+                "author_association": "MEMBER",
+                "created_at": "2026-05-13T14:29:55Z",
+            }
+        ]
+        with patch("gh_link_auditor.pr_tracker._fetch_pr_comments", return_value=comments):
+            hits = _find_anti_ai_comments("pallets", "flask", 6019)
+        assert len(hits) == 1
+        assert hits[0]["id"] == 99
+
+    def test_swallows_api_failure(self) -> None:
+        from gh_link_auditor.pr_tracker import _find_anti_ai_comments
+
+        with patch(
+            "gh_link_auditor.pr_tracker._fetch_pr_comments",
+            side_effect=RuntimeError("rate limited"),
+        ):
+            assert _find_anti_ai_comments("org", "repo", 1) == []
+
+
 class TestRefreshPrOutcomes:
     """Tests for refresh_pr_outcomes()."""
 
@@ -537,6 +589,49 @@ class TestRefreshPrOutcomes:
         try:
             entries = udb.get_blacklist()
             assert len([e for e in entries if e.repo_url == "https://github.com/org/repo"]) == 1
+        finally:
+            udb.close()
+
+    def test_blacklists_on_anti_ai_comment(self, tmp_path: Path) -> None:
+        """Issue #200: anti-AI maintainer comment auto-blacklists with source=anti_ai."""
+        from gh_link_auditor.unified_db import UnifiedDatabase
+
+        db_path = tmp_path / "metrics.db"
+        _seed_db(
+            db_path,
+            [
+                _make_outcome(
+                    pr_url="https://github.com/pallets/flask/pull/6019", repo_full_name="pallets/flask", status="open"
+                )
+            ],
+        )
+
+        still_open = {"state": "open", "merged": False, "merged_at": None, "closed_at": None}
+        anti_ai_comments = [
+            {
+                "id": 99,
+                "body": "Happy to update this, but please do not use genAI to generate or submit a PR.",
+                "html_url": "https://github.com/pallets/flask/pull/6019#issuecomment-99",
+                "author_association": "MEMBER",
+                "created_at": "2026-05-13T14:29:55Z",
+            }
+        ]
+
+        with (
+            patch("gh_link_auditor.pr_tracker._fetch_pr_status", return_value=still_open),
+            patch("gh_link_auditor.pr_tracker._fetch_pr_comments", return_value=anti_ai_comments),
+        ):
+            refresh_pr_outcomes(db_path)
+
+        udb = UnifiedDatabase(db_path)
+        try:
+            entries = udb.get_blacklist()
+            anti_ai_entries = [e for e in entries if e.repo_url == "https://github.com/pallets/flask"]
+            assert len(anti_ai_entries) == 1
+            assert "anti-ai" in anti_ai_entries[0].reason.lower() or "policy" in anti_ai_entries[0].reason.lower()
+            # source should be "anti_ai" in the underlying row.
+            by_source = udb.get_blacklist_by_source()
+            assert by_source.get("anti_ai", 0) >= 1
         finally:
             udb.close()
 


### PR DESCRIPTION
## Summary

Pallets/flask PR #6019 was closed with: *"Happy to update this, but please do not use genAI to generate or submit a PR."* Polite-but-firm anti-AI policy. Our `hostile_classifier` (#178) only matches rude language and missed it. Operator had to manually blacklist.

This PR mirrors the hostile classifier for the anti-AI class.

- ``ANTI_AI_PHRASES`` (20 entries) + ``is_anti_ai_text()`` in `hostile_classifier.py`
- ``_find_anti_ai_comments()`` in `pr_tracker.py`
- ``refresh_pr_outcomes`` checks both; hostile wins if both hit; otherwise anti-AI blacklists with ``source="anti_ai"``

Distinct source value separates the two signals in ``ghla blacklist stats``.

See [LLD-200](docs/lld/active/LLD-200.md).

## Test plan

- [x] 8 ``TestIsAntiAiText`` tests (each phrase + clean + None + case + orthogonality)
- [x] 4 ``TestFindAntiAiComments`` tests
- [x] 1 integration test using davidism's actual pallets/flask wording
- [x] Full suite: 1842 pass, 1 skip
- [x] ``ruff check`` + ``ruff format`` clean

Companion to #178 and still-open #201 (scan closed PRs too).

Closes #200