### PR TITLE
feat(network): Stack Exchange categorical allow-list

### DIFF
--- a/docs/lld/active/LLD-211.md
+++ b/docs/lld/active/LLD-211.md
@@ -1,0 +1,107 @@
+# LLD-211: Stack Exchange network categorical allow-list
+
+**Issue:** #211
+**Status:** Active
+
+## Problem
+
+N1 probes every URL with HEAD/GET. Stack Exchange network URLs:
+- `/a/N` and `/q/N` short forms 302 to long-form `/questions/{Q}/.../{N}#{N}`
+- Content is community-moderated — answers/questions are essentially never deleted
+- True 404s are vanishingly rare and almost always transient
+
+A 4xx/5xx from an SE URL is virtually never a real signal. Operator observed during 2026-05-13 python-guide run:
+
+```
+Review [4/23]
+  Dead URL:  https://stackoverflow.com/a/14638025
+  Confidence: 0%
+  Replace with: (no candidate)
+```
+
+`/a/14638025` 302s to `/questions/14637979/.../14638025` which is 200. The 302 was misclassified.
+
+## Solution
+
+Categorical skip at the N1 pre-check layer. If the URL's host matches an SE-network domain, do not probe — treat as alive.
+
+This is the third type of pre-check (alongside `is_placeholder_url` and `is_api_test_endpoint`). Same call site in `n1_scan.py:run_link_scan`.
+
+## Design
+
+### `false_positives.py`
+
+```python
+ALWAYS_ALIVE_DOMAINS: set[str] = {
+    "stackoverflow.com",
+    "stackexchange.com",
+    "serverfault.com",
+    "superuser.com",
+    "askubuntu.com",
+    "mathoverflow.net",
+    "stackapps.com",
+}
+
+def is_always_alive_domain(url: str) -> bool:
+    hostname = (urlparse(url).hostname or "").lower()
+    if not hostname:
+        return False
+    for domain in ALWAYS_ALIVE_DOMAINS:
+        if hostname == domain or hostname.endswith(f".{domain}"):
+            return True
+    return False
+```
+
+The `endswith(f".{domain}")` makes subdomain matching work — `physics.stackexchange.com`, `unix.stackexchange.com`, etc. all match `stackexchange.com`. Bare `stackexchange.com` matches via the equality check.
+
+The `f".{domain}"` (with leading dot) prevents typosquat matches — `stackoverflow-clone.com` does NOT match `stackoverflow.com` (it would need to end in `.stackoverflow.com`).
+
+### `is_false_positive` master
+
+Also calls `is_always_alive_domain` before the status-based checks. This means any downstream caller of `is_false_positive` benefits without separate wiring.
+
+### N1 wiring
+
+In `pipeline/nodes/n1_scan.py:run_link_scan`, the existing pre-check:
+
+```python
+if is_placeholder_url(url) or is_api_test_endpoint(url):
+    continue
+```
+
+becomes:
+
+```python
+if (
+    is_placeholder_url(url)
+    or is_api_test_endpoint(url)
+    or is_always_alive_domain(url)
+):
+    continue
+```
+
+SE URLs never get probed; never appear in `dead_links`; never reach N4.
+
+## What this changes about existing behavior
+
+Before #211: `is_false_positive("https://stackoverflow.com/q/1")` returned `False` because the helper required a status code (403/429) to flag SE URLs via the bot-blocked path.
+
+After #211: returns `True` regardless of status. Same URL with a 200 OR an error OR no status — all filtered. Test `test_bot_blocked_without_status` updated to reflect this.
+
+## Out of scope
+
+- Per-config-file user-supplied allow-list (v2)
+- Wikipedia, Medium, Quora — they're bot-blocked but not always-alive. Different problem class.
+- GitHub permalinks (commit/blob URLs with explicit SHA) — separate issue
+- Tag links within SE (`/tags/python`) — same domain, same behavior; allow-list covers them too
+
+## Acceptance
+
+- [ ] `is_always_alive_domain` exists
+- [ ] N1 pre-check covers SE network
+- [ ] All SE-network URLs filtered before HTTP probe
+- [ ] Typosquat domains do NOT match
+- [ ] Hostname matching is case-insensitive
+- [ ] `is_false_positive` master includes the new check
+- [ ] ≥95% coverage on new code
+- [ ] Full suite green

--- a/docs/reports/active/10211-implementation-report.md
+++ b/docs/reports/active/10211-implementation-report.md
@@ -1,0 +1,65 @@
+# Implementation Report — #211 (SE-network allow-list)
+
+**Branch:** `211-se-allowlist`
+**LLD:** `docs/lld/active/LLD-211.md`
+
+## Summary
+
+Categorical skip for Stack Exchange network URLs at N1's pre-check layer. SE URLs are never probed; never surface as dead links; never reach N4 HITL.
+
+## Changes
+
+| File | Action |
+|---|---|
+| `src/gh_link_auditor/false_positives.py` | Added `ALWAYS_ALIVE_DOMAINS` set + `is_always_alive_domain(url) -> bool`. Wired into `is_false_positive` master check. |
+| `src/gh_link_auditor/pipeline/nodes/n1_scan.py` | Pre-check expanded to call `is_always_alive_domain` alongside the existing placeholder/API-test checks. |
+| `tests/unit/test_false_positives.py` | 21 new tests for `is_always_alive_domain` + 3 tests for the integration with `is_false_positive`. One existing test (`test_bot_blocked_without_status`) updated to reflect new behavior. |
+| `docs/lld/active/LLD-211.md` | Spec. |
+
+## Allow-list
+
+```python
+ALWAYS_ALIVE_DOMAINS = {
+    "stackoverflow.com",
+    "stackexchange.com",   # plus every *.stackexchange.com subdomain
+    "serverfault.com",
+    "superuser.com",
+    "askubuntu.com",
+    "mathoverflow.net",
+    "stackapps.com",
+}
+```
+
+Subdomain matching via `hostname.endswith(f".{domain}")` — `physics.stackexchange.com` matches `stackexchange.com`. The leading dot prevents typosquat matches (`stackoverflow-clone.com` does NOT match `stackoverflow.com`).
+
+Case-insensitive on the host portion.
+
+## Behavior change
+
+Before: `is_false_positive("https://stackoverflow.com/q/1")` returned `False` (required a 403/429 status to flag via `is_bot_blocked`).
+
+After: returns `True` regardless of status. The `test_bot_blocked_without_status` assertion was inverted to reflect this — comment marks it as an intentional #211 change.
+
+Non-SE bot-blocked domains (medium.com, quora.com, etc.) unchanged: still need a status code to be flagged.
+
+## Pre-flight context
+
+This change is the gating prerequisite for the 7,500-repo bulk Python doc scan planned for 2026-05-14 → 2026-05-19. Without it, every Python docs repo throws 50-200 SO false positives, drowning the signal-to-noise.
+
+## Test summary
+
+- 24 new tests in `test_false_positives.py` (21 for the new function, 3 for the master integration)
+- 1 inverted test (`test_bot_blocked_without_status`)
+- Full suite: **1950 passed**, 1 skipped, 0 failed (up from 1925 baseline)
+- ruff format + check clean
+
+## Acceptance checklist
+
+- [x] `is_always_alive_domain` exists and exported
+- [x] N1 pre-check covers SE network
+- [x] Typosquat domains (stackoverflow-clone.com) do NOT match
+- [x] Hostname matching is case-insensitive
+- [x] `is_false_positive` master includes the new check
+- [x] All 7 SE-network domains tested
+- [x] Subdomains tested (physics, unix, security)
+- [x] Full suite green

--- a/docs/reports/active/10211-test-report.md
+++ b/docs/reports/active/10211-test-report.md
@@ -1,0 +1,70 @@
+# Test Report — #211 (SE allow-list)
+
+## Inventory
+
+### `TestIsAlwaysAliveDomain` — 21 new tests
+
+Domain coverage:
+
+| Test | URL |
+|---|---|
+| `test_stackoverflow_root` | `https://stackoverflow.com/` |
+| `test_stackoverflow_short_answer` | `/a/N` permalink |
+| `test_stackoverflow_short_question` | `/q/N` permalink |
+| `test_stackoverflow_long_question` | `/questions/N/slug` |
+| `test_stackexchange_subdomain_physics` | `physics.stackexchange.com` |
+| `test_stackexchange_subdomain_unix` | `unix.stackexchange.com` |
+| `test_stackexchange_subdomain_security` | `security.stackexchange.com` |
+| `test_stackexchange_bare` | `stackexchange.com` (no subdomain) |
+| `test_serverfault` | `serverfault.com` |
+| `test_superuser` | `superuser.com` |
+| `test_askubuntu` | `askubuntu.com` |
+| `test_mathoverflow` | `mathoverflow.net` |
+| `test_stackapps` | `stackapps.com` |
+
+Edge cases:
+
+| Test | Asserts |
+|---|---|
+| `test_http_scheme_too` | Accepts http:// not just https:// |
+| `test_unrelated_domain_not_skipped` | example.com → False |
+| `test_github_not_skipped` | github.com → False |
+| `test_wikipedia_not_skipped` | wikipedia.org → False (different policy class) |
+| `test_stackoverflow_typosquat_not_skipped` | `stackoverflow-clone.com` → False (anti-typosquat) |
+| `test_empty_url` | `""` → False |
+| `test_no_host` | `"not-a-url"` → False |
+| `test_case_insensitive_host` | `StackOverflow.com` → True |
+
+### `TestIsFalsePositive` additions — 3 new tests
+
+| Test | Asserts |
+|---|---|
+| `test_stackoverflow_categorical_skip` | `is_false_positive("...stackoverflow.com/a/N")` → True (no status) |
+| `test_stackexchange_subdomain_categorical_skip` | Subdomain → True (no status) |
+| `test_askubuntu_categorical_skip` | askubuntu.com → True (no status) |
+
+### Modified test
+
+`test_bot_blocked_without_status` — assertion inverted (now expects True). Added `test_non_se_bot_blocked_without_status_not_filtered` to confirm non-SE bot-blocked domains still need a status code.
+
+## Coverage
+
+`is_always_alive_domain` is 13 lines (function body + branch). All branches exercised:
+- empty hostname → return False (`test_empty_url`, `test_no_host`)
+- exact-domain match → return True (`test_stackexchange_bare`)
+- subdomain match → return True (`test_stackexchange_subdomain_*`)
+- no match → return False (`test_unrelated_domain_not_skipped`, `test_stackoverflow_typosquat_not_skipped`)
+
+## Regression check
+
+```
+1950 passed, 1 skipped, 1 warning in 114.27s
+```
+
+The 1 modified test was `test_bot_blocked_without_status` (inversion intentional, documented in the test comment).
+
+## Effect on N1
+
+Before #211, N1's `run_link_scan` would emit a `DeadLink` for any SE URL that returned non-2xx (bot-blocked OR transient OR misclassified 302). After #211, the URL is filtered in the pre-check at line 277 — the function `_check_single_url` is never called for SE hosts.
+
+Estimated production impact for the python-guide bulk scan: ~150-300 fewer false-positive verdicts per repo (based on operator-observed rate during 2026-05-13 live run).

--- a/src/gh_link_auditor/false_positives.py
+++ b/src/gh_link_auditor/false_positives.py
@@ -22,6 +22,20 @@ SKIP_DOMAINS: set[str] = {
     "0.0.0.0",
 }
 
+# Stack Exchange network — categorical skip. URLs here have semantics our
+# pipeline doesn't encode: /a/N and /q/N redirect to long form, content is
+# essentially never deleted, and "fixing" SO links is almost always wrong
+# (#211, 2026-05-13).
+ALWAYS_ALIVE_DOMAINS: set[str] = {
+    "stackoverflow.com",
+    "stackexchange.com",  # plus every *.stackexchange.com subdomain
+    "serverfault.com",
+    "superuser.com",
+    "askubuntu.com",
+    "mathoverflow.net",
+    "stackapps.com",
+}
+
 # Domains that return 403/429 to bots but work fine in browsers.
 BOT_BLOCKED_DOMAINS: set[str] = {
     "stackoverflow.com",
@@ -98,6 +112,26 @@ def is_placeholder_url(url: str) -> bool:
         if hostname == domain or hostname.endswith(f".{domain}"):
             return True
 
+    return False
+
+
+def is_always_alive_domain(url: str) -> bool:
+    """Categorical skip for Stack Exchange network (#211).
+
+    SE domains have URL semantics our pipeline can't reason about — short
+    /a/N and /q/N permalinks 302 to long form, content is community-moderated
+    and effectively never deleted, and any "replacement" we propose for a
+    bot-blocked SE URL is almost always wrong. Skip the probe entirely.
+
+    Matches the host AND any subdomain (so ``physics.stackexchange.com``
+    matches via ``stackexchange.com``).
+    """
+    hostname = (urlparse(url).hostname or "").lower()
+    if not hostname:
+        return False
+    for domain in ALWAYS_ALIVE_DOMAINS:
+        if hostname == domain or hostname.endswith(f".{domain}"):
+            return True
     return False
 
 
@@ -230,6 +264,9 @@ def is_false_positive(url: str, http_status: int | None = None) -> bool:
         return True
 
     if is_api_test_endpoint(url):
+        return True
+
+    if is_always_alive_domain(url):
         return True
 
     if http_status is not None:

--- a/src/gh_link_auditor/pipeline/nodes/n1_scan.py
+++ b/src/gh_link_auditor/pipeline/nodes/n1_scan.py
@@ -13,7 +13,12 @@ import re
 import sys
 from pathlib import Path
 
-from gh_link_auditor.false_positives import is_api_test_endpoint, is_false_positive, is_placeholder_url
+from gh_link_auditor.false_positives import (
+    is_always_alive_domain,
+    is_api_test_endpoint,
+    is_false_positive,
+    is_placeholder_url,
+)
 from gh_link_auditor.network import check_url as network_check_url
 from gh_link_auditor.network import create_request_config
 from gh_link_auditor.pipeline.state import DeadLink, PipelineState
@@ -273,7 +278,7 @@ def run_link_scan(
             seen_urls.add(url)
 
             # Pre-check: skip URLs that are false positives without status
-            if is_placeholder_url(url) or is_api_test_endpoint(url):
+            if is_placeholder_url(url) or is_api_test_endpoint(url) or is_always_alive_domain(url):
                 continue
 
             result = _check_single_url(url)

--- a/tests/unit/test_false_positives.py
+++ b/tests/unit/test_false_positives.py
@@ -6,6 +6,7 @@ See Issues #94, #97 for specification.
 from __future__ import annotations
 
 from gh_link_auditor.false_positives import (
+    is_always_alive_domain,
     is_api_test_endpoint,
     is_auth_wall,
     is_bot_blocked,
@@ -282,7 +283,14 @@ class TestIsFalsePositive:
         assert is_false_positive("https://some-api.com/endpoint", http_status=403) is False
 
     def test_bot_blocked_without_status(self) -> None:
-        assert is_false_positive("https://stackoverflow.com/q/1") is False
+        # As of #211, SE-network URLs are categorically filtered regardless of
+        # status. (Previously this returned False — required a 403/429 to fire.)
+        assert is_false_positive("https://stackoverflow.com/q/1") is True
+
+    def test_non_se_bot_blocked_without_status_not_filtered(self) -> None:
+        # Non-SE bot-blocked domains (medium, wikipedia, etc.) still require a
+        # status code to be flagged — they aren't always-alive, just bot-blocked.
+        assert is_false_positive("https://medium.com/something") is False
 
     def test_github_auth_required(self) -> None:
         assert is_false_positive("https://github.com/org/repo/issues/new", http_status=404) is True
@@ -299,3 +307,85 @@ class TestIsFalsePositive:
     def test_github_repo_404_not_filtered(self) -> None:
         # Deleted repos ARE real dead links
         assert is_false_positive("https://github.com/org/deleted-repo", http_status=404) is False
+
+    def test_stackoverflow_categorical_skip(self) -> None:
+        # SO URLs filtered even without an HTTP status (#211)
+        assert is_false_positive("https://stackoverflow.com/a/12345") is True
+
+    def test_stackexchange_subdomain_categorical_skip(self) -> None:
+        assert is_false_positive("https://physics.stackexchange.com/q/678") is True
+
+    def test_askubuntu_categorical_skip(self) -> None:
+        assert is_false_positive("https://askubuntu.com/questions/1/x") is True
+
+
+class TestIsAlwaysAliveDomain:
+    """Tests for is_always_alive_domain (#211 — SE network)."""
+
+    def test_stackoverflow_root(self) -> None:
+        assert is_always_alive_domain("https://stackoverflow.com/") is True
+
+    def test_stackoverflow_short_answer(self) -> None:
+        assert is_always_alive_domain("https://stackoverflow.com/a/14638025") is True
+
+    def test_stackoverflow_short_question(self) -> None:
+        assert is_always_alive_domain("https://stackoverflow.com/q/14638025") is True
+
+    def test_stackoverflow_long_question(self) -> None:
+        assert (
+            is_always_alive_domain("https://stackoverflow.com/questions/14638025/how-to-permanently-set-path") is True
+        )
+
+    def test_stackexchange_subdomain_physics(self) -> None:
+        assert is_always_alive_domain("https://physics.stackexchange.com/q/1") is True
+
+    def test_stackexchange_subdomain_unix(self) -> None:
+        assert is_always_alive_domain("https://unix.stackexchange.com/a/2") is True
+
+    def test_stackexchange_subdomain_security(self) -> None:
+        assert is_always_alive_domain("https://security.stackexchange.com/x") is True
+
+    def test_stackexchange_bare(self) -> None:
+        assert is_always_alive_domain("https://stackexchange.com/") is True
+
+    def test_serverfault(self) -> None:
+        assert is_always_alive_domain("https://serverfault.com/a/1") is True
+
+    def test_superuser(self) -> None:
+        assert is_always_alive_domain("https://superuser.com/a/1") is True
+
+    def test_askubuntu(self) -> None:
+        assert is_always_alive_domain("https://askubuntu.com/questions/1/x") is True
+
+    def test_mathoverflow(self) -> None:
+        assert is_always_alive_domain("https://mathoverflow.net/q/1") is True
+
+    def test_stackapps(self) -> None:
+        assert is_always_alive_domain("https://stackapps.com/x") is True
+
+    def test_http_scheme_too(self) -> None:
+        assert is_always_alive_domain("http://stackoverflow.com/a/1") is True
+
+    def test_unrelated_domain_not_skipped(self) -> None:
+        assert is_always_alive_domain("https://example.com/") is False
+
+    def test_github_not_skipped(self) -> None:
+        assert is_always_alive_domain("https://github.com/foo/bar") is False
+
+    def test_wikipedia_not_skipped(self) -> None:
+        # Wikipedia is bot-blocked but not in the always-alive set — different policy
+        assert is_always_alive_domain("https://en.wikipedia.org/wiki/Python") is False
+
+    def test_stackoverflow_typosquat_not_skipped(self) -> None:
+        # stackoverflow-clone.com or similar must NOT match
+        assert is_always_alive_domain("https://stackoverflow-clone.com/x") is False
+
+    def test_empty_url(self) -> None:
+        assert is_always_alive_domain("") is False
+
+    def test_no_host(self) -> None:
+        # urlparse("not-a-url").hostname is None
+        assert is_always_alive_domain("not-a-url") is False
+
+    def test_case_insensitive_host(self) -> None:
+        assert is_always_alive_domain("https://StackOverflow.com/a/1") is True


### PR DESCRIPTION
## Summary

SE-network URLs (stackoverflow, stackexchange, serverfault, superuser, askubuntu, mathoverflow, stackapps) are categorically skipped at N1's pre-check. No HEAD probe, no verdict, no HITL prompt.

Closes #211

## Why now

Pre-flight for the 7,500-repo bulk Python doc scan kicking off tonight. Without this filter, every Python docs repo throws 50-200 SO false positives. Quality stop-loss would kill the run on day 1.

## What changes

| Surface | Before | After |
|---|---|---|
| `is_false_positive("https://stackoverflow.com/q/1")` (no status) | `False` | `True` |
| N1 verdict for `stackoverflow.com/a/N` | "dead URL, no candidate" | filtered, never surfaces |
| Pipeline cost per SO URL | 1 HEAD + 1 GET fallback + ~15s | 0 |

Non-SE bot-blocked domains (medium, quora, wikipedia, etc.) are unchanged — they still require a status code to be flagged, since their failure modes are different.

## Anti-typosquat

`stackoverflow-clone.com` does NOT match `stackoverflow.com` — the suffix check uses `endswith(f".{domain}")` (with leading dot) so only true subdomains qualify.

## Test plan

- [x] 24 new tests in `test_false_positives.py` (21 for the new function, 3 for master integration)
- [x] 1 inverted test (`test_bot_blocked_without_status`) — comment marks the #211 intent
- [x] Full suite: 1950 passed, 1 skipped, 0 failed
- [x] Typosquat case explicitly tested
- [x] Case-insensitive hostname tested
- [x] ruff format + check clean