### PR TITLE
fix(github_resolver): pass follow_redirects=True for renamed-repo 301s

### DIFF
--- a/docs/reports/active/10264-implementation-report.md
+++ b/docs/reports/active/10264-implementation-report.md
@@ -1,0 +1,59 @@
+# Implementation Report: #264 follow_redirects=True regression after #257
+
+## Summary
+
+#257 routed `github_resolver` from `urllib.request.urlopen` through `GitHubRateLimitedClient.get(url)`. urllib follows 301 redirects by default; `httpx.Client` does not. The whole point of `resolve_repo_redirect` is to follow GitHub's 301 for a renamed repo, so this silently broke rename detection in production.
+
+Smoking gun in live Stage 3 output post-#257 merge (2026-05-23 09:51):
+
+```
+INFO  | github_resolver | GitHub redirect detected: Open-Catalyst-Project/ocp ->
+INFO  | github_resolver | GitHub redirect detected: Open-Catalyst-Project/ocp ->
+```
+
+Empty after the arrow → `data.get("full_name", "")` returned `""` → 301 body (`{"message": "Moved Permanently", ...}`) had no `full_name`. Same 100% no-cand symptom that motivated #257, different cause.
+
+## Changes
+
+### `src/gh_link_auditor/github_resolver.py`
+
+One line:
+
+```python
+r = active.get(url, follow_redirects=True)
+```
+
+with an inline comment naming the regression and pointing at #264. Matches the convention every other caller of `GitHubRateLimitedClient` already follows (`bulk_scan/inventory.py:204`, `:300`; `bulk_scan/language.py:36`).
+
+### `tests/unit/test_github_resolver.py`
+
+- `_FakeRateLimitedClient` gained a `call_kwargs: list[dict]` field; `.get()` records the kwargs of each call. Backwards-compatible (just an additional attribute).
+- New test `TestGitHubApiGet.test_api_get_passes_follow_redirects_true` — asserts `fake.call_kwargs == [{"follow_redirects": True}]` after a single `_github_api_get` call. This is the precise contract: every API call must carry the kwarg. A future maintainer who deletes the flag will see this test fail with the literal diff.
+
+## Why the existing #257 tests didn't catch this
+
+- `TestResolveRepoRedirect` mocks `_github_api_get` directly with pre-followed response dicts. It never exercises the 301 path.
+- `TestGitHubApiGet` (the rewritten class) mocks the client and feeds pre-shaped responses. The mock client doesn't behave like httpx — it just returns what you tell it.
+- `TestRateLimitBehavior` stubs `_client.request` directly, synthesizing responses. The redirect machinery (which lives in `httpx.Client.send` for follow_redirects-aware paths) is never touched.
+
+All three test layers mock *above* the layer that needed to be verified. The kwarg-passing test now sits at the exact boundary that was broken: the call from `_github_api_get` into the rate-limited client.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `src/gh_link_auditor/github_resolver.py` | +1 kwarg + comment |
+| `tests/unit/test_github_resolver.py` | +1 attr on fake; +1 new test |
+
+## Test count
+
+31 in `test_github_resolver.py` (+1 from #263's 30). Full suite: **2,158 passed, 1 skipped** (+1 net).
+
+## Coverage
+
+`src/gh_link_auditor/github_resolver.py` unchanged at 97% (the new line is exercised by the new test plus every test that goes through `_github_api_get`).
+
+## Out of scope
+
+- Diagnosing the `archive_client` log spam — tracked as #265, separate issue.
+- Stripping the `token=` kwarg from `_github_api_get` — orthogonal cleanup; would churn callers for no behavior change.

--- a/docs/reports/active/10264-test-report.md
+++ b/docs/reports/active/10264-test-report.md
@@ -1,0 +1,64 @@
+# Test Report: #264 follow_redirects=True regression after #257
+
+## Local verification
+
+### Targeted RED → GREEN
+
+Before the fix (after only the test was added):
+
+```
+$ pytest tests/unit/test_github_resolver.py::TestGitHubApiGet::test_api_get_passes_follow_redirects_true --tb=short
+F
+AssertionError: assert [{}] == [{'follow_redirects': True}]
+  At index 0 diff: {} != {'follow_redirects': True}
+1 failed in 0.16s
+```
+
+After the one-line fix:
+
+```
+$ pytest tests/unit/test_github_resolver.py
+31 passed in 0.58s
+```
+
+### Full suite
+
+```
+$ pytest -q --tb=line
+2158 passed, 1 skipped, 1 warning in 125.37s (0:02:05)
+```
+
+No regressions vs. the post-#263 baseline (2,157 passed, 1 skipped).
+
+### Lint + format
+
+```
+$ ruff format src/gh_link_auditor/github_resolver.py tests/unit/test_github_resolver.py
+2 files left unchanged
+$ ruff check src/gh_link_auditor/github_resolver.py tests/unit/test_github_resolver.py
+All checks passed!
+```
+
+## CI verification
+
+Standard gate: Test, Lint, auto-review, pr-sentinel.
+
+## Runtime verification path
+
+This PR fixes a *runtime* symptom — the 100% no-candidate rate that persisted after #257. The unit test proves the kwarg is in the call; the runtime fix is verified by re-running Stage 3 against `bulk-20260514T042627Z` after merge and watching:
+
+- `data/finish-stage3-status.txt` — `investigated_with_candidate` should start incrementing (it sat at 0 during the post-#257 run that showed the empty-arrow log lines).
+- `recent_no_cand_rate` should drop below 95% within the first few hundred investigations as renamed-repo redirects start surfacing valid candidates again.
+- `github_resolver` INFO log lines should now show the full target after the arrow: `GitHub redirect detected: Open-Catalyst-Project/ocp -> facebookresearch/fairchem` (or similar) — not empty.
+
+The operator runs the post-merge Stage 3 re-execution; this PR doesn't bundle that verification.
+
+## Lessons learned (for the LL log)
+
+- **urllib auto-follows 301; httpx does not.** When migrating any urllib-based call to an `httpx.Client`-based one, explicit `follow_redirects=True` is almost always required when the endpoint can legitimately redirect. Easy to miss because all the existing #257 tests mocked above the boundary that mattered.
+- **Mock-above-the-defect tests cannot catch defects at that boundary.** The #257 suite was thorough at every layer except the one that broke. A test that asserts the literal kwarg passed to the underlying client closes the gap, and is cheap.
+
+## Out of scope (tests deliberately not written)
+
+- Real-network integration against `api.github.com` to verify httpx actually follows 301 when `follow_redirects=True`. That's httpx-library behavior, not ours; we'd be re-testing httpx.
+- Coverage of the rate-limited client's redirect-aware path (e.g., what happens if both the redirect target and the original URL are rate-limited). #224's existing tests at `tests/unit/bulk_scan/test_gh_client.py` cover the rate-limit machinery; this PR is scoped to the kwarg passthrough.

--- a/src/gh_link_auditor/github_resolver.py
+++ b/src/gh_link_auditor/github_resolver.py
@@ -81,7 +81,12 @@ def _github_api_get(
     """
     active = client if client is not None else _get_default_client()
     try:
-        r = active.get(url)
+        # #264 — must follow 301s. urllib (pre-#257) did so by default;
+        # httpx.Client does NOT, which silently broke GitHub's
+        # repo-renamed-to-new-owner detection by returning the 301
+        # response body (which has no full_name) instead of the followed
+        # target.
+        r = active.get(url, follow_redirects=True)
     except httpx.HTTPError:
         logger.warning("GitHub API request failed for %s", url)
         return None

--- a/tests/unit/test_github_resolver.py
+++ b/tests/unit/test_github_resolver.py
@@ -63,9 +63,11 @@ class _FakeRateLimitedClient:
         self._responses = list(responses or [])
         self._side_effect = side_effect
         self.calls: list[str] = []
+        self.call_kwargs: list[dict[str, Any]] = []
 
     def get(self, url: str, **kwargs: Any) -> _FakeHttpxResponse:
         self.calls.append(url)
+        self.call_kwargs.append(kwargs)
         if self._side_effect is not None:
             raise self._side_effect
         if self._responses:
@@ -262,6 +264,21 @@ class TestGitHubApiGet:
         )
         result = _github_api_get("https://api.github.com/repos/owner/repo", client=fake)
         assert result is None
+
+    def test_api_get_passes_follow_redirects_true(self):
+        """#264 — must pass follow_redirects=True so GitHub's 301-for-renamed-repos works.
+
+        Without this flag, httpx returns the 301 response itself (body is
+        ``{"message": "Moved Permanently", ...}``), which has no ``full_name``
+        field. ``resolve_repo_redirect`` then logs an empty-target redirect
+        and returns a garbage URL. urllib followed redirects implicitly; the
+        rate-limited httpx client does not.
+        """
+        fake = _FakeRateLimitedClient(
+            response=_FakeHttpxResponse(status_code=200, json_data={"full_name": "owner/repo"}),
+        )
+        _github_api_get("https://api.github.com/repos/owner/repo", client=fake)
+        assert fake.call_kwargs == [{"follow_redirects": True}]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

#257 broke rename detection: urllib (pre-#257) followed 301s by default; `httpx.Client` (post-#257) does not. The whole point of `resolve_repo_redirect` is to follow GitHub's 301 for a renamed repo, so this silently produced empty `full_name` values and a useless `https://github.com/` reconstruction.

Smoking gun from the post-#257 Stage 3 restart at 2026-05-23 09:51:

```
INFO  | github_resolver | GitHub redirect detected: Open-Catalyst-Project/ocp ->
INFO  | github_resolver | GitHub redirect detected: Open-Catalyst-Project/ocp ->
```

Empty after the arrow = `data.get("full_name", "")` returned `""` because the 301 body has no `full_name`. Same 100% no-cand symptom that motivated #257, different cause.

## Fix

One line in `_github_api_get`:

```python
r = active.get(url, follow_redirects=True)
```

Matches the convention every other `GitHubRateLimitedClient` caller already follows (`bulk_scan/inventory.py`, `bulk_scan/language.py`).

## Why #257's tests didn't catch this

All three layers mocked *above* the boundary that broke:

- `TestResolveRepoRedirect` mocks `_github_api_get` directly with pre-followed dicts
- `TestGitHubApiGet` mocks the client and returns pre-shaped responses
- `TestRateLimitBehavior` stubs `_client.request` and synthesizes the response

None exercise httpx's redirect-following layer. The new test sits at the exact boundary: it asserts the literal kwarg is on every call.

## Tests

| Class | Tests | Status |
|---|---:|---|
| `TestIsGitHubUrl` / `TestParseGitHubUrl` / `TestResolveRepoRedirect` / `TestReconstructFileUrl` / `TestTokenFromEnv` / `TestClientInjection` / `TestDefaultClientFactory` / `TestRateLimitBehavior` | 30 | unchanged |
| `TestGitHubApiGet.test_api_get_passes_follow_redirects_true` | 1 | **new** |
| **Total** | **31** | **+1** |

`_FakeRateLimitedClient` gained a `call_kwargs` list — backwards compatible additional attribute.

Full suite: **2158 passed, 1 skipped** (+1 net from #263).

## Closes

Closes #264

## Test plan

- [x] Targeted test fails before the fix, passes after
- [x] Full suite 2158/0 (no regressions)
- [x] `ruff format --check` + `ruff check` clean
- [ ] Post-merge: operator re-runs Stage 3 against `bulk-20260514T042627Z`; `investigated_with_candidate` counter should start moving (sat at 0 during the post-#257 run); INFO log lines should show non-empty targets after `->`

🤖 Generated with [Claude Code](https://claude.com/claude-code)