### PR TITLE
fix(inventory): sanitize doc paths from GitHub trees API

### DIFF
--- a/docs/lld/active/LLD-251.md
+++ b/docs/lld/active/LLD-251.md
@@ -1,0 +1,97 @@
+# LLD-251: sanitize doc paths from GitHub trees API
+
+**Issue:** #251
+**Status:** Active
+
+## Problem
+
+`bulk_scan/inventory.py:_fetch_raw` builds the raw-CDN URL by interpolating a path returned by GitHub's trees API directly into an f-string:
+
+```python
+url = f"{_RAW_BASE}/{full_name}/HEAD/{path}"
+```
+
+Git permits almost any byte in a filename except `/` and `\0`, including control chars (`\n`, `\r`, `\t`). RFC 3986 forbids control chars in URLs, so `httpx.URL.__init__` raises `InvalidURL` — and because the exception escapes `inventory_repo`, the **entire repo's Stage 1 inventory is marked errored**, losing every other (perfectly valid) doc file in the same repo.
+
+Concrete: tonight `guestrin-lab/deepscholar` errored during Stage 1 of `bulk-20260514T042627Z` with `InvalidURL("Invalid non-printable ASCII character in URL, '\\n' at position 177.")`. One pathological doc filename killed inventory for the whole repo.
+
+## Solution — two defenses, one PR
+
+### A. Skip pathological paths in `_list_doc_files`
+
+When iterating the trees-API response, drop any entry whose `path` contains a C0 control character (`ord < 0x20`). These are essentially never real doc files anyone cares about; dropping them is the right behavior.
+
+```python
+def _is_safe_doc_path(path: str) -> bool:
+    """True if path is safe to construct a URL from for our doc-fetch purposes."""
+    return bool(path) and all(ord(c) >= 0x20 for c in path)
+```
+
+Apply inside `_list_doc_files` between the extension check and the append.
+
+### B. URL-encode in `_fetch_raw`
+
+Even after (A), other surprise characters (spaces, `#`, `?`, accented chars) might break URL parsing in some HTTP clients. URL-encoding is the correct defense:
+
+```python
+from urllib.parse import quote
+url = f"{_RAW_BASE}/{full_name}/HEAD/{quote(path, safe='/')}"
+```
+
+`safe='/'` keeps directory separators literal so `docs/foo.md` stays `docs/foo.md` and doesn't become `docs%2Ffoo.md`.
+
+### Why both
+
+(A) is the *binary correctness* fix — paths with control chars cannot survive in URLs no matter what we do. (B) is the *robustness* fix — paths with spaces or other reserved chars are valid but historically caused friction. Shipping (A) without (B) leaves us one surprise filename away from another whole-repo failure; shipping (B) without (A) doesn't fix the control-char case because `\n` and similar still produce invalid URLs even after `quote()`. Wait — does `quote()` handle `\n`?
+
+Verification: `urllib.parse.quote("\n")` returns `"%0A"`. So (B) alone *would* fix the `\n` case by encoding it. But (A) is still preferred for control chars because:
+
+1. A file literally named `weird\nfilename.md` is never the canonical docs file the operator wants us to triage. Encoding it to `weird%0Afilename.md` and successfully fetching its content would produce noise findings.
+2. Dropping the path is cheaper than a successful fetch + URL extraction + noise output.
+
+So: (A) drops the obvious pathological cases at the entry-list stage. (B) is the safety net for the long tail (spaces, `#`, `?`, accents).
+
+## Implementation surface
+
+Two functions in `src/gh_link_auditor/bulk_scan/inventory.py`:
+
+1. `_list_doc_files(client, full_name)` — add `_is_safe_doc_path(path)` guard between the extension check and `docs.append(path)`.
+2. `_fetch_raw(client, full_name, path)` — wrap `path` in `quote(path, safe='/')` when building the URL.
+
+No new module-level imports beyond `from urllib.parse import quote` (which already exists at top of file? — check during impl).
+
+## Tests
+
+New file `tests/unit/bulk_scan/test_inventory_sanitize.py`. Both tests use the existing `FakeHTTPResponse` fake (no MagicMock per the project's testing conventions).
+
+| Test | Setup | Assertion |
+|---|---|---|
+| `test_list_doc_files_drops_control_char_paths` | Trees response includes `{path: "README\nweird.md", type: "blob"}` plus normal entries | Result list excludes the `\n` entry, includes the normal ones |
+| `test_list_doc_files_drops_tab_and_cr_paths` | Trees response includes `\t` and `\r` in different paths | Both excluded |
+| `test_list_doc_files_keeps_normal_paths` | Plain `README.md`, `docs/foo.rst`, etc. | All kept |
+| `test_fetch_raw_url_encodes_space_in_path` | Path `"docs/My File.md"` (raw client captures the URL it's asked to GET) | URL contains `docs/My%20File.md` (and not `docs/My File.md` literal) |
+| `test_fetch_raw_url_encodes_hash_and_question_mark` | Path with `#` and `?` | URL has them percent-encoded |
+| `test_fetch_raw_keeps_directory_separators_literal` | Path `"a/b/c.md"` | URL contains `a/b/c.md` literally (no `%2F`) |
+
+The fake `httpx.Client` for `_fetch_raw` is a tiny stub that records the `get()` URL and returns a 200 with empty body — we only assert on the URL it was asked to fetch.
+
+## Acceptance
+
+- [x] `_is_safe_doc_path` added (or inline equivalent inside `_list_doc_files`)
+- [x] `_fetch_raw` URL-encodes via `urllib.parse.quote(path, safe='/')`
+- [x] Six tests covering both layers, using `FakeHTTPResponse`-style stubs (no MagicMock)
+- [x] All existing inventory tests still pass
+- [x] ≥95% line coverage on the changed code
+- [x] `poetry run ruff format` clean and `poetry run ruff check` clean
+
+## Out of scope
+
+- Schema changes (no DB changes needed)
+- Re-running Stage 1 against `guestrin-lab/deepscholar` to confirm the fix works for THIS run's data — that's an operator-driven follow-up, not part of the PR
+- More sophisticated path filtering (e.g., binary-file detection by extension) — separate concern
+- Anything affecting `_fetch_raw`'s timeout, retry, or stealth behavior
+
+## Related
+
+- #227 — precedent for defensive URL handling at a different layer (malformed URLs from text extraction). Same philosophy: one bad input shouldn't kill the whole repo.
+- #218 (bulk-scan umbrella)

--- a/docs/reports/active/10251-implementation-report.md
+++ b/docs/reports/active/10251-implementation-report.md
@@ -1,0 +1,48 @@
+# 10251 — Implementation Report
+
+**Issue:** #251 — fix(inventory): sanitize doc paths from GitHub trees API
+**Branch:** `251-sanitize-doc-paths`
+**LLD:** `docs/lld/active/LLD-251.md`
+
+## Changes
+
+### `src/gh_link_auditor/bulk_scan/inventory.py`
+
+Two surgical additions:
+
+1. New helper `_is_safe_doc_path(path: str) -> bool`. Returns `False` for any path containing a C0 control character (`ord(c) < 0x20`) and for the empty string. Real doc files never have these in their names; dropping them is the right behavior.
+
+2. `_list_doc_files` now consults `_is_safe_doc_path` between the `type=='blob'` check and the doc-extension append. Pathological paths are dropped silently (logged at DEBUG with the offending path's `repr()` so it stays in logs without polluting normal output). The rest of the repo's docs proceed normally.
+
+3. `_fetch_raw` now URL-encodes the path component via `urllib.parse.quote(path, safe='/')` when composing the raw-CDN URL. `safe='/'` keeps directory separators literal so the path structure survives encoding. This is a belt-and-suspenders defense — control chars are already filtered by (1), but spaces, `#`, `?`, accented chars, etc. still arrive and would historically have caused trouble with some clients.
+
+### `tests/unit/bulk_scan/test_inventory_sanitize.py` (new file)
+
+12 tests across three classes covering:
+
+* **Path-filter layer**: `\n`, `\r`, `\t`, `\x00` paths dropped; normal paths kept; non-doc extensions still filtered; empty tree handled.
+* **URL-encoding layer**: space → `%20`, `#` → `%23`, `?` → `%3F`; directory separators kept literal; normal ASCII paths unchanged.
+* **End-to-end**: `inventory_repo` returns a clean list when given a tree response with mixed pathological and normal paths — the original failure mode (whole-repo abort) is gone.
+
+Uses small typed fakes (`_FakeTreeResp`, `_FakeAPIClient`, `_RecordingRawClient`) local to the test file. No `MagicMock`.
+
+## Behavior change summary
+
+| Input | Before | After |
+|---|---|---|
+| Tree with one `\n`-containing path | `httpx.InvalidURL`; whole repo errored | `\n` path dropped; rest of repo inventoried normally |
+| Path with literal space (`docs/My File.md`) | Worked depending on client; could 404 | URL-encoded to `docs/My%20File.md`; raw CDN returns the file |
+| Path with `#` or `?` | URL parsing ambiguity (fragment / query) | Encoded; no ambiguity |
+| Path with directory separators | Worked | Still works — separators kept literal |
+| Path containing only normal ASCII | Worked | Unchanged behavior |
+
+## Net effect on tonight's failure mode
+
+`guestrin-lab/deepscholar` had one doc file whose path contained `\n` at position 177. With this PR, the `\n` entry is dropped at `_list_doc_files` and the rest of the repo's doc files (presumably normal `.md` files) are inventoried successfully. Operator can re-run `tools/finish_stage1.py` against the `bulk-20260514T042627Z` run after merge to confirm the repo lands in `'inventoried'` state.
+
+## Out of scope (per LLD)
+
+* Schema changes (none needed).
+* Re-running Stage 1 against the affected repo — operator-driven follow-up.
+* Path filtering by repo language or doc-format heuristics.
+* Anything affecting `_fetch_raw`'s timeout / retry / stealth behavior.

--- a/docs/reports/active/10251-test-report.md
+++ b/docs/reports/active/10251-test-report.md
@@ -1,0 +1,92 @@
+# 10251 — Test Report
+
+**Issue:** #251
+**Branch:** `251-sanitize-doc-paths`
+
+## Test results
+
+```
+poetry run pytest tests/unit/bulk_scan/test_inventory.py tests/unit/bulk_scan/test_inventory_sanitize.py -v
+============================= 26 passed in 0.07s =============================
+```
+
+```
+poetry run pytest tests/unit/bulk_scan/ -v
+============================= 146 passed in 8.90s =============================
+```
+
+All 12 new tests pass GREEN. All 134 pre-existing `bulk_scan` tests still pass — no regressions.
+
+## New tests added (12)
+
+`tests/unit/bulk_scan/test_inventory_sanitize.py`:
+
+| Class | Test | Asserts |
+|---|---|---|
+| `TestListDocFilesSanitizesPaths` | `test_drops_path_with_newline` | `\n` in path → entry dropped |
+| | `test_drops_path_with_carriage_return` | `\r` in path → entry dropped |
+| | `test_drops_path_with_tab` | `\t` in path → entry dropped |
+| | `test_drops_path_with_null_byte` | `\x00` in path → entry dropped |
+| | `test_keeps_normal_doc_paths` | Plain `.md`/`.rst`/`.txt`/`.adoc` all kept; non-docs filtered by extension |
+| | `test_empty_tree_returns_empty_list` | Empty tree → empty result |
+| `TestFetchRawURLEncodesPath` | `test_encodes_space_in_path` | Space → `%20` |
+| | `test_encodes_hash_in_path` | `#` → `%23` |
+| | `test_encodes_question_mark_in_path` | `?` → `%3F` |
+| | `test_keeps_directory_separators_literal` | `/` not encoded |
+| | `test_normal_ascii_path_unchanged` | `README.md` URL unchanged from prior behavior |
+| `TestInventoryRepoSurvivesPathologicalFilename` | `test_inventory_returns_normal_files_even_when_pathological_present` | End-to-end: mixed tree returns clean inventory, raw client sees only safe URLs |
+
+## RED → GREEN evidence
+
+Before implementation:
+
+```
+=========================== short test summary info ===========================
+FAILED tests/unit/bulk_scan/test_inventory_sanitize.py::TestListDocFilesSanitizesPaths::test_drops_path_with_newline
+FAILED tests/unit/bulk_scan/test_inventory_sanitize.py::TestListDocFilesSanitizesPaths::test_drops_path_with_carriage_return
+FAILED tests/unit/bulk_scan/test_inventory_sanitize.py::TestListDocFilesSanitizesPaths::test_drops_path_with_tab
+FAILED tests/unit/bulk_scan/test_inventory_sanitize.py::TestListDocFilesSanitizesPaths::test_drops_path_with_null_byte
+FAILED tests/unit/bulk_scan/test_inventory_sanitize.py::TestFetchRawURLEncodesPath::test_encodes_space_in_path
+FAILED tests/unit/bulk_scan/test_inventory_sanitize.py::TestFetchRawURLEncodesPath::test_encodes_hash_in_path
+FAILED tests/unit/bulk_scan/test_inventory_sanitize.py::TestFetchRawURLEncodesPath::test_encodes_question_mark_in_path
+FAILED tests/unit/bulk_scan/test_inventory_sanitize.py::TestInventoryRepoSurvivesPathologicalFilename::test_inventory_returns_normal_files_even_when_pathological_present
+========================= 8 failed, 4 passed in 0.20s =========================
+```
+
+After implementation: all 12 pass.
+
+## Coverage
+
+`src/gh_link_auditor/bulk_scan/inventory.py`: 78% line coverage overall.
+
+**New code added by this PR is 100% covered.** The 22% miss is in pre-existing functions this PR does not touch:
+
+* `_clean_url_tail` edge case (line 50)
+* `_fetch_raw` exception handler and non-200 branches (lines 131, 139-140)
+* `inventory_repo` `MAX_URLS_PER_REPO` early-exit branches (lines 155-157, 206-214)
+* `build_api_client` env-fallback (lines 178-188) — requires env var manipulation
+* `build_raw_client` trivial httpx client constructor (line 218)
+
+None of these lines were modified or affected by this PR.
+
+## Lint / format
+
+```
+poetry run ruff format src/gh_link_auditor/bulk_scan/inventory.py tests/unit/bulk_scan/test_inventory_sanitize.py
+2 files left unchanged
+
+poetry run ruff check src/gh_link_auditor/bulk_scan/inventory.py tests/unit/bulk_scan/test_inventory_sanitize.py
+(clean, no errors)
+```
+
+(Two initial ruff errors — unused `httpx` import and import-block ordering — auto-fixed via `ruff check --fix`.)
+
+## Manual verification path (post-merge)
+
+Operator can confirm the fix works against real data by re-running:
+
+```
+poetry run python tools/finish_stage1.py --run-id bulk-20260514T042627Z
+```
+
+`guestrin-lab/deepscholar` should land in `'inventoried'` status with its non-pathological doc files extracted, where previously it was stuck at `'error'` with the `InvalidURL` message.

--- a/src/gh_link_auditor/bulk_scan/inventory.py
+++ b/src/gh_link_auditor/bulk_scan/inventory.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import re
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import httpx
 
@@ -99,11 +99,28 @@ def filter_url(url: str) -> bool:
     return True
 
 
+def _is_safe_doc_path(path: str) -> bool:
+    """True if path can be safely composed into a URL (#251).
+
+    Git permits almost any byte in a filename except ``/`` and ``\\0``,
+    including C0 control chars (``\\n``, ``\\r``, ``\\t``, ``\\x00`` …).
+    RFC 3986 forbids these in URLs, and ``httpx.URL`` rejects them with
+    ``InvalidURL`` — which previously aborted the entire repo's inventory.
+    Real doc files do not have these in their names; dropping the path
+    is the correct behavior.
+    """
+    return bool(path) and all(ord(c) >= 0x20 for c in path)
+
+
 def _list_doc_files(client: Any, full_name: str) -> list[str]:
     """One Git Trees API call → all doc files in the repo.
 
     ``client`` may be either an ``httpx.Client`` or a
     :class:`GitHubRateLimitedClient` — both expose ``.get(url, params=...)``.
+
+    Per #251, paths containing C0 control characters are dropped silently —
+    they cannot survive in URLs and dropping them keeps the rest of the
+    repo's docs reachable.
     """
     r = client.get(f"{_GH_API}/repos/{full_name}/git/trees/HEAD", params={"recursive": "1"})
     r.raise_for_status()
@@ -113,6 +130,9 @@ def _list_doc_files(client: Any, full_name: str) -> list[str]:
         if entry.get("type") != "blob":
             continue
         path = entry.get("path", "")
+        if not _is_safe_doc_path(path):
+            logger.debug("dropping pathological doc path: %s :: %r", full_name, path)
+            continue
         if any(path.lower().endswith(ext) for ext in DOC_FILE_EXTENSIONS):
             docs.append(path)
         if len(docs) >= MAX_DOC_FILES_PER_REPO:
@@ -121,8 +141,13 @@ def _list_doc_files(client: Any, full_name: str) -> list[str]:
 
 
 def _fetch_raw(client: httpx.Client, full_name: str, path: str) -> str | None:
-    """Fetch via raw CDN — does NOT count against the REST API rate limit."""
-    url = f"{_RAW_BASE}/{full_name}/HEAD/{path}"
+    """Fetch via raw CDN — does NOT count against the REST API rate limit.
+
+    Per #251, the path component is URL-encoded so spaces, ``#``, ``?`` and
+    other reserved characters don't crash URL parsing. ``safe='/'`` keeps
+    directory separators literal so the path structure survives encoding.
+    """
+    url = f"{_RAW_BASE}/{full_name}/HEAD/{quote(path, safe='/')}"
     try:
         r = client.get(url, follow_redirects=True, timeout=20)
         if r.status_code == 200:

--- a/tests/unit/bulk_scan/test_inventory_sanitize.py
+++ b/tests/unit/bulk_scan/test_inventory_sanitize.py
@@ -1,0 +1,205 @@
+"""Tests for #251 — sanitize doc paths from GitHub trees API.
+
+Covers two defenses:
+* ``_list_doc_files`` drops paths containing C0 control chars (``\\n``, ``\\r``, ``\\t``).
+* ``_fetch_raw`` URL-encodes the path component so spaces, ``#``, ``?`` etc.
+  don't crash url parsing or pollute the URL structure.
+
+No MagicMock — uses small typed fakes per the project's testing conventions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from gh_link_auditor.bulk_scan import inventory
+
+# ---------------------------------------------------------------------------
+# Tiny fakes — local to this test file to keep the fake surface minimal.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeTreeResp:
+    """Minimal stand-in for the httpx Response from the trees API."""
+
+    tree: list[dict[str, Any]]
+
+    def json(self) -> dict[str, Any]:
+        return {"tree": self.tree}
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeAPIClient:
+    """Records GET calls and returns a pre-set trees-API response."""
+
+    def __init__(self, tree: list[dict[str, Any]]) -> None:
+        self._resp = _FakeTreeResp(tree=tree)
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, url: str, **kwargs: Any) -> _FakeTreeResp:
+        self.calls.append((url, kwargs))
+        return self._resp
+
+
+@dataclass
+class _RecordingResponse:
+    """200 with empty body — enough to satisfy ``_fetch_raw`` happy path."""
+
+    status_code: int = 200
+    text: str = ""
+
+
+@dataclass
+class _RecordingRawClient:
+    """Records the URLs ``_fetch_raw`` asks for; returns 200 + empty body."""
+
+    seen_urls: list[str] = field(default_factory=list)
+
+    def get(self, url: str, **kwargs: Any) -> _RecordingResponse:
+        self.seen_urls.append(url)
+        return _RecordingResponse()
+
+
+# ---------------------------------------------------------------------------
+# A. Path-filter tests at the trees-API layer
+# ---------------------------------------------------------------------------
+
+
+class TestListDocFilesSanitizesPaths:
+    """`_list_doc_files` drops paths containing control characters."""
+
+    def test_drops_path_with_newline(self) -> None:
+        client = _FakeAPIClient(
+            tree=[
+                {"type": "blob", "path": "README.md"},
+                {"type": "blob", "path": "docs/has\nweird.md"},
+                {"type": "blob", "path": "docs/normal.md"},
+            ]
+        )
+        docs = inventory._list_doc_files(client, "owner/repo")
+        assert "README.md" in docs
+        assert "docs/normal.md" in docs
+        assert all("\n" not in p for p in docs), f"\\n leaked into: {docs}"
+
+    def test_drops_path_with_carriage_return(self) -> None:
+        client = _FakeAPIClient(
+            tree=[
+                {"type": "blob", "path": "README.md"},
+                {"type": "blob", "path": "weird\rreadme.md"},
+            ]
+        )
+        docs = inventory._list_doc_files(client, "owner/repo")
+        assert docs == ["README.md"]
+
+    def test_drops_path_with_tab(self) -> None:
+        client = _FakeAPIClient(
+            tree=[
+                {"type": "blob", "path": "README.md"},
+                {"type": "blob", "path": "docs/tabby\there.rst"},
+            ]
+        )
+        docs = inventory._list_doc_files(client, "owner/repo")
+        assert docs == ["README.md"]
+
+    def test_drops_path_with_null_byte(self) -> None:
+        client = _FakeAPIClient(
+            tree=[
+                {"type": "blob", "path": "README.md"},
+                {"type": "blob", "path": "docs/null\x00byte.md"},
+            ]
+        )
+        docs = inventory._list_doc_files(client, "owner/repo")
+        assert docs == ["README.md"]
+
+    def test_keeps_normal_doc_paths(self) -> None:
+        tree = [
+            {"type": "blob", "path": "README.md"},
+            {"type": "blob", "path": "docs/foo.rst"},
+            {"type": "blob", "path": "CHANGELOG.txt"},
+            {"type": "blob", "path": "guide.adoc"},
+            {"type": "blob", "path": "src/main.py"},  # non-doc — filtered by extension
+        ]
+        client = _FakeAPIClient(tree=tree)
+        docs = inventory._list_doc_files(client, "owner/repo")
+        assert "README.md" in docs
+        assert "docs/foo.rst" in docs
+        assert "CHANGELOG.txt" in docs
+        assert "guide.adoc" in docs
+        assert "src/main.py" not in docs
+
+    def test_empty_tree_returns_empty_list(self) -> None:
+        client = _FakeAPIClient(tree=[])
+        assert inventory._list_doc_files(client, "owner/repo") == []
+
+
+# ---------------------------------------------------------------------------
+# B. URL-encoding tests at the raw-CDN fetch layer
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRawURLEncodesPath:
+    """`_fetch_raw` URL-encodes the path so surprise chars don't crash httpx."""
+
+    def test_encodes_space_in_path(self) -> None:
+        raw = _RecordingRawClient()
+        inventory._fetch_raw(raw, "owner/repo", "docs/My File.md")
+        assert len(raw.seen_urls) == 1
+        url = raw.seen_urls[0]
+        assert "My%20File" in url
+        assert "My File" not in url
+
+    def test_encodes_hash_in_path(self) -> None:
+        raw = _RecordingRawClient()
+        inventory._fetch_raw(raw, "owner/repo", "docs/file#tag.md")
+        assert "%23" in raw.seen_urls[0]
+
+    def test_encodes_question_mark_in_path(self) -> None:
+        raw = _RecordingRawClient()
+        inventory._fetch_raw(raw, "owner/repo", "docs/file?weird.md")
+        assert "%3F" in raw.seen_urls[0]
+
+    def test_keeps_directory_separators_literal(self) -> None:
+        raw = _RecordingRawClient()
+        inventory._fetch_raw(raw, "owner/repo", "a/b/c/d.md")
+        url = raw.seen_urls[0]
+        # Path separators must NOT be encoded — otherwise we'd 404 on raw CDN.
+        assert "/a/b/c/d.md" in url
+        assert "%2F" not in url
+
+    def test_normal_ascii_path_unchanged(self) -> None:
+        raw = _RecordingRawClient()
+        inventory._fetch_raw(raw, "owner/repo", "README.md")
+        assert raw.seen_urls[0].endswith("/owner/repo/HEAD/README.md")
+
+
+# ---------------------------------------------------------------------------
+# C. End-to-end: inventory_repo survives one pathological filename per #251
+# ---------------------------------------------------------------------------
+
+
+class TestInventoryRepoSurvivesPathologicalFilename:
+    """The whole-repo-aborts-on-one-bad-path failure mode (deepscholar) is gone."""
+
+    def test_inventory_returns_normal_files_even_when_pathological_present(
+        self,
+    ) -> None:
+        # Tree response with one \n-containing path mixed in with normal ones.
+        tree = [
+            {"type": "blob", "path": "README.md"},
+            {"type": "blob", "path": "docs/has\nweird.md"},
+            {"type": "blob", "path": "docs/normal.md"},
+        ]
+        api = _FakeAPIClient(tree=tree)
+        raw = _RecordingRawClient()
+        result = inventory.inventory_repo("owner/repo", api, raw)
+        # The pathological path was dropped at _list_doc_files; the raw fetches
+        # therefore only attempt the two safe paths.
+        assert "README.md" in result["doc_files"]
+        assert "docs/normal.md" in result["doc_files"]
+        assert all("\n" not in p for p in result["doc_files"])
+        # And the raw client was only asked for safe URLs.
+        assert all("%0A" not in u and "\n" not in u for u in raw.seen_urls)


### PR DESCRIPTION
## Summary

- Drop tree-API paths containing C0 control chars (`\n`, `\r`, `\t`, `\x00`) at `_list_doc_files` — one pathological filename no longer aborts the entire repo's Stage 1 inventory.
- URL-encode the path component in `_fetch_raw` via `urllib.parse.quote(path, safe='/')` — handles spaces, `#`, `?`, accented chars as a defense in depth.
- 12 new tests cover both layers plus an end-to-end case. All 146 bulk_scan tests pass.

Real case driving this: tonight's Stage 1 of `bulk-20260514T042627Z` had `guestrin-lab/deepscholar` error with `InvalidURL("Invalid non-printable ASCII character in URL, '\n' at position 177.")` — one doc file in the repo's tree had `\n` in its filename, killing inventory for the whole repo. With this PR, that path is dropped and the rest of the repo's docs inventory normally.

## Test plan

- [x] 8 new RED tests written before implementation
- [x] All 12 new tests GREEN after implementation
- [x] 146 / 146 bulk_scan tests pass — zero regressions
- [x] `ruff format` + `ruff check` clean
- [x] 100% coverage on new code (the 22% miss in `inventory.py` overall is pre-existing untouched paths: `build_api_client` env-fallback, `_fetch_raw` exception handler, `inventory_repo` `MAX_URLS_PER_REPO` early-exits)
- [ ] Post-merge manual verification: re-run `tools/finish_stage1.py --run-id bulk-20260514T042627Z` — `guestrin-lab/deepscholar` should land in `'inventoried'` (operator-driven follow-up)

## Files

- `src/gh_link_auditor/bulk_scan/inventory.py` — new `_is_safe_doc_path` helper, guard in `_list_doc_files`, `quote()` in `_fetch_raw`
- `tests/unit/bulk_scan/test_inventory_sanitize.py` — new test file with 12 tests
- `docs/lld/active/LLD-251.md` — design doc
- `docs/reports/active/10251-implementation-report.md` — implementation report
- `docs/reports/active/10251-test-report.md` — test report

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)