### PR TITLE
fix(inventory): follow repo-rename 301 redirects on trees API

### DIFF
--- a/docs/lld/active/LLD-250.md
+++ b/docs/lld/active/LLD-250.md
@@ -1,0 +1,177 @@
+# LLD-250: follow GitHub repo-rename 301 redirects in Stage 1 inventory
+
+**Issue:** #250
+**Status:** Active
+
+## Problem
+
+When a GitHub repo is renamed, `GET /repos/{owner}/{name}/git/trees/HEAD` returns 301 Moved Permanently with `Location: https://api.github.com/repositories/{repo_id}/git/trees/HEAD?recursive=1` — pointing at the numeric-ID form of the new location. Our `bulk_scan/inventory.py:_list_doc_files` doesn't handle this: `httpx`'s default `follow_redirects=False` plus the existing `r.raise_for_status()` causes the 301 to surface as `HTTPStatusError`, which the caller catches and marks the entire repo `'error'`. The repo is alive and well at its new name; we just can't reach it.
+
+Real cases from Stage 1 of `bulk-20260514T042627Z` (2026-05-23):
+
+- `ElliottYan/LUFFY` → `/repositories/969637328`
+- `tukuaiai/tradecat` → `/repositories/1125036278`
+
+Both were selected on 2026-05-14, renamed between then and now, and tonight got marked errored. Re-running with this fix should pick them up.
+
+## Solution
+
+Three new pieces of plumbing plus a small caller-side update:
+
+### A. Detect 301 in `_list_doc_files`, raise `RepoRenamed`
+
+```python
+class RepoRenamed(Exception):
+    """Signal from Stage 1 inventory that the repo was renamed.
+
+    Carries the new full_name so callers can update the DB and retry.
+    """
+    def __init__(self, new_full_name: str) -> None:
+        self.new_full_name = new_full_name
+        super().__init__(f"repo renamed to {new_full_name}")
+```
+
+In `_list_doc_files`, before `r.raise_for_status()`, check for a 301 with a Location header pointing at `/repositories/{id}`. If so, look up the new `full_name` via `GET /repositories/{id}` and raise `RepoRenamed(new_full_name)`. Other 3xx and 4xx/5xx still propagate via `raise_for_status` as before.
+
+### B. Helper `_resolve_renamed_repo`
+
+```python
+def _resolve_renamed_repo(client: Any, redirect_location: str) -> str | None:
+    """Given a redirect Location URL of the form .../repositories/{id}/..., return
+    the current full_name of repo {id}, or None if resolution fails.
+    """
+    m = re.search(r"/repositories/(\d+)", redirect_location)
+    if not m:
+        return None
+    repo_id = m.group(1)
+    try:
+        r = client.get(f"{_GH_API}/repositories/{repo_id}")
+        r.raise_for_status()
+        return r.json().get("full_name")
+    except Exception:
+        return None
+```
+
+The function is intentionally permissive: any failure (network, 404, malformed JSON) returns None, and the caller falls back to normal `raise_for_status` behavior. We never want a rename-resolution bug to make things worse than the pre-existing error path.
+
+### C. `inventory_repo` catches and retries once
+
+```python
+def inventory_repo(full_name, api_client, raw_client) -> dict:
+    renamed_from = None
+    try:
+        docs = _list_doc_files(api_client, full_name)
+    except RepoRenamed as e:
+        renamed_from = full_name
+        full_name = e.new_full_name
+        # One-shot retry — if the new name ALSO redirects, let the exception
+        # propagate. Multi-rename chains are rare and not worth optimizing.
+        docs = _list_doc_files(api_client, full_name)
+    # ... existing URL-extraction logic unchanged ...
+    return {
+        "doc_files": docs,
+        "urls": urls,
+        "renamed_from": renamed_from,
+        "current_full_name": full_name,
+    }
+```
+
+`renamed_from` is `None` for the common case (no rename); non-`None` signals to the caller that a DB update is needed.
+
+### D. Storage helper `apply_repo_rename`
+
+```python
+def apply_repo_rename(db, run_id, old_full_name, new_full_name) -> bool:
+    """Update bulk_scan_repos PK from old_full_name to new_full_name, recording
+    the old name in previous_full_name. Also propagates the rename to any
+    existing bulk_scan_findings rows for that repo.
+
+    Returns True if applied, False on a collision (the new_full_name is
+    already present in this run — rare; leave the data alone).
+    """
+```
+
+Atomic transaction:
+
+1. Check if `(run_id, new_full_name)` already exists. If yes → return False, log.
+2. `UPDATE bulk_scan_repos SET repo_full_name = new, previous_full_name = old, updated_at = now WHERE run_id = ? AND repo_full_name = old`.
+3. `UPDATE bulk_scan_findings SET repo_full_name = new WHERE run_id = ? AND repo_full_name = old` — keeps findings linked to the repo row.
+
+SQLite supports updating a PK column when the new value is unique, so the PK change works cleanly.
+
+### E. Schema migration v7 → v8
+
+Add `previous_full_name TEXT NULL` to `bulk_scan_repos`. Pure additive ALTER TABLE — safe and fast in WAL mode. Update the bootstrap CREATE TABLE so fresh DBs include the column.
+
+### F. Caller-side update in `runner.run_inventory`
+
+```python
+result = inventory.inventory_repo(full_name, api, raw)
+if result.get("renamed_from"):
+    if storage.apply_repo_rename(db, run_id, result["renamed_from"], result["current_full_name"]):
+        full_name = result["current_full_name"]
+storage.update_repo_inventory(db, run_id, full_name, result["doc_files"], len(result["urls"]))
+for url, src, ln in result["urls"]:
+    storage.add_finding(db, run_id, full_name, src, ln, url, ...)
+```
+
+If `apply_repo_rename` returns False (PK collision), we keep using the OLD name for the inventory write — better to inventory under the wrong name than to lose the row entirely.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| Repo not renamed (common) | No 301, no exception, no DB change. Zero overhead per repo for the new code path. |
+| Repo renamed once | `RepoRenamed` raised, one-shot retry succeeds, DB updated, inventory proceeds. |
+| Repo renamed twice (very rare) | First retry hits another 301; `RepoRenamed` raised from retry; not caught a second time; repo errored. Acceptable. |
+| 301 but Location header missing/malformed | `_resolve_renamed_repo` returns None; `_list_doc_files` falls through to `raise_for_status` and errors the repo normally. |
+| 301 → `/repositories/{id}` 404 | Same: None returned, normal error path. |
+| PK collision (new name already in run's bulk_scan_repos) | `apply_repo_rename` returns False, logs, caller keeps using old name. Inventory still succeeds; the rename record is just lost. |
+| 4xx / 5xx other than 301 | Unchanged behavior — `raise_for_status` raises, caller marks repo errored. |
+
+## Test plan
+
+| Test | Asserts |
+|---|---|
+| `test_repo_renamed_exception_carries_new_name` | `RepoRenamed("a/b").new_full_name == "a/b"` |
+| `test_resolve_renamed_repo_extracts_id_from_location` | Extracts `969637328` from `.../repositories/969637328/...` |
+| `test_resolve_renamed_repo_returns_none_when_no_id_in_location` | `https://api.github.com/foo` → None |
+| `test_resolve_renamed_repo_returns_none_when_lookup_404s` | API returns 404 → None |
+| `test_resolve_renamed_repo_returns_full_name_on_success` | API returns `{"full_name": "new/name"}` → "new/name" |
+| `test_list_doc_files_raises_on_301` | 301 + valid Location → `RepoRenamed` raised |
+| `test_list_doc_files_doesnt_raise_renamed_on_404` | 404 → `HTTPStatusError` (unchanged) |
+| `test_inventory_repo_handles_rename` | First call 301, second call 200 → result has `renamed_from`, `current_full_name` set |
+| `test_inventory_repo_no_rename` | No 301 → result has `renamed_from=None`, `current_full_name=original` |
+| `test_inventory_repo_double_rename_errors` | Both calls 301 → exception propagates |
+| `test_apply_repo_rename_updates_pk` | Old row → new row in DB with `previous_full_name` set |
+| `test_apply_repo_rename_propagates_to_findings` | Findings under old name now reference new name |
+| `test_apply_repo_rename_collision_returns_false` | New name already present → False, no changes |
+| `test_schema_v8_adds_previous_full_name` | Fresh DB has the column; migration from v7 adds it |
+| `test_run_inventory_handles_rename_end_to_end` | runner-level test using the existing FakeAPI pattern |
+
+## Acceptance
+
+- [x] `RepoRenamed` exception
+- [x] `_resolve_renamed_repo` helper
+- [x] `_list_doc_files` raises on 301
+- [x] `inventory_repo` retries once + reports renamed_from
+- [x] `apply_repo_rename` storage helper
+- [x] `previous_full_name TEXT NULL` column in bulk_scan_repos (v7 → v8 migration + bootstrap)
+- [x] `runner.run_inventory` calls `apply_repo_rename` and uses the new name
+- [x] 15 tests covering all branches above
+- [x] All existing bulk_scan tests still pass
+- [x] `ruff format` + `ruff check` clean
+- [x] ≥95% coverage on new code
+
+## Out of scope
+
+- Updating the standalone `tools/finish_stage1.py` (not in the test suite; benefits from this fix indirectly only when re-run; can be updated in a follow-up).
+- Multi-rename chains (a repo that's been renamed twice during the window between selection and inventory).
+- Reverse lookup index (`previous_full_name → current_full_name`) — not needed for the operator workflow.
+- Bulk re-resolution sweep across already-errored repos from prior runs (operator can re-run Stage 1 and these errored repos will be picked up via the normal pending → inventoried path; we'd need to manually reset their status to 'pending' first — separate operator-time concern).
+
+## Related
+
+- #251 (just merged) — sibling defensive fix at the same layer (`inventory.py`). This PR rebases on top of it cleanly.
+- #218 (bulk-scan umbrella)
+- #224 (rate-limit-aware GH client — its `.get()` is what we're calling; no client changes needed)

--- a/docs/reports/active/10250-implementation-report.md
+++ b/docs/reports/active/10250-implementation-report.md
@@ -1,0 +1,72 @@
+# 10250 — Implementation Report
+
+**Issue:** #250 — fix(inventory): follow repo-rename 301 redirects on GitHub trees API
+**Branch:** `250-follow-rename-301`
+**LLD:** `docs/lld/active/LLD-250.md`
+
+## Changes
+
+### `src/gh_link_auditor/bulk_scan/inventory.py`
+
+* New exception `RepoRenamed(new_full_name)` — carries the new ``full_name`` so callers can update state and retry.
+* New helper `_resolve_renamed_repo(client, redirect_location)` — extracts `{repo_id}` from a `/repositories/{id}/...` Location header and looks up the current `full_name` via `/repositories/{id}`. Permissive: any failure returns `None` so the normal `raise_for_status` error path takes over.
+* `_list_doc_files` now checks `r.status_code == 301` before `raise_for_status`. On a 301 with a resolvable Location, raises `RepoRenamed(new_full_name)`. Unresolvable 301s and all other non-2xx statuses propagate via `raise_for_status` unchanged.
+* `inventory_repo` catches `RepoRenamed`, performs exactly one retry under the new name, and returns two new keys: `renamed_from` (the original argument or `None`) and `current_full_name` (the name under which inventory actually succeeded). Multi-rename chains (very rare) propagate the second `RepoRenamed` rather than looping.
+
+### `src/gh_link_auditor/bulk_scan/storage.py`
+
+* New helper `apply_repo_rename(db, run_id, old, new) -> bool`. Atomic transaction:
+  1. Check for `(run_id, new)` PK collision; on collision, return `False` and log a warning.
+  2. `UPDATE bulk_scan_repos SET repo_full_name = new, previous_full_name = old WHERE PK matches old`.
+  3. `UPDATE bulk_scan_findings SET repo_full_name = new WHERE PK matches old` — keeps finding rows linked to the renamed repo.
+
+### `src/gh_link_auditor/unified_db.py`
+
+* `SCHEMA_VERSION` bumped 7 → 8.
+* `previous_full_name TEXT` added to the bootstrap `CREATE TABLE bulk_scan_repos`.
+* New `_migrate_v7_to_v8` performs an additive `ALTER TABLE … ADD COLUMN previous_full_name TEXT` and updates the version. Existing v6 → v7 migration's final `UPDATE schema_version` now sets v7 explicitly (instead of `SCHEMA_VERSION`) so the chain is correct.
+
+### `src/gh_link_auditor/bulk_scan/runner.py`
+
+* `run_inventory` now consumes the new keys: if `result["renamed_from"]` is set, calls `storage.apply_repo_rename`; on success, the local `full_name` is rebound so subsequent `update_repo_inventory` + `add_finding` calls land under the new name. On PK-collision (apply returns `False`), the loop falls back to the old name — better to inventory under the wrong name than lose the row.
+
+### Tests
+
+* `tests/unit/bulk_scan/test_inventory_rename.py` (new) — 14 tests:
+  * 2 for `RepoRenamed` (carries new_full_name, repr is informative)
+  * 5 for `_resolve_renamed_repo` (success, no-id-in-location, lookup 404, no full_name in response, network error)
+  * 4 for `_list_doc_files` 301 detection (raise on resolvable 301, fall through on unresolvable, 404 unchanged, 200 unchanged)
+  * 3 for `inventory_repo` retry behavior (rename + success, no rename, double rename propagates)
+* `tests/unit/bulk_scan/test_storage_rename.py` (new) — 8 tests:
+  * 3 for schema v8 (fresh DB has column, version constant, v7 → v8 migration adds column)
+  * 4 for `apply_repo_rename` (success path with previous_full_name, propagation to findings, PK collision returns False, same-name no-op)
+  * 1 for runner integration (end-to-end `run_inventory` flips the row + writes findings under the new name)
+* `tests/unit/bulk_scan/test_storage.py` — assertion bumped from `SCHEMA_VERSION == 7` to `== 8`.
+* `tests/unit/bulk_scan/test_inventory_sanitize.py` (from #251) — `_FakeTreeResp` gained `status_code` and `headers` fields so the new 301 check works without breaking existing tests.
+
+## Behavior change summary
+
+| Input | Before | After |
+|---|---|---|
+| Repo not renamed (common) | Normal flow | Normal flow — `renamed_from=None`, zero new code touched |
+| Repo renamed once on GitHub | `HTTPStatusError("301 Moved Permanently")` → repo errored | `RepoRenamed` raised → caught → re-fetch by new name → DB row + findings re-keyed → inventoried |
+| Repo renamed twice during selection window | Same — errored | Second `RepoRenamed` propagates → errored. Acceptable. |
+| 301 with garbled Location header | Errored | `_resolve_renamed_repo` returns None → `raise_for_status` fires normally → errored |
+| 301 → `/repositories/{id}` 404 | (Wouldn't have made the second call) | `_resolve_renamed_repo` returns None → normal error path |
+| PK collision (new name already in run) | n/a | `apply_repo_rename` returns False → caller continues under old name |
+
+## Net effect on tonight's failure mode
+
+`ElliottYan/LUFFY` and `tukuaiai/tradecat` will now be picked up cleanly when Stage 1 is re-run against `bulk-20260514T042627Z`. Their DB rows will have:
+- `repo_full_name` = the new owner/name returned by `/repositories/{id}`
+- `previous_full_name` = the old name (forensic record)
+- `status` = `'inventoried'`
+
+Any future runs that select the new name directly will hit it without a rename detour.
+
+## Out of scope (per LLD)
+
+* Updating `tools/finish_stage1.py` (not in test suite; future re-runs will benefit via the package fix once we update it as part of the audit pass).
+* Multi-rename chains (rare; second `RepoRenamed` propagates).
+* Reverse lookup index (`previous_full_name → current_full_name`).
+* Resetting status of previously-errored repos in old DBs (operator-driven).

--- a/docs/reports/active/10250-test-report.md
+++ b/docs/reports/active/10250-test-report.md
@@ -1,0 +1,113 @@
+# 10250 — Test Report
+
+**Issue:** #250
+**Branch:** `250-follow-rename-301`
+
+## Test results
+
+```
+poetry run pytest tests/unit/bulk_scan/ -v
+============================= 168 passed in 9.80s =============================
+```
+
+All 22 new tests pass GREEN. All 146 pre-existing bulk_scan tests still pass.
+
+## New tests added (22)
+
+### `tests/unit/bulk_scan/test_inventory_rename.py` (14)
+
+| Class | Test | Asserts |
+|---|---|---|
+| `TestRepoRenamedException` | `test_carries_new_full_name` | `.new_full_name` accessible |
+| | `test_string_repr_mentions_new_name` | `str(e)` includes the new name |
+| `TestResolveRenamedRepo` | `test_extracts_id_and_returns_new_full_name` | Happy path → calls `/repositories/{id}` once |
+| | `test_returns_none_when_no_id_in_location` | Bad Location URL → None, no API call |
+| | `test_returns_none_when_lookup_404s` | API 404 → None |
+| | `test_returns_none_when_response_has_no_full_name` | Response without `full_name` field → None |
+| | `test_returns_none_when_lookup_raises` | Network error → None (permissive) |
+| `TestListDocFilesHandles301` | `test_raises_repo_renamed_on_301_with_valid_location` | 301 + resolvable Location → `RepoRenamed` |
+| | `test_falls_through_when_301_location_unresolvable` | 301 + non-resolvable Location → `HTTPStatusError` |
+| | `test_404_still_raises_normal_httpstatuserror` | 404 unchanged |
+| | `test_200_no_rename_no_exception` | Happy path unchanged |
+| `TestInventoryRepoHandlesRename` | `test_rename_then_success_returns_renamed_from` | One-shot retry sets `renamed_from` + `current_full_name` |
+| | `test_no_rename_returns_renamed_from_none` | Common path: `renamed_from=None`, `current_full_name=original` |
+| | `test_double_rename_propagates` | Second `RepoRenamed` propagates (no infinite loop) |
+
+### `tests/unit/bulk_scan/test_storage_rename.py` (8)
+
+| Class | Test | Asserts |
+|---|---|---|
+| `TestSchemaV8AddsPreviousFullName` | `test_fresh_db_has_previous_full_name_column` | Bootstrap creates the column |
+| | `test_schema_version_advances_to_8` | `SCHEMA_VERSION >= 8` |
+| | `test_migration_v7_to_v8_adds_column` | v7 DB → upgrade adds column, version advances |
+| `TestApplyRepoRename` | `test_renames_existing_row_and_sets_previous_full_name` | PK updates, `previous_full_name` records old, other cols preserved |
+| | `test_propagates_rename_to_findings` | `bulk_scan_findings` rows re-keyed |
+| | `test_collision_returns_false_and_leaves_data_intact` | PK collision → False, no DB changes |
+| | `test_same_name_is_noop` | Old == new → False, no DB changes |
+| `TestRunInventoryHandlesRename` | `test_rename_updates_repo_row_and_findings_use_new_name` | End-to-end runner test: `run_inventory` flips the row, findings use new name |
+
+### `tests/unit/bulk_scan/test_storage.py`
+
+Existing `TestSchemaV7::test_schema_version` assertion bumped from `== 7` to `== 8`. Class name kept for git-blame continuity.
+
+## RED → GREEN evidence
+
+Before implementation (rename tests):
+
+```
+=========================== short test summary info ===========================
+FAILED tests/unit/bulk_scan/test_inventory_rename.py::TestRepoRenamedException::test_carries_new_full_name
+FAILED tests/unit/bulk_scan/test_inventory_rename.py::TestRepoRenamedException::test_string_repr_mentions_new_name
+FAILED tests/unit/bulk_scan/test_inventory_rename.py::TestResolveRenamedRepo::test_extracts_id_and_returns_new_full_name
+FAILED tests/unit/bulk_scan/test_inventory_rename.py::TestResolveRenamedRepo::test_returns_none_when_no_id_in_location
+FAILED tests/unit/bulk_scan/test_inventory_rename.py::TestResolveRenamedRepo::test_returns_none_when_lookup_404s
+FAILED tests/unit/bulk_scan/test_inventory_rename.py::TestResolveRenamedRepo::test_returns_none_when_response_has_no_full_name
+FAILED tests/unit/bulk_scan/test_inventory_rename.py::TestResolveRenamedRepo::test_returns_none_when_lookup_raises
+FAILED tests/unit/bulk_scan/test_inventory_rename.py::TestListDocFilesHandles301::test_raises_repo_renamed_on_301_with_valid_location
+FAILED tests/unit/bulk_scan/test_inventory_rename.py::TestInventoryRepoHandlesRename::test_rename_then_success_returns_renamed_from
+FAILED tests/unit/bulk_scan/test_inventory_rename.py::TestInventoryRepoHandlesRename::test_no_rename_returns_renamed_from_none
+FAILED tests/unit/bulk_scan/test_inventory_rename.py::TestInventoryRepoHandlesRename::test_double_rename_propagates
+======================== 11 failed, 3 passed in 0.18s =========================
+```
+
+After implementation: all 14 pass.
+
+## Schema migration tested
+
+* Fresh DB at v8: column present ✓
+* v7 DB with no column: migration runs, column added, version advances to 8 ✓
+* Migration is additive `ALTER TABLE ADD COLUMN` — fast and safe in WAL mode, no data loss
+
+## Lint / format
+
+```
+poetry run ruff format <files>
+3 files reformatted, 4 files left unchanged
+
+poetry run ruff check <files>
+All checks passed!
+```
+
+(Two initial ruff errors auto-fixed: trailing newline + import order.)
+
+## Coverage
+
+`src/gh_link_auditor/bulk_scan/inventory.py`: new code (RepoRenamed, `_resolve_renamed_repo`, 301-detection branch in `_list_doc_files`, `inventory_repo` retry path) is 100% covered by the 14 rename tests.
+
+`src/gh_link_auditor/bulk_scan/storage.py`: new `apply_repo_rename` has 100% branch coverage (success, propagation, collision, same-name).
+
+`src/gh_link_auditor/unified_db.py`: new `_migrate_v7_to_v8` covered by `test_migration_v7_to_v8_adds_column`.
+
+`src/gh_link_auditor/bulk_scan/runner.py`: new rename-handling wiring covered by `TestRunInventoryHandlesRename::test_rename_updates_repo_row_and_findings_use_new_name`.
+
+## Manual verification path (post-merge)
+
+Operator can re-run Stage 1 against the bulk-scan run that hit the rename failure:
+
+```
+poetry run python tools/finish_stage1.py --run-id bulk-20260514T042627Z
+```
+
+The 2 previously-errored repos (`ElliottYan/LUFFY`, `tukuaiai/tradecat`) should resolve to their renamed targets, get inventoried, and have their DB rows show `previous_full_name` set.
+
+Note: `tools/finish_stage1.py` itself wasn't modified in this PR. It calls into the package's `inventory_repo` which now returns `renamed_from`. The tool's `write_repo_atomically` doesn't yet honor that field — operator-time follow-up to wire the tool to the package update, OR the operator can use the package's `runner.run_inventory` directly for the next run.

--- a/src/gh_link_auditor/bulk_scan/inventory.py
+++ b/src/gh_link_auditor/bulk_scan/inventory.py
@@ -112,6 +112,46 @@ def _is_safe_doc_path(path: str) -> bool:
     return bool(path) and all(ord(c) >= 0x20 for c in path)
 
 
+class RepoRenamed(Exception):
+    """Signal from Stage 1 inventory that the repo was renamed on GitHub (#250).
+
+    Carries the new ``full_name`` so callers can update DB state and retry
+    inventory under the new name in a single bounded retry.
+    """
+
+    def __init__(self, new_full_name: str) -> None:
+        self.new_full_name = new_full_name
+        super().__init__(f"repo renamed to {new_full_name}")
+
+
+def _resolve_renamed_repo(client: Any, redirect_location: str) -> str | None:
+    """Given a 301 ``Location`` URL of the form ``.../repositories/{id}/...``,
+    return the repo's current ``full_name`` or ``None`` if it can't be resolved.
+
+    Failure modes (all return ``None``):
+
+    * No ``/repositories/{id}`` pattern in the URL.
+    * Lookup ``/repositories/{id}`` returns non-2xx.
+    * Response body lacks ``full_name``.
+    * Network / transport error.
+
+    The function is deliberately permissive — any failure here should fall
+    through to the normal ``raise_for_status`` error path so we don't make
+    things worse than the pre-existing failure mode.
+    """
+    m = re.search(r"/repositories/(\d+)", redirect_location)
+    if not m:
+        return None
+    repo_id = m.group(1)
+    try:
+        r = client.get(f"{_GH_API}/repositories/{repo_id}")
+        r.raise_for_status()
+        full_name = r.json().get("full_name")
+        return full_name if isinstance(full_name, str) and full_name else None
+    except Exception:
+        return None
+
+
 def _list_doc_files(client: Any, full_name: str) -> list[str]:
     """One Git Trees API call → all doc files in the repo.
 
@@ -121,8 +161,20 @@ def _list_doc_files(client: Any, full_name: str) -> list[str]:
     Per #251, paths containing C0 control characters are dropped silently —
     they cannot survive in URLs and dropping them keeps the rest of the
     repo's docs reachable.
+
+    Per #250, a 301 redirect with a resolvable ``Location`` header signals
+    that the repo was renamed: ``RepoRenamed`` is raised carrying the new
+    ``full_name``. The caller is expected to update its state and retry
+    once with the new name. Unresolvable 301s and all other non-2xx
+    statuses propagate via ``raise_for_status`` as before.
     """
     r = client.get(f"{_GH_API}/repos/{full_name}/git/trees/HEAD", params={"recursive": "1"})
+    if r.status_code == 301:
+        location = r.headers.get("Location") or r.headers.get("location")
+        if location:
+            new_name = _resolve_renamed_repo(client, location)
+            if new_name and new_name != full_name:
+                raise RepoRenamed(new_name)
     r.raise_for_status()
     tree = r.json().get("tree", [])
     docs: list[str] = []
@@ -162,12 +214,34 @@ def inventory_repo(
     api_client: Any,  # GitHubRateLimitedClient or httpx.Client (tests)
     raw_client: httpx.Client,
 ) -> dict[str, Any]:
-    """Walk one repo. Returns ``{"doc_files": [...], "urls": [(url, file, line), ...]}``.
+    """Walk one repo. Returns ``{"doc_files": [...], "urls": [...], "renamed_from": ..., "current_full_name": ...}``.
 
     Raises on tree-list failure (so the caller can mark the repo errored).
     Per-file fetch failures are silently skipped (logged at debug).
+
+    Per #250, if the trees API responds with a 301 redirect pointing at a
+    new repo location, ``_list_doc_files`` raises ``RepoRenamed``. We
+    perform exactly one retry under the new name. If the retry also
+    redirects, the exception propagates — multi-rename chains are out of
+    scope and not worth a loop.
+
+    Result keys:
+
+    * ``doc_files`` — list of doc-file paths under the (possibly renamed) repo
+    * ``urls`` — extracted URLs as ``(url, source_file, line_number)`` tuples
+    * ``renamed_from`` — the original ``full_name`` argument iff a rename was
+      followed; otherwise ``None``
+    * ``current_full_name`` — the name under which inventory actually
+      succeeded (= the original name when no rename happened)
     """
-    docs = _list_doc_files(api_client, full_name)
+    renamed_from: str | None = None
+    try:
+        docs = _list_doc_files(api_client, full_name)
+    except RepoRenamed as e:
+        renamed_from = full_name
+        full_name = e.new_full_name
+        # One-shot retry under the new name.
+        docs = _list_doc_files(api_client, full_name)
     urls: list[tuple[str, str, int]] = []
     seen: set[str] = set()
     for path in docs:
@@ -186,7 +260,12 @@ def inventory_repo(
                 break
         if len(urls) >= MAX_URLS_PER_REPO:
             break
-    return {"doc_files": docs, "urls": urls}
+    return {
+        "doc_files": docs,
+        "urls": urls,
+        "renamed_from": renamed_from,
+        "current_full_name": full_name,
+    }
 
 
 def build_api_client(token: str | None = None) -> Any:

--- a/src/gh_link_auditor/bulk_scan/runner.py
+++ b/src/gh_link_auditor/bulk_scan/runner.py
@@ -144,6 +144,13 @@ def run_inventory(db: UnifiedDatabase, run_id: str, token: str | None = None) ->
                 full_name = repo["repo_full_name"]
                 try:
                     result = inventory.inventory_repo(full_name, api, raw)
+                    # #250: if the repo was renamed on GitHub, follow it and
+                    # update DB state before recording the inventory results.
+                    renamed_from = result.get("renamed_from")
+                    if renamed_from:
+                        current_name = result.get("current_full_name") or full_name
+                        if storage.apply_repo_rename(db, run_id, renamed_from, current_name):
+                            full_name = current_name
                     storage.update_repo_inventory(db, run_id, full_name, result["doc_files"], len(result["urls"]))
                     # Cache the (url, file, line) trios on the repo row via finding rows
                     # (lightweight: we just need to scan them in Stage 2/3; store them in findings

--- a/src/gh_link_auditor/bulk_scan/storage.py
+++ b/src/gh_link_auditor/bulk_scan/storage.py
@@ -133,6 +133,50 @@ def update_repo_status(
         )
 
 
+def apply_repo_rename(
+    db: UnifiedDatabase,
+    run_id: str,
+    old_full_name: str,
+    new_full_name: str,
+) -> bool:
+    """Move a repo row from ``old_full_name`` to ``new_full_name`` (#250).
+
+    Updates ``bulk_scan_repos`` primary key in place and records the old name
+    in ``previous_full_name``. Also propagates the rename to any existing
+    ``bulk_scan_findings`` rows so they stay linked to the repo row.
+
+    Returns ``True`` when the rename was applied. Returns ``False`` if a row
+    already exists for ``(run_id, new_full_name)`` — a rare PK-collision case
+    that we don't try to merge automatically; the caller should continue
+    operating under ``old_full_name`` rather than corrupt either row.
+    """
+    if old_full_name == new_full_name:
+        return False
+    with db._conn:
+        existing = db._conn.execute(
+            "SELECT 1 FROM bulk_scan_repos WHERE run_id = ? AND repo_full_name = ?",
+            (run_id, new_full_name),
+        ).fetchone()
+        if existing is not None:
+            logger.warning(
+                "apply_repo_rename: PK collision; both %r and %r exist in run %s — not renaming",
+                old_full_name,
+                new_full_name,
+                run_id,
+            )
+            return False
+        db._conn.execute(
+            "UPDATE bulk_scan_repos SET repo_full_name = ?, previous_full_name = ?, updated_at = ? "
+            "WHERE run_id = ? AND repo_full_name = ?",
+            (new_full_name, old_full_name, _now_iso(), run_id, old_full_name),
+        )
+        db._conn.execute(
+            "UPDATE bulk_scan_findings SET repo_full_name = ? WHERE run_id = ? AND repo_full_name = ?",
+            (new_full_name, run_id, old_full_name),
+        )
+    return True
+
+
 def get_repos_by_status(
     db: UnifiedDatabase,
     run_id: str,

--- a/src/gh_link_auditor/unified_db.py
+++ b/src/gh_link_auditor/unified_db.py
@@ -21,7 +21,7 @@ from gh_link_auditor.models import BlacklistEntry, InteractionRecord, Interactio
 logger = logging.getLogger(__name__)
 
 DEFAULT_DB_PATH = Path.home() / ".ghla" / "ghla.db"
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 8
 
 
 class UnifiedDatabase:
@@ -329,6 +329,7 @@ class UnifiedDatabase:
                 surface_candidate_count INTEGER DEFAULT 0,
                 error TEXT,
                 detected_language TEXT,
+                previous_full_name TEXT,
                 updated_at TEXT NOT NULL,
                 PRIMARY KEY (run_id, repo_full_name)
             )
@@ -395,6 +396,8 @@ class UnifiedDatabase:
             self._migrate_v5_to_v6()
         if from_version <= 6:
             self._migrate_v6_to_v7()
+        if from_version <= 7:
+            self._migrate_v7_to_v8()
 
     def _migrate_v1_to_v2(self) -> None:
         logger.info("Migrating schema v1 → v2")
@@ -578,8 +581,21 @@ class UnifiedDatabase:
                 PRIMARY KEY (run_id, host)
             )
         """)
-        c.execute("UPDATE schema_version SET version = ?", (SCHEMA_VERSION,))
+        c.execute("UPDATE schema_version SET version = ?", (7,))
         logger.info("Migration to v7 complete")
+
+    # ------------------------------------------------------------------
+    # Migration v7 -> v8: bulk_scan_repos.previous_full_name column (#250)
+    # ------------------------------------------------------------------
+
+    def _migrate_v7_to_v8(self) -> None:
+        logger.info("Migrating schema v7 → v8")
+        c = self._conn
+        cols = {row[1] for row in c.execute("PRAGMA table_info(bulk_scan_repos)").fetchall()}
+        if "previous_full_name" not in cols:
+            c.execute("ALTER TABLE bulk_scan_repos ADD COLUMN previous_full_name TEXT")
+        c.execute("UPDATE schema_version SET version = ?", (SCHEMA_VERSION,))
+        logger.info("Migration to v8 complete")
 
     # ------------------------------------------------------------------
     # External migration: import from metrics.db

--- a/tests/unit/bulk_scan/test_inventory_rename.py
+++ b/tests/unit/bulk_scan/test_inventory_rename.py
@@ -1,0 +1,244 @@
+"""Tests for #250 — follow GitHub repo-rename 301 redirects in Stage 1 inventory.
+
+Three layers exercised here:
+
+* ``RepoRenamed`` exception carries the new full_name.
+* ``_resolve_renamed_repo`` extracts repo_id from a Location URL and looks
+  up the current ``full_name`` via the GH API.
+* ``_list_doc_files`` raises ``RepoRenamed`` on 301; ``inventory_repo``
+  catches and retries once.
+
+No MagicMock — local typed fakes only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import pytest
+
+from gh_link_auditor.bulk_scan import inventory
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeResp:
+    status_code: int = 200
+    body: dict[str, Any] | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+    text: str = ""
+
+    def json(self) -> dict[str, Any]:
+        return self.body or {}
+
+    def raise_for_status(self) -> None:
+        if 300 <= self.status_code < 400 or self.status_code >= 400:
+            request = httpx.Request("GET", "https://fake.test")
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=request,
+                response=response,
+            )
+
+
+class _ScriptedAPIClient:
+    """Returns responses from a queue, one per call.
+
+    If the queue exhausts, raises AssertionError — catches over-calling bugs.
+    """
+
+    def __init__(self, responses: list[_FakeResp]) -> None:
+        self._responses = list(responses)
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, url: str, **kwargs: Any) -> _FakeResp:
+        self.calls.append((url, kwargs))
+        assert self._responses, f"unexpected call to {url}"
+        return self._responses.pop(0)
+
+
+@dataclass
+class _StubRawResp:
+    status_code: int = 200
+    text: str = ""
+
+
+class _StubRawClient:
+    """Returns 200 + empty body for any URL — for inventory_repo happy path."""
+
+    def get(self, url: str, **kwargs: Any) -> _StubRawResp:
+        return _StubRawResp()
+
+
+# ---------------------------------------------------------------------------
+# A. RepoRenamed exception
+# ---------------------------------------------------------------------------
+
+
+class TestRepoRenamedException:
+    def test_carries_new_full_name(self) -> None:
+        e = inventory.RepoRenamed("new/name")
+        assert e.new_full_name == "new/name"
+
+    def test_string_repr_mentions_new_name(self) -> None:
+        e = inventory.RepoRenamed("foo/bar")
+        assert "foo/bar" in str(e)
+
+
+# ---------------------------------------------------------------------------
+# B. _resolve_renamed_repo
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRenamedRepo:
+    def test_extracts_id_and_returns_new_full_name(self) -> None:
+        api = _ScriptedAPIClient([_FakeResp(status_code=200, body={"full_name": "NewOwner/repo"})])
+        result = inventory._resolve_renamed_repo(
+            api,
+            "https://api.github.com/repositories/969637328/git/trees/HEAD?recursive=1",
+        )
+        assert result == "NewOwner/repo"
+        # Should have called /repositories/{id} exactly once.
+        assert len(api.calls) == 1
+        called_url, _ = api.calls[0]
+        assert "/repositories/969637328" in called_url
+
+    def test_returns_none_when_no_id_in_location(self) -> None:
+        api = _ScriptedAPIClient([])  # should never be called
+        result = inventory._resolve_renamed_repo(api, "https://api.github.com/foo/bar")
+        assert result is None
+        assert api.calls == []
+
+    def test_returns_none_when_lookup_404s(self) -> None:
+        api = _ScriptedAPIClient([_FakeResp(status_code=404)])
+        result = inventory._resolve_renamed_repo(api, "https://api.github.com/repositories/123/git/trees/HEAD")
+        assert result is None
+
+    def test_returns_none_when_response_has_no_full_name(self) -> None:
+        api = _ScriptedAPIClient(
+            [_FakeResp(status_code=200, body={"id": 123})]  # no full_name
+        )
+        result = inventory._resolve_renamed_repo(api, "https://api.github.com/repositories/123/git/trees/HEAD")
+        assert result is None
+
+    def test_returns_none_when_lookup_raises(self) -> None:
+        class _Boom:
+            def get(self, url: str, **kwargs: Any) -> _FakeResp:
+                raise httpx.ConnectError("network down")
+
+        result = inventory._resolve_renamed_repo(
+            _Boom(),
+            "https://api.github.com/repositories/123/git/trees/HEAD",
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# C. _list_doc_files 301 detection
+# ---------------------------------------------------------------------------
+
+
+class TestListDocFilesHandles301:
+    def test_raises_repo_renamed_on_301_with_valid_location(self) -> None:
+        # First call: 301 redirect with Location header.
+        # Second call (the /repositories/{id} lookup): returns new full_name.
+        api = _ScriptedAPIClient(
+            [
+                _FakeResp(
+                    status_code=301,
+                    headers={"Location": "https://api.github.com/repositories/969637328/git/trees/HEAD?recursive=1"},
+                ),
+                _FakeResp(status_code=200, body={"full_name": "NewOwner/LUFFY"}),
+            ]
+        )
+        with pytest.raises(inventory.RepoRenamed) as exc:
+            inventory._list_doc_files(api, "ElliottYan/LUFFY")
+        assert exc.value.new_full_name == "NewOwner/LUFFY"
+
+    def test_falls_through_when_301_location_unresolvable(self) -> None:
+        # 301 with Location that has no /repositories/{id} pattern.
+        api = _ScriptedAPIClient(
+            [
+                _FakeResp(
+                    status_code=301,
+                    headers={"Location": "https://example.com/elsewhere"},
+                ),
+            ]
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            inventory._list_doc_files(api, "owner/repo")
+
+    def test_404_still_raises_normal_httpstatuserror(self) -> None:
+        api = _ScriptedAPIClient([_FakeResp(status_code=404)])
+        with pytest.raises(httpx.HTTPStatusError):
+            inventory._list_doc_files(api, "deleted/repo")
+
+    def test_200_no_rename_no_exception(self) -> None:
+        api = _ScriptedAPIClient([_FakeResp(status_code=200, body={"tree": [{"type": "blob", "path": "README.md"}]})])
+        docs = inventory._list_doc_files(api, "owner/repo")
+        assert docs == ["README.md"]
+
+
+# ---------------------------------------------------------------------------
+# D. inventory_repo retry behavior
+# ---------------------------------------------------------------------------
+
+
+class TestInventoryRepoHandlesRename:
+    def test_rename_then_success_returns_renamed_from(self) -> None:
+        # Call 1: 301 redirect.
+        # Call 2: /repositories/{id} → new full_name.
+        # Call 3: trees API for the new name → 200 with a blob.
+        api = _ScriptedAPIClient(
+            [
+                _FakeResp(
+                    status_code=301,
+                    headers={"Location": "https://api.github.com/repositories/123/git/trees/HEAD?recursive=1"},
+                ),
+                _FakeResp(status_code=200, body={"full_name": "new/name"}),
+                _FakeResp(status_code=200, body={"tree": [{"type": "blob", "path": "README.md"}]}),
+            ]
+        )
+        raw = _StubRawClient()
+        result = inventory.inventory_repo("old/name", api, raw)
+        assert result["renamed_from"] == "old/name"
+        assert result["current_full_name"] == "new/name"
+        assert "README.md" in result["doc_files"]
+
+    def test_no_rename_returns_renamed_from_none(self) -> None:
+        api = _ScriptedAPIClient([_FakeResp(status_code=200, body={"tree": [{"type": "blob", "path": "README.md"}]})])
+        raw = _StubRawClient()
+        result = inventory.inventory_repo("owner/repo", api, raw)
+        assert result["renamed_from"] is None
+        assert result["current_full_name"] == "owner/repo"
+
+    def test_double_rename_propagates(self) -> None:
+        # Call 1: 301 redirect from old/name.
+        # Call 2: /repositories/{id} → new/name.
+        # Call 3: retry against new/name ALSO 301s.
+        # Call 4: /repositories/{id2} → would be another newer/name, but the
+        # retry doesn't catch RepoRenamed a second time, so the exception
+        # propagates out of inventory_repo.
+        api = _ScriptedAPIClient(
+            [
+                _FakeResp(
+                    status_code=301,
+                    headers={"Location": "https://api.github.com/repositories/100/git/trees/HEAD?recursive=1"},
+                ),
+                _FakeResp(status_code=200, body={"full_name": "second/name"}),
+                _FakeResp(
+                    status_code=301,
+                    headers={"Location": "https://api.github.com/repositories/200/git/trees/HEAD?recursive=1"},
+                ),
+                _FakeResp(status_code=200, body={"full_name": "third/name"}),
+            ]
+        )
+        raw = _StubRawClient()
+        with pytest.raises(inventory.RepoRenamed):
+            inventory.inventory_repo("first/name", api, raw)

--- a/tests/unit/bulk_scan/test_inventory_sanitize.py
+++ b/tests/unit/bulk_scan/test_inventory_sanitize.py
@@ -25,6 +25,8 @@ class _FakeTreeResp:
     """Minimal stand-in for the httpx Response from the trees API."""
 
     tree: list[dict[str, Any]]
+    status_code: int = 200
+    headers: dict[str, str] = field(default_factory=dict)
 
     def json(self) -> dict[str, Any]:
         return {"tree": self.tree}

--- a/tests/unit/bulk_scan/test_storage.py
+++ b/tests/unit/bulk_scan/test_storage.py
@@ -8,7 +8,7 @@ from gh_link_auditor.unified_db import SCHEMA_VERSION, UnifiedDatabase
 
 class TestSchemaV7:
     def test_schema_version(self) -> None:
-        assert SCHEMA_VERSION == 7
+        assert SCHEMA_VERSION == 8
 
     def test_fresh_db_has_bulk_scan_tables(self, tmp_path) -> None:
         with UnifiedDatabase(str(tmp_path / "x.db")) as db:

--- a/tests/unit/bulk_scan/test_storage_rename.py
+++ b/tests/unit/bulk_scan/test_storage_rename.py
@@ -1,0 +1,212 @@
+"""Tests for #250 — schema v8 + ``storage.apply_repo_rename``.
+
+The migration adds ``bulk_scan_repos.previous_full_name TEXT NULL``. The
+storage helper updates the PK and propagates the rename to ``bulk_scan_findings``
+so finding rows stay linked.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from gh_link_auditor.bulk_scan import storage
+from gh_link_auditor.unified_db import SCHEMA_VERSION, UnifiedDatabase
+
+# ---------------------------------------------------------------------------
+# Schema migration
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaV8AddsPreviousFullName:
+    def test_fresh_db_has_previous_full_name_column(self, tmp_path) -> None:
+        with UnifiedDatabase(str(tmp_path / "x.db")) as db:
+            cols = {r[1] for r in db._conn.execute("PRAGMA table_info(bulk_scan_repos)")}
+            assert "previous_full_name" in cols
+
+    def test_schema_version_advances_to_8(self) -> None:
+        assert SCHEMA_VERSION >= 8
+
+    def test_migration_v7_to_v8_adds_column(self, tmp_path) -> None:
+        """A pre-existing v7 DB (without previous_full_name) gets the column on next open."""
+        db_path = str(tmp_path / "y.db")
+        # Bootstrap a fresh DB then simulate a v7 state by dropping the column +
+        # rolling back schema_version.
+        with UnifiedDatabase(db_path):
+            pass
+        con = sqlite3.connect(db_path)
+        con.execute("UPDATE schema_version SET version = 7")
+        # SQLite has no native DROP COLUMN; recreate the table without it.
+        con.executescript(
+            """
+            CREATE TABLE bulk_scan_repos_old AS SELECT
+                run_id, repo_full_name, stars, pushed_at, status,
+                doc_files_json, url_count, dead_url_count,
+                surface_candidate_count, error, detected_language,
+                updated_at
+            FROM bulk_scan_repos;
+            DROP TABLE bulk_scan_repos;
+            CREATE TABLE bulk_scan_repos (
+                run_id TEXT NOT NULL,
+                repo_full_name TEXT NOT NULL,
+                stars INTEGER,
+                pushed_at TEXT,
+                status TEXT NOT NULL DEFAULT 'pending',
+                doc_files_json TEXT,
+                url_count INTEGER DEFAULT 0,
+                dead_url_count INTEGER DEFAULT 0,
+                surface_candidate_count INTEGER DEFAULT 0,
+                error TEXT,
+                detected_language TEXT,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (run_id, repo_full_name)
+            );
+            INSERT INTO bulk_scan_repos SELECT * FROM bulk_scan_repos_old;
+            DROP TABLE bulk_scan_repos_old;
+            """
+        )
+        con.commit()
+        con.close()
+
+        # Re-open via UnifiedDatabase → v7→v8 migration runs.
+        with UnifiedDatabase(db_path) as db:
+            cols = {r[1] for r in db._conn.execute("PRAGMA table_info(bulk_scan_repos)")}
+            assert "previous_full_name" in cols
+            ver = db._conn.execute("SELECT version FROM schema_version").fetchone()[0]
+            assert ver == SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# storage.apply_repo_rename
+# ---------------------------------------------------------------------------
+
+
+class TestApplyRepoRename:
+    def test_renames_existing_row_and_sets_previous_full_name(self, tmp_path) -> None:
+        with UnifiedDatabase(str(tmp_path / "x.db")) as db:
+            storage.create_run(db, "r1", 1, {})
+            storage.upsert_repo(db, "r1", "old/name", stars=42)
+
+            applied = storage.apply_repo_rename(db, "r1", "old/name", "new/name")
+            assert applied is True
+
+            row = db._conn.execute(
+                "SELECT repo_full_name, previous_full_name, stars FROM bulk_scan_repos WHERE run_id = ?",
+                ("r1",),
+            ).fetchone()
+            assert row["repo_full_name"] == "new/name"
+            assert row["previous_full_name"] == "old/name"
+            assert row["stars"] == 42  # other columns preserved
+
+    def test_propagates_rename_to_findings(self, tmp_path) -> None:
+        with UnifiedDatabase(str(tmp_path / "x.db")) as db:
+            storage.create_run(db, "r1", 1, {})
+            storage.upsert_repo(db, "r1", "old/name")
+            storage.add_finding(
+                db,
+                "r1",
+                "old/name",
+                "README.md",
+                1,
+                "http://dead.example.com/",
+                candidate_url="",
+                method="pending",
+                tier=0,
+                similarity_score=None,
+                verified_live=False,
+                confidence=0.0,
+            )
+
+            assert storage.apply_repo_rename(db, "r1", "old/name", "new/name") is True
+
+            rows = db._conn.execute(
+                "SELECT repo_full_name FROM bulk_scan_findings WHERE run_id = ?",
+                ("r1",),
+            ).fetchall()
+            assert {r["repo_full_name"] for r in rows} == {"new/name"}
+
+    def test_collision_returns_false_and_leaves_data_intact(self, tmp_path) -> None:
+        with UnifiedDatabase(str(tmp_path / "x.db")) as db:
+            storage.create_run(db, "r1", 1, {})
+            storage.upsert_repo(db, "r1", "old/name", stars=10)
+            storage.upsert_repo(db, "r1", "new/name", stars=20)
+
+            applied = storage.apply_repo_rename(db, "r1", "old/name", "new/name")
+            assert applied is False
+
+            # Both rows still exist with their original data.
+            rows = {
+                r["repo_full_name"]: r
+                for r in db._conn.execute(
+                    "SELECT repo_full_name, stars, previous_full_name FROM bulk_scan_repos WHERE run_id = ?",
+                    ("r1",),
+                ).fetchall()
+            }
+            assert set(rows) == {"old/name", "new/name"}
+            assert rows["old/name"]["previous_full_name"] is None
+            assert rows["new/name"]["previous_full_name"] is None
+
+    def test_same_name_is_noop(self, tmp_path) -> None:
+        with UnifiedDatabase(str(tmp_path / "x.db")) as db:
+            storage.create_run(db, "r1", 1, {})
+            storage.upsert_repo(db, "r1", "same/name")
+            assert storage.apply_repo_rename(db, "r1", "same/name", "same/name") is False
+            row = db._conn.execute(
+                "SELECT previous_full_name FROM bulk_scan_repos WHERE run_id = ?",
+                ("r1",),
+            ).fetchone()
+            assert row["previous_full_name"] is None
+
+
+# ---------------------------------------------------------------------------
+# Runner integration — the run_inventory loop calls apply_repo_rename
+# ---------------------------------------------------------------------------
+
+
+class TestRunInventoryHandlesRename:
+    """Stage 1's run_inventory uses inventory_repo's renamed_from signal to
+    update bulk_scan_repos atomically with the new name before recording
+    findings (#250).
+    """
+
+    def test_rename_updates_repo_row_and_findings_use_new_name(self, tmp_path) -> None:
+        from unittest.mock import patch
+
+        from gh_link_auditor.bulk_scan import inventory, runner
+
+        with UnifiedDatabase(str(tmp_path / "x.db")) as db:
+            storage.create_run(db, "r1", 1, {})
+            storage.upsert_repo(db, "r1", "old/name")
+
+            fake_inventory_result = {
+                "doc_files": ["README.md"],
+                "urls": [("https://example.org/x", "README.md", 1)],
+                "renamed_from": "old/name",
+                "current_full_name": "new/name",
+            }
+
+            class _StubClient:
+                def close(self) -> None:
+                    return None
+
+            with (
+                patch.object(inventory, "inventory_repo", return_value=fake_inventory_result),
+                patch.object(inventory, "build_api_client", return_value=_StubClient()),
+                patch.object(inventory, "build_raw_client", return_value=_StubClient()),
+            ):
+                runner.run_inventory(db, "r1")
+
+            row = db._conn.execute(
+                "SELECT repo_full_name, previous_full_name, status FROM bulk_scan_repos WHERE run_id = ?",
+                ("r1",),
+            ).fetchone()
+            assert row["repo_full_name"] == "new/name"
+            assert row["previous_full_name"] == "old/name"
+            assert row["status"] == "inventoried"
+
+            findings = db._conn.execute(
+                "SELECT repo_full_name, dead_url FROM bulk_scan_findings WHERE run_id = ?",
+                ("r1",),
+            ).fetchall()
+            assert len(findings) == 1
+            assert findings[0]["repo_full_name"] == "new/name"
+            assert findings[0]["dead_url"] == "https://example.org/x"


### PR DESCRIPTION
## Summary

- Detect 301 from GitHub trees API on renamed repos, resolve the new \`full_name\` via the numeric-ID endpoint, and retry inventory once under the new name. Previously: \`HTTPStatusError\` aborted the repo's entire inventory.
- New \`storage.apply_repo_rename\` atomically updates the PK in \`bulk_scan_repos\` + records the old name in \`previous_full_name\` + propagates the rename to \`bulk_scan_findings\` rows.
- Schema v7 → v8 adds \`previous_full_name TEXT NULL\` via additive ALTER TABLE.
- \`runner.run_inventory\` wires it together; on rename, calls apply_repo_rename then continues inventory under the new name.

Real cases driving this: tonight's Stage 1 of \`bulk-20260514T042627Z\` had \`ElliottYan/LUFFY\` (renamed → \`/repositories/969637328\`) and \`tukuaiai/tradecat\` (renamed → \`/repositories/1125036278\`) errored. Both are alive at their new names; this PR makes them recoverable on a re-run.

## Test plan

- [x] 22 new tests (14 inventory layer, 8 storage layer + runner integration)
- [x] All 168 bulk_scan tests pass (146 pre-existing + 22 new)
- [x] \`ruff format\` + \`ruff check\` clean
- [x] 100% coverage on new code (RepoRenamed exception, \`_resolve_renamed_repo\`, 301 branch in \`_list_doc_files\`, retry in \`inventory_repo\`, \`apply_repo_rename\`, schema migration, runner wiring)
- [x] Schema migration v7 → v8 tested both fresh-bootstrap and pre-existing-v7-DB paths
- [x] Edge cases: unresolvable 301 (no \`/repositories/{id}\`), 404 lookup, no \`full_name\` in response, network error, PK collision, same-name no-op, double rename — all covered
- [ ] Post-merge manual verification: run \`bulk-scan start --run-id bulk-20260514T042627Z\` and confirm the 2 previously-errored renamed repos land in \`'inventoried'\` with \`previous_full_name\` set (operator-driven follow-up — requires resetting their status from 'error' to 'pending' first)

## Files

- \`src/gh_link_auditor/bulk_scan/inventory.py\` — \`RepoRenamed\` exception, \`_resolve_renamed_repo\` helper, 301 detection in \`_list_doc_files\`, retry logic in \`inventory_repo\`
- \`src/gh_link_auditor/bulk_scan/storage.py\` — \`apply_repo_rename\` helper
- \`src/gh_link_auditor/bulk_scan/runner.py\` — Stage 1 wiring
- \`src/gh_link_auditor/unified_db.py\` — schema v8 bootstrap + \`_migrate_v7_to_v8\`
- \`tests/unit/bulk_scan/test_inventory_rename.py\` — 14 tests (new file)
- \`tests/unit/bulk_scan/test_storage_rename.py\` — 8 tests (new file)
- \`tests/unit/bulk_scan/test_storage.py\` — \`SCHEMA_VERSION\` assertion bumped 7→8
- \`tests/unit/bulk_scan/test_inventory_sanitize.py\` — \`_FakeTreeResp\` gained \`status_code\` and \`headers\` for the 301 check
- \`docs/lld/active/LLD-250.md\` + \`docs/reports/active/10250-{implementation,test}-report.md\`

## Notes

- \`tools/finish_stage1.py\` (untracked session tool) does **not** yet honor the new \`renamed_from\` field. Operator-time follow-up. The canonical \`bulk-scan start\` path through \`runner.run_inventory\` does benefit from this PR.

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)