### PR TITLE
fix(bulk-scan): rate limiting + GITHUB_TOKEN fallback

### DIFF
--- a/src/gh_link_auditor/bulk_scan/gh_client.py
+++ b/src/gh_link_auditor/bulk_scan/gh_client.py
@@ -1,0 +1,198 @@
+"""Rate-limit-aware GitHub REST API client for the bulk scan (#224).
+
+Wraps ``httpx.Client`` with three protections against secondary rate limits:
+
+1. **Inter-request throttle** — enforces a minimum delay between requests
+   (default 750ms = ~80 req/min, well under any documented GH limit).
+2. **Quota watermark** — when ``X-RateLimit-Remaining`` drops below a floor,
+   sleep until ``X-RateLimit-Reset``.
+3. **Retry on 429 / secondary rate limit** — honors ``Retry-After``, falls back
+   to exponential backoff up to 15 min. Max 5 retries.
+
+GitHub's secondary rate limit fires on burst patterns (many requests in a short
+window) even when the primary 5K/hr is far from exhausted. This is the one that
+took down the first 7500-repo run on 2026-05-14.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubRateLimitedClient:
+    """Sync httpx wrapper enforcing GH API rate-limit etiquette."""
+
+    def __init__(
+        self,
+        token: str | None = None,
+        *,
+        per_request_delay_s: float = 0.75,
+        low_watermark: int = 100,
+        max_retries: int = 5,
+        max_backoff_s: float = 900.0,
+        base_backoff_s: float = 2.0,
+        timeout_s: float = 30.0,
+    ) -> None:
+        headers: dict[str, str] = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "gh-link-auditor-bulk",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        self._client = httpx.Client(headers=headers, timeout=timeout_s)
+        self._per_request_delay = per_request_delay_s
+        self._low_watermark = low_watermark
+        self._max_retries = max_retries
+        self._max_backoff = max_backoff_s
+        self._base_backoff = base_backoff_s
+
+        self._last_request_t = 0.0
+        self._remaining: int | None = None
+        self._reset_at: datetime | None = None
+        # Telemetry
+        self.total_requests = 0
+        self.total_429s = 0
+        self.total_secondary_limits = 0
+        self.total_sleep_s = 0.0
+
+    # ------------------------------------------------------------------
+    # Public
+    # ------------------------------------------------------------------
+
+    def get(self, url: str, **kwargs: Any) -> httpx.Response:
+        """GET with full rate-limit machinery applied."""
+        return self._request("GET", url, **kwargs)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> GitHubRateLimitedClient:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        for attempt in range(self._max_retries + 1):
+            self._wait_for_quota()
+            self._wait_for_request_spacing()
+            r = self._client.request(method, url, **kwargs)
+            self._last_request_t = time.monotonic()
+            self.total_requests += 1
+            self._update_quota(r.headers)
+            if not self._is_rate_limited(r):
+                return r
+            self._record_rate_limit(r)
+            if attempt >= self._max_retries:
+                logger.warning(
+                    "max retries exhausted on %s — returning %d response",
+                    url,
+                    r.status_code,
+                )
+                return r
+            delay = self._compute_backoff(r, attempt)
+            logger.warning(
+                "rate-limited (%d) on %s — backing off %.1fs (attempt %d/%d)",
+                r.status_code,
+                url,
+                delay,
+                attempt + 1,
+                self._max_retries,
+            )
+            self.total_sleep_s += delay
+            time.sleep(delay)
+        # Unreachable — loop returns or sleeps then continues
+        raise RuntimeError("unreachable")
+
+    def _wait_for_quota(self) -> None:
+        """If remaining quota is below floor, sleep until reset."""
+        if self._remaining is None or self._remaining > self._low_watermark:
+            return
+        if self._reset_at is None:
+            return
+        now = datetime.now(timezone.utc)
+        sleep_s = (self._reset_at - now).total_seconds() + 1.0
+        if sleep_s <= 0:
+            return
+        logger.warning(
+            "quota low (%d remaining); sleeping %.0fs until reset",
+            self._remaining,
+            sleep_s,
+        )
+        self.total_sleep_s += sleep_s
+        time.sleep(sleep_s)
+
+    def _wait_for_request_spacing(self) -> None:
+        elapsed = time.monotonic() - self._last_request_t
+        if elapsed >= self._per_request_delay:
+            return
+        sleep_s = self._per_request_delay - elapsed
+        self.total_sleep_s += sleep_s
+        time.sleep(sleep_s)
+
+    def _update_quota(self, headers: httpx.Headers) -> None:
+        remaining = headers.get("X-RateLimit-Remaining")
+        if remaining is not None:
+            try:
+                self._remaining = int(remaining)
+            except ValueError:
+                pass
+        reset = headers.get("X-RateLimit-Reset")
+        if reset is not None:
+            try:
+                self._reset_at = datetime.fromtimestamp(int(reset), tz=timezone.utc)
+            except ValueError:
+                pass
+
+    def _is_rate_limited(self, r: httpx.Response) -> bool:
+        """True if the response indicates a primary OR secondary rate limit."""
+        if r.status_code == 429:
+            return True
+        if r.status_code == 403:
+            # Secondary rate limit: 403 with remaining>0 and body says so.
+            text = (r.text or "").lower()
+            if "secondary rate limit" in text or "abuse" in text:
+                return True
+            # Primary exhaustion: 403 with X-RateLimit-Remaining == 0
+            if self._remaining is not None and self._remaining == 0:
+                return True
+        return False
+
+    def _record_rate_limit(self, r: httpx.Response) -> None:
+        if r.status_code == 429:
+            self.total_429s += 1
+        else:
+            self.total_secondary_limits += 1
+
+    def _compute_backoff(self, r: httpx.Response, attempt: int) -> float:
+        """Prefer Retry-After header; else exponential + jitter."""
+        retry_after = r.headers.get("Retry-After")
+        if retry_after:
+            try:
+                delay = float(retry_after)
+                return min(delay, self._max_backoff)
+            except ValueError:
+                pass
+        # GH may also send `X-RateLimit-Reset` epoch when 403'd
+        if r.status_code == 403 and self._reset_at is not None:
+            now = datetime.now(timezone.utc)
+            delta = (self._reset_at - now).total_seconds() + 1.0
+            if delta > 0:
+                return min(delta, self._max_backoff)
+        # Exponential fallback: 2s, 4s, 8s, 16s, 32s ... capped at max_backoff
+        base = self._base_backoff * (2**attempt)
+        jitter = random.uniform(0, base * 0.25)
+        return min(base + jitter, self._max_backoff)

--- a/src/gh_link_auditor/bulk_scan/inventory.py
+++ b/src/gh_link_auditor/bulk_scan/inventory.py
@@ -89,8 +89,12 @@ def filter_url(url: str) -> bool:
     return True
 
 
-def _list_doc_files(client: httpx.Client, full_name: str) -> list[str]:
-    """One Git Trees API call → all doc files in the repo."""
+def _list_doc_files(client: Any, full_name: str) -> list[str]:
+    """One Git Trees API call → all doc files in the repo.
+
+    ``client`` may be either an ``httpx.Client`` or a
+    :class:`GitHubRateLimitedClient` — both expose ``.get(url, params=...)``.
+    """
     r = client.get(f"{_GH_API}/repos/{full_name}/git/trees/HEAD", params={"recursive": "1"})
     r.raise_for_status()
     tree = r.json().get("tree", [])
@@ -120,7 +124,7 @@ def _fetch_raw(client: httpx.Client, full_name: str, path: str) -> str | None:
 
 def inventory_repo(
     full_name: str,
-    api_client: httpx.Client,
+    api_client: Any,  # GitHubRateLimitedClient or httpx.Client (tests)
     raw_client: httpx.Client,
 ) -> dict[str, Any]:
     """Walk one repo. Returns ``{"doc_files": [...], "urls": [(url, file, line), ...]}``.
@@ -150,15 +154,29 @@ def inventory_repo(
     return {"doc_files": docs, "urls": urls}
 
 
-def build_api_client(token: str | None = None) -> httpx.Client:
-    headers: dict[str, str] = {
-        "Accept": "application/vnd.github+json",
-        "User-Agent": "gh-link-auditor-bulk",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return httpx.Client(headers=headers, timeout=30.0)
+def build_api_client(token: str | None = None) -> Any:
+    """Build the rate-limited GitHub REST client used by the bulk scan (#224).
+
+    Returns a :class:`GitHubRateLimitedClient` (compatible with the prior
+    ``httpx.Client`` interface — supports ``.get(url, params=...)`` and
+    ``.close()`` / context-manager use).
+
+    If ``token`` is not provided AND ``GITHUB_TOKEN`` is not in env, falls
+    back to ``gh auth token`` via :func:`resolve_github_token`. This is
+    critical for the bulk run — without auth, GitHub's anonymous rate limit
+    is **60 req/hr**, which trips the secondary rate limit immediately on
+    a 7500-repo sweep. The first 2026-05-14 fire failed for exactly this
+    reason: ``GITHUB_TOKEN`` was unset and the client was anonymous.
+    """
+    from gh_link_auditor.auth import resolve_github_token
+    from gh_link_auditor.bulk_scan.gh_client import GitHubRateLimitedClient
+
+    if not token:
+        try:
+            token = resolve_github_token()
+        except Exception:
+            token = None
+    return GitHubRateLimitedClient(token=token)
 
 
 def build_raw_client() -> httpx.Client:

--- a/tests/unit/bulk_scan/test_gh_client.py
+++ b/tests/unit/bulk_scan/test_gh_client.py
@@ -1,0 +1,295 @@
+"""Tests for the GitHubRateLimitedClient (#224 hotfix)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from gh_link_auditor.bulk_scan.gh_client import GitHubRateLimitedClient
+
+
+def _make_response(
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+    text: str = "",
+) -> MagicMock:
+    """Build a MagicMock that quacks like httpx.Response."""
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status_code
+    r.headers = httpx.Headers(headers or {})
+    r.text = text
+    return r
+
+
+def _make_client(**kwargs) -> GitHubRateLimitedClient:
+    """Tight-budget client for tests (no real sleeps)."""
+    defaults = {
+        "per_request_delay_s": 0.0,  # don't actually sleep between requests in tests
+        "low_watermark": 100,
+        "max_retries": 3,
+        "max_backoff_s": 1.0,
+        "base_backoff_s": 0.01,
+        "timeout_s": 5.0,
+    }
+    defaults.update(kwargs)
+    return GitHubRateLimitedClient(token="test-token", **defaults)
+
+
+class TestSuccessfulRequest:
+    def test_returns_200_immediately(self) -> None:
+        client = _make_client()
+        with patch.object(
+            client._client,
+            "request",
+            return_value=_make_response(200, {"X-RateLimit-Remaining": "4999"}),
+        ):
+            r = client.get("https://api.github.com/repos/x/y")
+        assert r.status_code == 200
+        assert client.total_requests == 1
+        assert client.total_429s == 0
+        client.close()
+
+    def test_updates_quota_from_headers(self) -> None:
+        client = _make_client()
+        reset_epoch = int((datetime.now(timezone.utc) + timedelta(hours=1)).timestamp())
+        with patch.object(
+            client._client,
+            "request",
+            return_value=_make_response(
+                200,
+                {
+                    "X-RateLimit-Remaining": "4321",
+                    "X-RateLimit-Reset": str(reset_epoch),
+                },
+            ),
+        ):
+            client.get("https://api.github.com/repos/x/y")
+        assert client._remaining == 4321
+        assert client._reset_at is not None
+        client.close()
+
+    def test_records_total_requests(self) -> None:
+        client = _make_client()
+        with patch.object(client._client, "request", return_value=_make_response(200)):
+            client.get("u1")
+            client.get("u2")
+            client.get("u3")
+        assert client.total_requests == 3
+        client.close()
+
+
+class TestRateLimit429:
+    def test_retries_on_429_then_succeeds(self) -> None:
+        client = _make_client(max_retries=3, base_backoff_s=0.0, per_request_delay_s=0.0)
+        responses = [
+            _make_response(429, {"Retry-After": "0"}),
+            _make_response(429, {"Retry-After": "0"}),
+            _make_response(200),
+        ]
+        with patch.object(client._client, "request", side_effect=responses):
+            r = client.get("u")
+        assert r.status_code == 200
+        assert client.total_429s == 2
+        assert client.total_requests == 3
+        client.close()
+
+    def test_returns_final_429_when_max_retries_exceeded(self) -> None:
+        client = _make_client(max_retries=2, base_backoff_s=0.0)
+        with patch.object(
+            client._client,
+            "request",
+            return_value=_make_response(429, {"Retry-After": "0"}),
+        ):
+            r = client.get("u")
+        assert r.status_code == 429
+        # 1 initial + 2 retries = 3 total
+        assert client.total_requests == 3
+        client.close()
+
+    def test_honors_retry_after_header(self) -> None:
+        client = _make_client(max_retries=1, base_backoff_s=10.0, max_backoff_s=1.0)
+        # Retry-After=0 means we go through both attempts immediately.
+        with (
+            patch.object(
+                client._client,
+                "request",
+                side_effect=[_make_response(429, {"Retry-After": "0"}), _make_response(200)],
+            ),
+            patch("time.sleep") as sleep_mock,
+        ):
+            r = client.get("u")
+        # First sleep call(s) are from per_request_delay or quota wait (=0 in test).
+        # Should have called sleep with 0.0 for Retry-After=0
+        assert r.status_code == 200
+        sleep_args = [c.args[0] for c in sleep_mock.call_args_list]
+        # At least one sleep with the Retry-After value
+        assert any(s == 0.0 for s in sleep_args)
+        client.close()
+
+    def test_retry_after_capped_at_max_backoff(self) -> None:
+        client = _make_client(max_retries=0, max_backoff_s=1.5)
+        delay = client._compute_backoff(_make_response(429, {"Retry-After": "999"}), attempt=0)
+        assert delay <= 1.5
+        client.close()
+
+
+class TestSecondaryRateLimit:
+    def test_detects_403_with_secondary_message(self) -> None:
+        client = _make_client(max_retries=2, base_backoff_s=0.0)
+        responses = [
+            _make_response(403, text="You have exceeded a secondary rate limit"),
+            _make_response(200),
+        ]
+        with patch.object(client._client, "request", side_effect=responses):
+            r = client.get("u")
+        assert r.status_code == 200
+        assert client.total_secondary_limits == 1
+        client.close()
+
+    def test_detects_403_with_abuse_message(self) -> None:
+        client = _make_client(max_retries=2, base_backoff_s=0.0)
+        responses = [
+            _make_response(403, text="abuse detection triggered"),
+            _make_response(200),
+        ]
+        with patch.object(client._client, "request", side_effect=responses):
+            r = client.get("u")
+        assert r.status_code == 200
+        assert client.total_secondary_limits == 1
+        client.close()
+
+    def test_403_remaining_zero_is_rate_limit(self) -> None:
+        client = _make_client(max_retries=2, base_backoff_s=0.0)
+        # First call sets X-RateLimit-Remaining=0; next call gets 403 → treated as rate-limit
+        responses = [
+            _make_response(403, {"X-RateLimit-Remaining": "0"}),
+            _make_response(200, {"X-RateLimit-Remaining": "1"}),
+        ]
+        with patch.object(client._client, "request", side_effect=responses):
+            r = client.get("u")
+        assert r.status_code == 200
+        assert client.total_secondary_limits == 1
+        client.close()
+
+    def test_403_unrelated_to_rate_limit_returns_immediately(self) -> None:
+        """A 403 with no rate-limit signals (e.g., bad auth) is NOT retried."""
+        client = _make_client(max_retries=3, base_backoff_s=0.0)
+        with patch.object(
+            client._client,
+            "request",
+            return_value=_make_response(
+                403,
+                {"X-RateLimit-Remaining": "4999"},
+                text="bad credentials",
+            ),
+        ):
+            r = client.get("u")
+        assert r.status_code == 403
+        assert client.total_requests == 1  # No retries
+        client.close()
+
+
+class TestQuotaWatermark:
+    def test_sleeps_when_below_watermark(self) -> None:
+        client = _make_client(low_watermark=100)
+        client._remaining = 50
+        client._reset_at = datetime.now(timezone.utc) + timedelta(seconds=2)
+        with (
+            patch("time.sleep") as sleep_mock,
+            patch.object(client._client, "request", return_value=_make_response(200)),
+        ):
+            client.get("u")
+        # Should have slept for ~2 seconds before request
+        sleep_calls = [c.args[0] for c in sleep_mock.call_args_list]
+        assert any(s >= 1.5 for s in sleep_calls)
+        client.close()
+
+    def test_no_sleep_above_watermark(self) -> None:
+        client = _make_client(low_watermark=100)
+        client._remaining = 5000
+        client._reset_at = datetime.now(timezone.utc) + timedelta(hours=1)
+        with (
+            patch("time.sleep") as sleep_mock,
+            patch.object(client._client, "request", return_value=_make_response(200)),
+        ):
+            client.get("u")
+        # No long sleep — request spacing is 0 in test config
+        for c in sleep_mock.call_args_list:
+            assert c.args[0] < 1.0
+        client.close()
+
+    def test_no_sleep_when_quota_unknown(self) -> None:
+        client = _make_client()
+        # Don't set _remaining or _reset_at
+        with (
+            patch("time.sleep") as sleep_mock,
+            patch.object(client._client, "request", return_value=_make_response(200)),
+        ):
+            client.get("u")
+        for c in sleep_mock.call_args_list:
+            assert c.args[0] < 1.0
+        client.close()
+
+
+class TestRequestSpacing:
+    def test_enforces_minimum_delay(self) -> None:
+        client = _make_client(per_request_delay_s=0.5)
+        client._last_request_t = 0.0
+        # Simulate having just made a request very recently
+        import time as time_mod
+
+        client._last_request_t = time_mod.monotonic() - 0.1  # 0.1s ago
+
+        slept = []
+
+        def fake_sleep(s):
+            slept.append(s)
+            # do not actually sleep — just record
+
+        with (
+            patch("time.sleep", side_effect=fake_sleep),
+            patch.object(client._client, "request", return_value=_make_response(200)),
+        ):
+            client.get("u")
+        # Should have slept the gap between 0.1 elapsed and 0.5 floor = ~0.4s
+        assert any(0.3 <= s <= 0.5 for s in slept)
+        client.close()
+
+
+class TestBackoffComputation:
+    def test_exponential_growth(self) -> None:
+        client = _make_client(base_backoff_s=1.0, max_backoff_s=1000.0)
+        r = _make_response(429)
+        d0 = client._compute_backoff(r, 0)
+        d1 = client._compute_backoff(r, 1)
+        d2 = client._compute_backoff(r, 2)
+        # Each roughly doubles (with jitter up to +25%); just verify monotonic-ish
+        assert d0 <= 1.5
+        assert d1 <= 3.0
+        assert d2 <= 6.0
+        # No retry-after, no reset: pure exponential
+        client.close()
+
+    def test_capped_at_max_backoff(self) -> None:
+        client = _make_client(base_backoff_s=1000.0, max_backoff_s=5.0)
+        r = _make_response(429)
+        for attempt in range(10):
+            d = client._compute_backoff(r, attempt)
+            assert d <= 5.0
+        client.close()
+
+    def test_prefer_retry_after(self) -> None:
+        client = _make_client(base_backoff_s=100.0, max_backoff_s=1000.0)
+        r = _make_response(429, {"Retry-After": "7"})
+        d = client._compute_backoff(r, 0)
+        assert d == 7.0
+        client.close()
+
+
+class TestContextManager:
+    def test_works_as_context_manager(self) -> None:
+        with GitHubRateLimitedClient(token="x", per_request_delay_s=0.0) as c:
+            assert c._remaining is None
+        # client closed automatically

--- a/tools/smoke_bulk_inventory.py
+++ b/tools/smoke_bulk_inventory.py
@@ -1,0 +1,27 @@
+"""Smoke test for the rate-limited bulk-scan inventory client (#224)."""
+
+import os
+
+from gh_link_auditor.bulk_scan.inventory import (
+    build_api_client,
+    build_raw_client,
+    inventory_repo,
+)
+
+
+def main() -> None:
+    api = build_api_client(os.environ.get("GITHUB_TOKEN"))
+    raw = build_raw_client()
+    try:
+        result = inventory_repo("pallets/click", api, raw)
+        print(f"docs: {len(result['doc_files'])}, urls: {len(result['urls'])}")
+        print(f"requests: {api.total_requests}, sleep_s: {api.total_sleep_s:.1f}")
+        print(f"429s: {api.total_429s}, secondary: {api.total_secondary_limits}")
+        print(f"quota remaining: {api._remaining}")
+    finally:
+        api.close()
+        raw.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Hotfix for #224 — the 2026-05-14 secondary-rate-limit cascade that took down the 7,500-repo bulk run within seconds of firing.

Closes #224

## Two root causes (both fixed)

| Cause | Fix |
|---|---|
| No rate-limit handling in inventory (LLD promised it but missing in impl) | New `bulk_scan/gh_client.py` — `GitHubRateLimitedClient` wraps httpx with throttle + quota watermark + 429 + secondary-rate-limit retry |
| `GITHUB_TOKEN` not in user's env → anonymous client (60 req/hr) | `build_api_client` falls back to `resolve_github_token()` which runs `gh auth token` silently |

## Rate-limit protections

| Protection | Default | Purpose |
|---|---|---|
| Inter-request throttle | 750ms | ~80 req/min, well under secondary-limit burst threshold |
| Quota watermark | 100 remaining | Sleep until reset when quota drops below floor |
| 429 retry | 5 attempts | Honor `Retry-After`; exponential 2-4-8-16-32... cap 15 min |
| Secondary-rate-limit retry | same | Detect `403 + "secondary rate limit"` text OR `403 + remaining==0` |

## Smoke proof (real GH, this terminal)

Before token fallback: `X-RateLimit-Remaining: 30` (anonymous, near-exhausted)
After token fallback: `X-RateLimit-Remaining: 4970` (authenticated, healthy)

## Test plan

- [x] 19 unit tests for `GitHubRateLimitedClient` covering 200-path, 429 retry, secondary rate limit, quota watermark sleep, request spacing, backoff math (exponential, Retry-After preference, max-backoff cap), context manager
- [x] Full suite: **2043 passed**, 1 skipped, 0 failed
- [x] ruff format + check clean
- [x] Smoke test against real GH verified authenticated mode (4970 remaining vs 30 anonymous)

## Operator re-fire

After this merges:

```bash
git pull --ff-only
poetry run python -m gh_link_auditor.cli.main bulk-scan start --target 7500
```

No `GITHUB_TOKEN` export required — `gh auth token` is the new fallback.