### PR TITLE
fix(tools): eager-import LinkDetective chain so setLevel(ERROR) sticks

### DIFF
--- a/docs/reports/active/10265-implementation-report.md
+++ b/docs/reports/active/10265-implementation-report.md
@@ -1,0 +1,82 @@
+# Implementation Report: #265 logger silencing not taking effect in Stage 3 tools
+
+## Summary
+
+`finish_stage3.py` (and three sibling tools) calls `logging.getLogger("archive_client").setLevel(logging.ERROR)` to silence the LinkDetective module loggers. The silencing was *not actually taking effect* — every Stage 3 run filled the operator console with CDX warnings at WARNING level.
+
+Root cause traced via a minimal repro:
+
+1. `finish_stage3.py` imports `from gh_link_auditor.bulk_scan import investigation` at top — but `investigation.investigate_one()` does `from gh_link_auditor.link_detective import LinkDetective` **lazily inside the function**.
+2. So `link_detective`, `archive_client`, etc. only get imported when the **first worker actually calls `investigate_one`** — which is after `main()`'s `setLevel(ERROR)` loop has already run.
+3. The `setLevel(ERROR)` runs on loggers that have no handlers yet (`level=NOTSET`, `propagate=True`). The set takes effect at that instant.
+4. Then the first worker triggers the lazy chain; `setup_logging("archive_client")` finally fires and **resets `level` to INFO** (and adds a StreamHandler).
+5. WARNINGs now pass the logger-level filter and reach setup_logging's StreamHandler. Spam.
+
+Probe output verifying the fix (`after eager imports (before silencing)`):
+
+```
+archive_client: level=INFO handlers=2 propagate=False
+github_resolver: level=INFO handlers=2 propagate=False
+link_detective: level=INFO handlers=2 propagate=False
+policy_checker: level=INFO handlers=2 propagate=False
+redirect_resolver: level=INFO handlers=2 propagate=False
+```
+
+`setup_logging` ran during the eager-import block. Then `setLevel(ERROR)` lands on a fully-configured logger and actually filters records.
+
+## Changes
+
+### `tools/finish_stage1.py`, `tools/finish_stage2.py`, `tools/finish_stage3.py`, `tools/detect_languages.py`
+
+All four tools gain the same eager-import block right after the existing `sys.path` setup, before any other imports:
+
+```python
+from gh_link_auditor import (  # noqa: E402
+    archive_client,  # noqa: F401
+    github_resolver,  # noqa: F401
+    link_detective,  # noqa: F401
+    policy_checker,  # noqa: F401
+    redirect_resolver,  # noqa: F401
+)
+```
+
+These are the modules whose loggers the in-`main()` `for noisy in (...): setLevel(ERROR)` loop targets. Eager-importing them forces each module's top-level `logger = setup_logging("<name>")` to run NOW, before `main()`'s silencing.
+
+### `src/gh_link_auditor/bulk_scan/host_blocklist.py` (NEW)
+
+`finish_stage3.py` imports `is_blocklisted_host` from this module. The module was untracked in the working tree from a prior session. Bundling it here so CI's import-of-finish_stage3 doesn't fail. (It's the same content the operator's been running with for the last two days: 14 `ANTI_BOT_HUMANS_OK` + 2 `PIPELINE_AND_HUMANS_BLOCKED` hosts, browser-verified.)
+
+## Why not fix setup_logging itself?
+
+Two reasons:
+
+1. **The current `setup_logging` semantic is "always reconfigure on call"** — it explicitly does `if logger.handlers: logger.handlers.clear()` then sets the level. That's intentional for callers that want to re-configure. Changing it to "preserve pre-existing levels" would silently affect any other caller.
+2. **The eager-import fix is the same shape that already works for `httpx`/`httpcore`/`urllib3`** in the same silencing list — those module loggers don't have a `setup_logging` call, so their levels stay as set. Eager-importing the LinkDetective chain makes them behave the same way.
+
+Filing a separate ticket if `setup_logging`'s "always reconfigure" semantic causes pain elsewhere — out of scope here.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `tools/finish_stage1.py` | NEW (with #265 fix applied) |
+| `tools/finish_stage2.py` | NEW (with #265 fix applied) |
+| `tools/finish_stage3.py` | NEW (with #265 fix applied) |
+| `tools/detect_languages.py` | NEW (with #265 fix applied) |
+| `src/gh_link_auditor/bulk_scan/host_blocklist.py` | NEW (required dep of finish_stage3) |
+
+All five were untracked in the working tree from the overnight session — first-time commit.
+
+## Test count
+
+Unchanged: **2158 passed, 1 skipped**. No new tests; the tools are standalone scripts and the fix is a structural import-order change verified by the repro probe.
+
+## Coverage
+
+`host_blocklist.py` is small and self-contained (~75 LoC, 1 frozenset + 1 helper). The helper has implicit coverage via every Stage 3 finding it filters. A dedicated unit test for it would be a follow-up; the operator's been running it in production for 48h without incident.
+
+## Out of scope
+
+- Refactor `setup_logging` to respect pre-existing levels. Different design conversation.
+- Commit the other six tools from the working tree (probes, `derive_host_blocklist.py`, etc.) — that's the broader #258 phase 1 PR, which the operator wants done separately.
+- Add unit tests for the four tool scripts. They run in worker-thread orchestration patterns that don't lend themselves to clean unit testing; integration is via the operator running them.

--- a/docs/reports/active/10265-test-report.md
+++ b/docs/reports/active/10265-test-report.md
@@ -1,0 +1,83 @@
+# Test Report: #265 logger silencing not taking effect in Stage 3 tools
+
+## Verification path
+
+This bug is a structural import-order problem, not a logic bug. Unit tests aren't a clean fit; the fix is verified by:
+
+1. **Diagnostic probe** that reproduces the original failure and confirms the fix
+2. **Live restart of Stage 3** by the operator post-merge (already confirmed in-session: "the spam is gone")
+3. **Full suite regression check**: 2158 passed, 1 skipped — no behavioral change to anything under test
+
+### Probe — before the fix
+
+`probe_log_silence.py` (not committed; diagnostic only). Mirrors `finish_stage3.py`'s import + silencing order *without* the eager-import block:
+
+```
+=== after import (before silencing) ===
+level: 0 (NOTSET)
+propagate: True
+handlers: 0
+```
+
+`setup_logging("archive_client")` NEVER ran during the imports because the LinkDetective chain is lazy. Logger has no handlers, propagate=True (default).
+
+### Probe — after the fix
+
+With the eager imports applied:
+
+```
+=== after eager imports (before silencing) ===
+level: 20 (INFO)
+propagate: False
+handlers: 2
+```
+
+`setup_logging` ran for all 5 modules. Then `setLevel(ERROR)` actually has something to override:
+
+```
+=== after silencing ===
+level: 40 (ERROR)
+effectiveLevel: 40 (ERROR)
+
+--- WARNING (should be SUPPRESSED): (nothing printed)
+--- ERROR (should APPEAR): 2026-05-23T... | ERROR | archive_client | TEST_ERR
+```
+
+WARNING is suppressed; ERROR passes. Exactly the contract.
+
+### Live restart
+
+The operator restarted Stage 3 with `poetry run python tools/finish_stage3.py --workers 32` after the working-tree edit. Their console output went from ~50-100 archive_client WARNINGs/sec drowning the per-minute status line to clean status lines only. Confirmed in-session.
+
+### Suite regression
+
+```
+$ poetry run pytest -q --tb=line
+2158 passed, 1 skipped, 1 warning in 149.29s
+```
+
+Same count as post-#266. No test touched.
+
+## Lint + format
+
+```
+$ ruff check tools/finish_stage1.py tools/finish_stage2.py tools/finish_stage3.py \
+    tools/detect_languages.py src/gh_link_auditor/bulk_scan/host_blocklist.py
+All checks passed!
+```
+
+ruff combined the 5 individual `from gh_link_auditor import X` lines into one parenthesized block per its import-organization rule. `# noqa: E402` on the opening `(` suppresses the "import not at top of file" warning that the `sys.path` insert above triggers (same noqa pattern as the existing `from gh_link_auditor.bulk_scan import ...` lines that already had `# noqa: E402`).
+
+## CI verification
+
+Standard gate: Test, Lint, auto-review, pr-sentinel. The tools are not imported by the package or by tests, so CI's `pytest` collection won't touch them — Lint catches any import/syntax breakage.
+
+## What's NOT tested
+
+- A unit test that imports `finish_stage3.py` and asserts the resulting logger state. Doable but brittle — the script has `_PROJECT_ROOT` resolution via `Path(__file__).resolve().parent.parent`, sys.path inserts, and a `main()` guard that argparse would block. A subprocess-based test would work but is heavy for the value.
+- The other six untracked tools (probes, `derive_host_blocklist.py`, etc.) — out of scope; #258 phase 1.
+- `setup_logging`'s "always reconfigure" semantic — possibly worth a separate ticket if it causes friction elsewhere.
+
+## Risk
+
+Structural change with no behavior change to library code. The only failure mode is a future maintainer deleting the eager imports thinking they're unused (the `# noqa: F401` is documentation; the comment block above the import explains why). The fix is verifiable by running any of the four tools and observing the absence of CDX warnings between status lines.

--- a/src/gh_link_auditor/bulk_scan/host_blocklist.py
+++ b/src/gh_link_auditor/bulk_scan/host_blocklist.py
@@ -1,0 +1,78 @@
+"""Static host blocklist for Stage 3 investigation (#258).
+
+Hosts in this set are skipped at the investigation stage — we record the
+finding row as ``investigation_state='skipped_blocklist'`` and move on
+without running LinkDetective against the URL. Saves wall time and reduces
+operator-triage noise.
+
+Two classes of hosts here:
+
+1. **Anti-bot walls where humans get through.** Findings are NOT removal-PR
+   candidates — the URLs work for real users. We just can't verify them
+   from automation. Examples: huggingface.co, medium.com, openai.com.
+
+2. **Walls that block humans too** (cert-broken, login-required without
+   public access, etc.). Findings ARE removal-PR candidates. The blocklist
+   still skips them at Stage 3 because LinkDetective can't help; the
+   findings remain in the DB for the removal-PR-derivation pass.
+
+The operator-investigation column from manual checks (browser-verified)
+should be cross-referenced when building the removal-PR queue.
+
+Conservative initial seed — only hosts with very high confidence in the
+anti-bot or rebrand classification. Expand via #258's derive workflow as
+ground-truth accumulates.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+# Hosts where humans get through but our pipeline cannot — findings on these
+# hosts are NOT removal-PR candidates.
+ANTI_BOT_HUMANS_OK: frozenset[str] = frozenset(
+    {
+        "huggingface.co",
+        "medium.com",
+        "openai.com",
+        "experimentalhistory.substack.com",
+        "dl.acm.org",
+        "ecode360.com",
+        "kalshi.com",  # login wall (browser-verified 2026-05-23)
+        "www.npmjs.com",
+        "forums.welltrainedmind.com",
+        "www.linkedin.com",  # 999 status signature
+        "notes.andymatuschak.org",
+        "glyphwiki.org",
+        "gseth.com",
+        "web.archive.org",  # findings ARE archive URLs; no replacement possible
+    }
+)
+
+# Hosts where both humans and our pipeline are blocked — findings ARE
+# removal-PR candidates (operator can file PRs to remove these references).
+# Listed here so Stage 3 skips re-investigation; the removal-PR derivation
+# pass uses these findings as input.
+PIPELINE_AND_HUMANS_BLOCKED: frozenset[str] = frozenset(
+    {
+        "opendap.4tu.nl",  # cert broken (browser-verified 2026-05-23)
+        "play.picoctf.org",  # rebranded to learn.cylabacademy.org (operator-verified)
+    }
+)
+
+# Union of all blocklisted hosts. Stage 3 consults this set.
+BLOCKLIST: frozenset[str] = ANTI_BOT_HUMANS_OK | PIPELINE_AND_HUMANS_BLOCKED
+
+
+def is_blocklisted_host(url: str) -> bool:
+    """True if the URL's host is in the static blocklist.
+
+    Stage 1 inventory can also use this to drop URLs at extraction time
+    once that integration ships (#258 Phase 2). For now, only Stage 3
+    consults this — Stage 1 inventory is unchanged.
+    """
+    try:
+        host = urlparse(url).netloc.lower()
+    except Exception:
+        return False
+    return host in BLOCKLIST

--- a/tools/detect_languages.py
+++ b/tools/detect_languages.py
@@ -1,0 +1,487 @@
+"""Backfill ``detected_language`` for every inventoried repo in a bulk-scan run.
+
+Why: Stage 3's English-only filter (#238) reads ``bulk_scan_repos.detected_language``
+and skips findings from non-English repos. For the long-stalled ``T042627Z``
+run, this column is NULL for all 7,500 repos, so the filter never fires and
+non-English-doc URLs get investigated needlessly. This program walks the
+inventoried repos, fetches each one's README from raw.githubusercontent.com,
+runs ``langdetect`` on the first ~5,000 chars, and writes the ISO code into
+``bulk_scan_repos.detected_language``.
+
+Concurrency: SAFE to run while ``finish_stage1.py`` is also running on the
+same run. We do NOT take the per-(run_id, host) bulk-scan lock — Stage 1
+writes the ``status``/``doc_files_json`` columns, this script writes only the
+``detected_language`` column. SQLite serializes writers automatically.
+
+Rate limiting: raw.githubusercontent.com is a Fastly CDN that returns 429
+under sustained bursts (~300/sec aggregate). Two layers of backoff:
+
+  * Inner (per-request): on 429, sleep for ``Retry-After`` if present, else
+    ``2s -> 4 -> 8 -> 16 -> 32 -> 64 -> 128 -> 256 -> 512 -> 900s`` (capped).
+    Max 10 retries per README variant fetch.
+
+  * Outer (per-program): if inner retries exhaust on the same repo, the
+    whole program pauses ``2 -> 5 -> 10 -> 20 -> 40 -> 80`` minutes,
+    escalating each storm. The counter never decrements -- a night of
+    repeated storms gets progressively longer waits. The repo stays
+    unclassified for now and gets retried at the end of the pass.
+
+Observability: status line every 60s + mirror to ``data/detect-languages-status.txt``.
+
+Usage::
+
+    poetry run python tools/detect_languages.py
+    poetry run python tools/detect_languages.py --run-id <other-run>
+
+Safe to re-run. Only walks repos with ``detected_language IS NULL`` and
+``status = 'inventoried'``. Idempotent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import signal
+import sqlite3
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+from langdetect import DetectorFactory, LangDetectException, detect
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+
+# #265 — eager-import the chatty modules so each module's setup_logging()
+# call fires BEFORE main()'s setLevel(ERROR) loop. Without these, the
+# silencing runs on loggers with no handlers, then setup_logging fires
+# during lazy import and resets level=INFO + adds a StreamHandler, defeating
+# the silencing.
+from gh_link_auditor import (  # noqa: E402
+    archive_client,  # noqa: F401
+    github_resolver,  # noqa: F401
+    link_detective,  # noqa: F401
+    policy_checker,  # noqa: F401
+    redirect_resolver,  # noqa: F401
+)
+from gh_link_auditor.unified_db import UnifiedDatabase  # noqa: E402
+
+DetectorFactory.seed = 0  # deterministic detection
+
+DEFAULT_RUN_ID = "bulk-20260514T042627Z"
+STATUS_FILE = _PROJECT_ROOT / "data" / "detect-languages-status.txt"
+LOG_INTERVAL_S = 60
+RAW_BASE = "https://raw.githubusercontent.com"
+README_VARIANTS = ("README.md", "README.rst", "README.txt", "README")
+MIN_TEXT_LEN = 100  # langdetect is unreliable below this
+MAX_TEXT_LEN = 5000  # cap to keep detection fast
+# Outer backoff (minutes) on sustained rate limiting from the raw CDN.
+PROGRAM_BACKOFF_MINUTES = [2, 5, 10, 20, 40, 80]
+PER_REQUEST_BASE_S = 2.0
+PER_REQUEST_MAX_S = 900.0  # 15 min cap on single retry
+PER_REQUEST_MAX_RETRIES = 10
+# Gentle inter-request floor so we don't hammer the CDN ourselves.
+INTER_REQUEST_DELAY_S = 0.2
+
+
+# ---------------------------------------------------------------------------
+
+
+class RateLimitExhausted(RuntimeError):
+    """Raised when raw-CDN 429s persist past PER_REQUEST_MAX_RETRIES."""
+
+
+@dataclass
+class Stats:
+    started_monotonic: float = field(default_factory=time.monotonic)
+    total: int = 0
+    processed_ok: int = 0
+    processed_unknown: int = 0  # README missing / too short / can't classify
+    processed_error: int = 0
+    by_lang: dict[str, int] = field(default_factory=dict)
+    program_backoff_count: int = 0
+    last_repo: str = ""
+    last_lang: str = ""
+    last_429_msg: str = ""
+
+    def elapsed_s(self) -> float:
+        return time.monotonic() - self.started_monotonic
+
+    def processed(self) -> int:
+        return self.processed_ok + self.processed_unknown + self.processed_error
+
+    def remaining(self) -> int:
+        return max(0, self.total - self.processed())
+
+    def per_min(self) -> float:
+        e = self.elapsed_s()
+        if e <= 0 or self.processed() == 0:
+            return 0.0
+        return self.processed() / (e / 60.0)
+
+    def eta_str(self) -> str:
+        rate = self.per_min()
+        if rate <= 0:
+            return "?"
+        m = self.remaining() / rate
+        return f"{m:.0f}m" if m < 60 else f"{m / 60:.1f}h"
+
+    def top_langs(self, n: int = 6) -> str:
+        items = sorted(self.by_lang.items(), key=lambda kv: kv[1], reverse=True)[:n]
+        return " ".join(f"{k}={v}" for k, v in items) if items else "-"
+
+    def render_line(self) -> str:
+        now = datetime.now().strftime("%H:%M:%S")
+        pct = (100.0 * self.processed() / self.total) if self.total else 0.0
+        bo = f" backoffs={self.program_backoff_count}" if self.program_backoff_count else ""
+        last = f" last={self.last_repo}->{self.last_lang}" if self.last_repo else ""
+        return (
+            f"[{now}] lang {self.processed():,}/{self.total:,} "
+            f"({pct:.1f}%) ok={self.processed_ok:,} unk={self.processed_unknown:,} "
+            f"err={self.processed_error:,} rate={self.per_min():.1f}/min "
+            f"ETA={self.eta_str()} top: {self.top_langs()}{bo}{last}"
+        )
+
+
+class GracefulShutdown:
+    def __init__(self) -> None:
+        self.requested = False
+        signal.signal(signal.SIGINT, self._handler)
+        try:
+            signal.signal(signal.SIGTERM, self._handler)
+        except (AttributeError, ValueError):
+            pass
+
+    def _handler(self, signum: int, frame: object) -> None:  # noqa: ARG002
+        self.requested = True
+        sys.stdout.write(f"\n[!] shutdown signal {signum} — finishing current repo and exiting\n")
+        sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+
+
+def write_status_file(stats: Stats, run_id: str, *, final: bool = False) -> None:
+    STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    body = [
+        f"run_id: {run_id}",
+        f"status: {'finished' if final else 'running'}",
+        f"started: {datetime.fromtimestamp(time.time() - stats.elapsed_s(), tz=timezone.utc).isoformat()}",
+        f"now: {datetime.now(timezone.utc).isoformat()}",
+        f"elapsed_min: {stats.elapsed_s() / 60:.1f}",
+        f"total: {stats.total}",
+        f"processed: {stats.processed()}",
+        f"processed_ok: {stats.processed_ok}",
+        f"processed_unknown: {stats.processed_unknown}",
+        f"processed_error: {stats.processed_error}",
+        f"remaining: {stats.remaining()}",
+        f"rate_per_min: {stats.per_min():.2f}",
+        f"eta: {stats.eta_str()}",
+        f"top_langs: {stats.top_langs(10)}",
+        f"program_backoffs_so_far: {stats.program_backoff_count}",
+        f"last_repo: {stats.last_repo}",
+        f"last_lang: {stats.last_lang}",
+        f"last_rate_limit_msg: {stats.last_429_msg}",
+    ]
+    STATUS_FILE.write_text("\n".join(body) + "\n", encoding="utf-8")
+
+
+def status_emitter(stats: Stats, run_id: str, shutdown: GracefulShutdown) -> None:
+    last = 0.0
+    while not shutdown.requested:
+        now = time.monotonic()
+        if now - last >= LOG_INTERVAL_S:
+            sys.stdout.write(stats.render_line() + "\n")
+            sys.stdout.flush()
+            write_status_file(stats, run_id)
+            last = now
+        time.sleep(1)
+
+
+# ---------------------------------------------------------------------------
+
+
+def fetch_readme_text(
+    client: httpx.Client,
+    repo: str,
+    variant: str,
+) -> str | None:
+    """One-variant fetch with retry-on-429. Raises RateLimitExhausted past max retries.
+
+    Returns the text on 200, ``None`` on 404 / other non-rate-limit failures.
+    """
+    url = f"{RAW_BASE}/{repo}/HEAD/{variant}"
+    backoff = PER_REQUEST_BASE_S
+    last_msg = ""
+    for _attempt in range(PER_REQUEST_MAX_RETRIES):
+        time.sleep(INTER_REQUEST_DELAY_S)
+        try:
+            r = client.get(url, follow_redirects=True, timeout=15)
+        except (httpx.HTTPError, OSError) as e:
+            last_msg = f"{type(e).__name__}: {e}"
+            time.sleep(min(backoff, PER_REQUEST_MAX_S))
+            backoff = min(backoff * 2, PER_REQUEST_MAX_S)
+            continue
+        if r.status_code == 200:
+            return r.text
+        if r.status_code == 404:
+            return None
+        if r.status_code == 429:
+            retry_after = r.headers.get("Retry-After")
+            wait_s = backoff
+            if retry_after:
+                try:
+                    wait_s = float(retry_after)
+                except ValueError:
+                    pass
+            wait_s = min(wait_s, PER_REQUEST_MAX_S)
+            last_msg = f"429 on {variant}, sleeping {wait_s:.0f}s"
+            time.sleep(wait_s)
+            backoff = min(backoff * 2, PER_REQUEST_MAX_S)
+            continue
+        # Other non-2xx, non-404, non-429 — treat as soft fail, move on.
+        last_msg = f"status={r.status_code} on {variant}"
+        return None
+    # Out of retries on 429s
+    raise RateLimitExhausted(f"{repo} {variant}: {last_msg}")
+
+
+def detect_repo_language(client: httpx.Client, repo: str) -> str | None:
+    """Try each README variant; return ISO code or None.
+
+    Raises RateLimitExhausted upward so the main loop can program-backoff.
+    """
+    for variant in README_VARIANTS:
+        text = fetch_readme_text(client, repo, variant)
+        if text is None or len(text) < MIN_TEXT_LEN:
+            continue
+        try:
+            return detect(text[:MAX_TEXT_LEN])
+        except LangDetectException:
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+
+
+def fetch_pending_repos(db: UnifiedDatabase, run_id: str) -> list[str]:
+    """Inventoried repos still missing a detected_language."""
+    rows = db._conn.execute(
+        "SELECT repo_full_name FROM bulk_scan_repos "
+        "WHERE run_id = ? AND status = 'inventoried' "
+        "AND detected_language IS NULL "
+        "ORDER BY repo_full_name",
+        (run_id,),
+    ).fetchall()
+    return [r["repo_full_name"] for r in rows]
+
+
+def write_lang(db: UnifiedDatabase, run_id: str, repo: str, lang: str | None) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    # Use COALESCE so concurrent writers don't clobber if another agent set it first.
+    with db._conn:
+        db._conn.execute(
+            "UPDATE bulk_scan_repos SET detected_language = COALESCE(detected_language, ?), "
+            "updated_at = ? "
+            "WHERE run_id = ? AND repo_full_name = ?",
+            (lang, now, run_id, repo),
+        )
+
+
+def program_backoff(stats: Stats, shutdown: GracefulShutdown, run_id: str) -> None:
+    idx = min(stats.program_backoff_count, len(PROGRAM_BACKOFF_MINUTES) - 1)
+    minutes = PROGRAM_BACKOFF_MINUTES[idx]
+    stats.program_backoff_count += 1
+    msg = (
+        f"[!] raw-CDN sustained rate limit — pausing program for {minutes} minutes "
+        f"(escalation #{stats.program_backoff_count})"
+    )
+    stats.last_429_msg = msg
+    sys.stdout.write("\n" + msg + "\n")
+    sys.stdout.flush()
+    write_status_file(stats, run_id)
+    for _ in range(minutes * 60 // 5):
+        if shutdown.requested:
+            return
+        time.sleep(5)
+
+
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Backfill detected_language for inventoried repos.")
+    parser.add_argument("--run-id", default=DEFAULT_RUN_ID)
+    parser.add_argument(
+        "--db",
+        default=str(Path.home() / ".ghla" / "ghla.db"),
+        help="path to ghla.db (default: ~/.ghla/ghla.db)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress per-minute status lines (status file still updates)",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s :: %(message)s",
+        force=True,
+    )
+    # Silence verbose modules — same set as finish_stage3.py per #256.
+    for noisy in (
+        "httpx",
+        "httpcore",
+        "urllib3",
+        "langdetect",
+        "archive_client",
+        "github_resolver",
+        "link_detective",
+        "redirect_resolver",
+        "policy_checker",
+    ):
+        logging.getLogger(noisy).setLevel(logging.ERROR)
+
+    db_path = Path(args.db)
+    if not db_path.exists():
+        sys.stderr.write(f"DB not found: {db_path}\n")
+        return 2
+
+    db = UnifiedDatabase(str(db_path))
+    shutdown = GracefulShutdown()
+    stats = Stats()
+
+    try:
+        # Quick run existence check
+        row = db._conn.execute("SELECT status FROM bulk_scan_runs WHERE run_id = ?", (args.run_id,)).fetchone()
+        if row is None:
+            sys.stderr.write(f"run not found: {args.run_id!r}\n")
+            return 4
+
+        repos = fetch_pending_repos(db, args.run_id)
+        stats.total = len(repos)
+        sys.stdout.write(
+            f"run_id: {args.run_id}\n"
+            f"repos needing detected_language: {stats.total}\n"
+            f"DB: {db_path}\n"
+            f"status file: {STATUS_FILE}\n"
+            f"PID: {os.getpid()}\n\n"
+        )
+        sys.stdout.flush()
+
+        if not repos:
+            sys.stdout.write("nothing to do — every inventoried repo already has detected_language.\n")
+            return 0
+
+        client = httpx.Client(
+            headers={"User-Agent": "gh-link-auditor-langdetect"},
+            timeout=15.0,
+            follow_redirects=True,
+        )
+
+        if not args.quiet:
+            t = threading.Thread(
+                target=status_emitter,
+                args=(stats, args.run_id, shutdown),
+                daemon=True,
+            )
+            t.start()
+
+        deferred: list[str] = []  # repos that hit rate-limit storms; retried later
+
+        try:
+            for repo in repos:
+                if shutdown.requested:
+                    break
+                stats.last_repo = repo
+                try:
+                    lang = detect_repo_language(client, repo)
+                except RateLimitExhausted as e:
+                    stats.last_429_msg = str(e)
+                    program_backoff(stats, shutdown, args.run_id)
+                    if shutdown.requested:
+                        break
+                    deferred.append(repo)
+                    continue
+                except Exception as e:
+                    write_lang(db, args.run_id, repo, None)
+                    stats.processed_error += 1
+                    stats.last_lang = f"err:{type(e).__name__}"
+                    continue
+
+                if lang is None:
+                    # No README we could classify — record explicit 'unknown' so
+                    # we don't keep retrying. Stage 3 treats NULL as include;
+                    # use literal 'unknown' for that signal and let operator
+                    # decide later. Until then: NULL is fine too.
+                    write_lang(db, args.run_id, repo, "unknown")
+                    stats.processed_unknown += 1
+                    stats.last_lang = "unknown"
+                else:
+                    write_lang(db, args.run_id, repo, lang)
+                    stats.by_lang[lang] = stats.by_lang.get(lang, 0) + 1
+                    stats.processed_ok += 1
+                    stats.last_lang = lang
+
+            # Pass 2: anything deferred due to rate-limit storms gets one more try.
+            if deferred and not shutdown.requested:
+                sys.stdout.write(
+                    f"\n[pass 2] retrying {len(deferred)} repos that were skipped during rate-limit storms\n"
+                )
+                sys.stdout.flush()
+                for repo in deferred:
+                    if shutdown.requested:
+                        break
+                    stats.last_repo = repo
+                    try:
+                        lang = detect_repo_language(client, repo)
+                    except RateLimitExhausted as e:
+                        stats.last_429_msg = str(e)
+                        program_backoff(stats, shutdown, args.run_id)
+                        continue
+                    except Exception as e:
+                        write_lang(db, args.run_id, repo, None)
+                        stats.processed_error += 1
+                        stats.last_lang = f"err:{type(e).__name__}"
+                        continue
+                    if lang is None:
+                        write_lang(db, args.run_id, repo, "unknown")
+                        stats.processed_unknown += 1
+                        stats.last_lang = "unknown"
+                    else:
+                        write_lang(db, args.run_id, repo, lang)
+                        stats.by_lang[lang] = stats.by_lang.get(lang, 0) + 1
+                        stats.processed_ok += 1
+                        stats.last_lang = lang
+        finally:
+            client.close()
+
+        # Final summary
+        final_remaining = len(fetch_pending_repos(db, args.run_id))
+        sys.stdout.write("\n" + stats.render_line() + "\n")
+        sys.stdout.write(
+            f"\nfinished. ok={stats.processed_ok:,} unknown={stats.processed_unknown:,} "
+            f"err={stats.processed_error:,} still-needing-detection={final_remaining} "
+            f"backoffs={stats.program_backoff_count} "
+            f"elapsed={stats.elapsed_s() / 60:.1f}min\n"
+        )
+        sys.stdout.write(f"\nlanguage breakdown: {stats.top_langs(20)}\n")
+        sys.stdout.flush()
+        write_status_file(stats, args.run_id, final=True)
+        return 0
+    finally:
+        try:
+            db.close()
+        except sqlite3.Error:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/finish_stage1.py
+++ b/tools/finish_stage1.py
@@ -1,0 +1,562 @@
+"""Standalone Stage 1 completion for bulk-20260514T042627Z.
+
+Resumes Stage 1 (inventory) for the 661 still-pending repos in the 440k-finding
+run that was abandoned on 2026-05-14. Designed to be launched and walked away
+from. Built-in observability + sane failure handling so you don't have to babysit.
+
+Design rules (lessons from prior disasters):
+
+* **No quality stop-loss.** The run completes or you stop it. Period.
+* **No in-memory accumulation across the whole run.** Each repo's results are
+  written to the DB as soon as they're produced; a crash loses at most the
+  one repo currently in flight.
+* **No overwriting of prior work.** Repos already in `'inventoried'` status
+  are skipped entirely. The DELETE-then-INSERT anti-pattern is gone.
+* **Failures don't clutch forward.** Per-repo errors are recorded and the
+  next repo is tried; sustained rate-limiting pauses the whole program with
+  exponential backoff (5min -> 10 -> 20 -> 40 -> 80 -> 120, then capped) so
+  the program doesn't pound through every remaining repo as an error.
+* **Observability over silence.** Status line every 60s with progress, rate,
+  ETA, and the most recent repo touched. Mirrored to a status file you can
+  ``Get-Content`` from another window.
+* **Multi-agent safe.** Acquires the bulk_scan_locks row before doing any
+  work; a second invocation while one is running exits with a clear message.
+
+Usage:
+
+    poetry run python tools/finish_stage1.py
+
+To force a different run id:
+
+    poetry run python tools/finish_stage1.py --run-id bulk-XXXXX
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import signal
+import sqlite3
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+# Ensure src/ is importable when the tool is run from project root.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+
+# #265 — eager-import the chatty modules so each module's setup_logging()
+# call fires BEFORE main()'s setLevel(ERROR) loop. Without these, the
+# silencing runs on loggers with no handlers, then setup_logging fires
+# during lazy import and resets level=INFO + adds a StreamHandler, defeating
+# the silencing.
+from gh_link_auditor import (  # noqa: E402
+    archive_client,  # noqa: F401
+    github_resolver,  # noqa: F401
+    link_detective,  # noqa: F401
+    policy_checker,  # noqa: F401
+    redirect_resolver,  # noqa: F401
+)
+from gh_link_auditor.bulk_scan import inventory, process_lock, storage  # noqa: E402
+from gh_link_auditor.bulk_scan.gh_client import GitHubRateLimitedClient  # noqa: E402
+from gh_link_auditor.unified_db import UnifiedDatabase  # noqa: E402
+
+DEFAULT_RUN_ID = "bulk-20260514T042627Z"
+STATUS_FILE = _PROJECT_ROOT / "data" / "finish-stage1-status.txt"
+LOG_INTERVAL_S = 60
+# Adaptive program-level backoff schedule (minutes) — kicks in only after
+# the GitHub client's internal retries have already been exhausted on the
+# same repo. We pause the whole program rather than burn through repos as
+# errors.
+PROGRAM_BACKOFF_MINUTES = [5, 10, 20, 40, 80, 120]
+
+
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Stats:
+    started_monotonic: float = field(default_factory=time.monotonic)
+    total_repos: int = 0
+    done_at_start: int = 0  # repos already inventoried before this run started
+    processed_ok: int = 0
+    processed_error: int = 0
+    findings_added: int = 0
+    last_repo: str = ""
+    last_repo_outcome: str = ""
+    program_backoff_count: int = 0  # how many times we've had to pause the whole program
+    last_429_msg: str = ""
+
+    def elapsed_s(self) -> float:
+        return time.monotonic() - self.started_monotonic
+
+    def processed(self) -> int:
+        return self.processed_ok + self.processed_error
+
+    def remaining(self) -> int:
+        return self.total_repos - self.processed()
+
+    def repos_per_min(self) -> float:
+        e = self.elapsed_s()
+        if e <= 0 or self.processed() == 0:
+            return 0.0
+        return self.processed() / (e / 60.0)
+
+    def eta_str(self) -> str:
+        rate = self.repos_per_min()
+        if rate <= 0:
+            return "?"
+        remaining_min = self.remaining() / rate
+        if remaining_min < 60:
+            return f"{remaining_min:.0f}m"
+        return f"{remaining_min / 60:.1f}h"
+
+    def render_line(self) -> str:
+        now = datetime.now().strftime("%H:%M:%S")
+        pct = (100.0 * self.processed() / self.total_repos) if self.total_repos else 0.0
+        bo = f" backoffs={self.program_backoff_count}" if self.program_backoff_count else ""
+        last = f" last={self.last_repo}" if self.last_repo else ""
+        return (
+            f"[{now}] stage1 {self.processed():,}/{self.total_repos:,} "
+            f"({pct:.1f}%) ok={self.processed_ok:,} err={self.processed_error:,} "
+            f"findings+={self.findings_added:,} rate={self.repos_per_min():.1f}/min "
+            f"ETA={self.eta_str()}{bo}{last}"
+        )
+
+
+# ---------------------------------------------------------------------------
+
+
+class GracefulShutdown:
+    """Capture SIGINT/SIGTERM and let the inner loop notice."""
+
+    def __init__(self) -> None:
+        self.requested = False
+        signal.signal(signal.SIGINT, self._handler)
+        try:
+            signal.signal(signal.SIGTERM, self._handler)
+        except (AttributeError, ValueError):
+            # SIGTERM not available on Windows-Python in some shells.
+            pass
+
+    def _handler(self, signum: int, frame: object) -> None:  # noqa: ARG002
+        self.requested = True
+        sys.stdout.write(f"\n[!] shutdown signal {signum} — finishing current repo then exiting cleanly\n")
+        sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+
+
+def write_status_file(stats: Stats, run_id: str, *, final: bool = False) -> None:
+    STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    body = [
+        f"run_id: {run_id}",
+        f"status: {'finished' if final else 'running'}",
+        f"started: {datetime.fromtimestamp(time.time() - stats.elapsed_s(), tz=timezone.utc).isoformat()}",
+        f"now: {datetime.now(timezone.utc).isoformat()}",
+        f"elapsed_min: {stats.elapsed_s() / 60:.1f}",
+        f"total_repos: {stats.total_repos}",
+        f"done_before_run: {stats.done_at_start}",
+        f"processed: {stats.processed()}",
+        f"processed_ok: {stats.processed_ok}",
+        f"processed_error: {stats.processed_error}",
+        f"remaining: {stats.remaining()}",
+        f"findings_added: {stats.findings_added}",
+        f"rate_per_min: {stats.repos_per_min():.2f}",
+        f"eta: {stats.eta_str()}",
+        f"program_backoffs_so_far: {stats.program_backoff_count}",
+        f"last_repo: {stats.last_repo}",
+        f"last_repo_outcome: {stats.last_repo_outcome}",
+        f"last_rate_limit_msg: {stats.last_429_msg}",
+    ]
+    STATUS_FILE.write_text("\n".join(body) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+
+
+def fetch_pending_repos(db: UnifiedDatabase, run_id: str) -> list[str]:
+    rows = db._conn.execute(
+        "SELECT repo_full_name FROM bulk_scan_repos WHERE run_id = ? AND status = 'pending' ORDER BY repo_full_name",
+        (run_id,),
+    ).fetchall()
+    return [r["repo_full_name"] for r in rows]
+
+
+def repo_status(db: UnifiedDatabase, run_id: str, repo: str) -> str | None:
+    row = db._conn.execute(
+        "SELECT status FROM bulk_scan_repos WHERE run_id = ? AND repo_full_name = ?",
+        (run_id, repo),
+    ).fetchone()
+    return row["status"] if row else None
+
+
+def total_repo_count(db: UnifiedDatabase, run_id: str) -> int:
+    row = db._conn.execute("SELECT COUNT(*) AS n FROM bulk_scan_repos WHERE run_id = ?", (run_id,)).fetchone()
+    return int(row["n"])
+
+
+def already_inventoried_count(db: UnifiedDatabase, run_id: str) -> int:
+    row = db._conn.execute(
+        "SELECT COUNT(*) AS n FROM bulk_scan_repos WHERE run_id = ? AND status = 'inventoried'",
+        (run_id,),
+    ).fetchone()
+    return int(row["n"])
+
+
+# ---------------------------------------------------------------------------
+
+
+def write_repo_atomically(
+    db: UnifiedDatabase,
+    run_id: str,
+    repo: str,
+    result: dict,
+) -> int:
+    """One transaction: mark repo inventoried + insert all its findings.
+
+    Returns count of finding rows inserted. If any step fails the whole
+    transaction rolls back; the repo stays 'pending' and will be retried
+    on the next pass.
+    """
+    docs = result["doc_files"]
+    urls = result["urls"]
+    now = datetime.now(timezone.utc).isoformat()
+    inserted = 0
+    with db._conn:  # implicit BEGIN/COMMIT on success, ROLLBACK on exception
+        db._conn.execute(
+            "UPDATE bulk_scan_repos SET doc_files_json = ?, url_count = ?, "
+            "status = 'inventoried', updated_at = ? "
+            "WHERE run_id = ? AND repo_full_name = ?",
+            (
+                _json_dumps(docs),
+                len(urls),
+                now,
+                run_id,
+                repo,
+            ),
+        )
+        for url, src, ln in urls:
+            db._conn.execute(
+                "INSERT INTO bulk_scan_findings "
+                "(run_id, repo_full_name, source_file, line_number, dead_url, "
+                " candidate_url, method, tier, similarity_score, verified_live, "
+                " confidence, surfaced, created_at, investigation_state) "
+                "VALUES (?, ?, ?, ?, ?, '', 'pending', 0, NULL, 0, 0.0, 0, ?, 'pending')",
+                (run_id, repo, src, ln, url, now),
+            )
+            inserted += 1
+    return inserted
+
+
+def _json_dumps(obj: object) -> str:
+    import json
+
+    return json.dumps(obj)
+
+
+def mark_error_safely(db: UnifiedDatabase, run_id: str, repo: str, error: str) -> None:
+    """Record a non-rate-limit failure so we don't loop on it. Truncates long errors."""
+    now = datetime.now(timezone.utc).isoformat()
+    with db._conn:
+        db._conn.execute(
+            "UPDATE bulk_scan_repos SET status = 'error', error = ?, updated_at = ? "
+            "WHERE run_id = ? AND repo_full_name = ?",
+            (error[:500], now, run_id, repo),
+        )
+
+
+# ---------------------------------------------------------------------------
+
+
+class RateLimitExhausted(Exception):
+    """Raised when the GH client's internal retries are spent on the same repo."""
+
+
+def is_rate_limited_response(e: Exception) -> bool:
+    """True if exception traces back to a rate-limit / 403-secondary response."""
+    if isinstance(e, RateLimitExhausted):
+        return True
+    if isinstance(e, httpx.HTTPStatusError):
+        if e.response.status_code == 429:
+            return True
+        if e.response.status_code == 403:
+            text = (e.response.text or "").lower()
+            if "secondary rate limit" in text or "abuse" in text or "rate limit" in text:
+                return True
+    return False
+
+
+def inventory_one_repo(
+    repo: str,
+    api: GitHubRateLimitedClient,
+    raw: httpx.Client,
+) -> dict:
+    """Wrapper that turns an exhausted-retries rate-limit response into an exception.
+
+    The client's ``.get`` returns the rate-limited response after max_retries.
+    Calling ``raise_for_status`` then throws — we re-raise as RateLimitExhausted
+    so the program-level backoff loop catches it.
+    """
+    try:
+        return inventory.inventory_repo(repo, api, raw)
+    except httpx.HTTPStatusError as e:
+        if is_rate_limited_response(e):
+            raise RateLimitExhausted(
+                f"rate limited after client retries on {repo}: status={e.response.status_code}"
+            ) from e
+        raise
+
+
+# ---------------------------------------------------------------------------
+
+
+def program_backoff(stats: Stats, shutdown: GracefulShutdown, run_id: str) -> None:
+    """Sleep the whole program with escalating duration on sustained rate-limiting."""
+    idx = min(stats.program_backoff_count, len(PROGRAM_BACKOFF_MINUTES) - 1)
+    minutes = PROGRAM_BACKOFF_MINUTES[idx]
+    stats.program_backoff_count += 1
+    msg = (
+        f"[!] sustained rate limit — pausing program for {minutes} minutes (escalation #{stats.program_backoff_count})"
+    )
+    stats.last_429_msg = msg
+    sys.stdout.write("\n" + msg + "\n")
+    sys.stdout.flush()
+    write_status_file(stats, run_id)
+    # Sleep in 5-second chunks so Ctrl+C is responsive.
+    for _ in range(minutes * 60 // 5):
+        if shutdown.requested:
+            return
+        time.sleep(5)
+
+
+# ---------------------------------------------------------------------------
+
+
+def status_emitter(stats: Stats, run_id: str, shutdown: GracefulShutdown) -> None:
+    """Background thread: print status line every LOG_INTERVAL_S, mirror to file."""
+    last_emit = 0.0
+    while not shutdown.requested:
+        now = time.monotonic()
+        if now - last_emit >= LOG_INTERVAL_S:
+            sys.stdout.write(stats.render_line() + "\n")
+            sys.stdout.flush()
+            write_status_file(stats, run_id)
+            last_emit = now
+        time.sleep(1)
+
+
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Resume Stage 1 inventory for a bulk-scan run.")
+    parser.add_argument("--run-id", default=DEFAULT_RUN_ID)
+    parser.add_argument(
+        "--db",
+        default=str(Path.home() / ".ghla" / "ghla.db"),
+        help="path to ghla.db (default: ~/.ghla/ghla.db)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress per-minute status lines (status file still updates)",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s :: %(message)s",
+        force=True,
+    )
+    # Silence verbose modules — same set as finish_stage3.py per #256.
+    for noisy in (
+        "httpx",
+        "httpcore",
+        "urllib3",
+        "archive_client",
+        "github_resolver",
+        "link_detective",
+        "redirect_resolver",
+        "policy_checker",
+    ):
+        logging.getLogger(noisy).setLevel(logging.ERROR)
+
+    db_path = Path(args.db)
+    if not db_path.exists():
+        sys.stderr.write(f"DB not found: {db_path}\n")
+        return 2
+
+    db = UnifiedDatabase(str(db_path))
+
+    # Lock the run so a second agent can't race us.
+    try:
+        process_lock.acquire(db, args.run_id)
+    except process_lock.LockBusyError as e:
+        sys.stderr.write(f"{e}\n")
+        return 3
+
+    shutdown = GracefulShutdown()
+    stats = Stats()
+    stats.total_repos = total_repo_count(db, args.run_id)
+    stats.done_at_start = already_inventoried_count(db, args.run_id)
+    stats.processed_ok = 0  # this run's processed; counters are independent of done_at_start
+
+    try:
+        run = storage.get_run(db, args.run_id)
+        if run is None:
+            sys.stderr.write(f"run not found: {args.run_id!r}\n")
+            return 4
+
+        pending = fetch_pending_repos(db, args.run_id)
+        sys.stdout.write(
+            f"run_id: {args.run_id}\n"
+            f"status: {run['status']}\n"
+            f"total repos in run: {stats.total_repos}\n"
+            f"already inventoried: {stats.done_at_start}\n"
+            f"pending (to do now): {len(pending)}\n"
+            f"DB: {db_path}\n"
+            f"status file: {STATUS_FILE}\n"
+            f"PID: {os.getpid()}\n\n"
+        )
+        sys.stdout.flush()
+
+        if not pending:
+            sys.stdout.write("nothing pending — Stage 1 already complete for this run.\n")
+            return 0
+
+        # The total to track is the pending count (so percentages line up with
+        # this invocation's work). done_at_start is reported separately.
+        stats.total_repos = len(pending)
+
+        api = inventory.build_api_client()
+        # Bump internal retries to ride out longer rate-limit storms before the
+        # program-level escalation kicks in.
+        if hasattr(api, "_max_retries"):
+            api._max_retries = 15  # noqa: SLF001
+            api._base_backoff = 4.0  # noqa: SLF001
+        raw = inventory.build_raw_client()
+
+        if not args.quiet:
+            t = threading.Thread(
+                target=status_emitter,
+                args=(stats, args.run_id, shutdown),
+                daemon=True,
+            )
+            t.start()
+
+        try:
+            for repo in pending:
+                if shutdown.requested:
+                    break
+                # Re-check status — another agent may have claimed it in another DB.
+                cur = repo_status(db, args.run_id, repo)
+                if cur != "pending":
+                    continue
+
+                stats.last_repo = repo
+                try:
+                    result = inventory_one_repo(repo, api, raw)
+                except RateLimitExhausted as e:
+                    stats.last_repo_outcome = f"rate-limited: {e}"
+                    stats.last_429_msg = str(e)
+                    program_backoff(stats, shutdown, args.run_id)
+                    if shutdown.requested:
+                        break
+                    # Retry the same repo on next iteration — leave it 'pending'.
+                    # We re-add it to the front by NOT continuing past here; the
+                    # outer 'for' will move on, but a periodic re-pull below
+                    # picks up still-pending repos. To avoid skipping, we'll
+                    # retry immediately by attempting it once more right now.
+                    try:
+                        result = inventory_one_repo(repo, api, raw)
+                    except Exception:
+                        # Still failing — leave it 'pending' and move on to other
+                        # repos. We'll come back at the end.
+                        continue
+                except Exception as e:
+                    mark_error_safely(db, args.run_id, repo, repr(e))
+                    stats.processed_error += 1
+                    stats.last_repo_outcome = f"error: {e!r}"
+                    continue
+
+                try:
+                    inserted = write_repo_atomically(db, args.run_id, repo, result)
+                except Exception as e:
+                    # DB write failure is unusual; record but don't crash.
+                    mark_error_safely(db, args.run_id, repo, f"db-write: {e!r}")
+                    stats.processed_error += 1
+                    stats.last_repo_outcome = f"db-error: {e!r}"
+                    continue
+                stats.processed_ok += 1
+                stats.findings_added += inserted
+                stats.last_repo_outcome = f"ok ({inserted} URLs)"
+
+            # Pass 2: pick up any repos still 'pending' (skipped during rate-limit
+            # storms above). This loop runs at most once and short-circuits if
+            # nothing is left.
+            still_pending = fetch_pending_repos(db, args.run_id)
+            if still_pending and not shutdown.requested:
+                sys.stdout.write(
+                    f"\n[pass 2] retrying {len(still_pending)} repos that were skipped during rate-limit storms\n"
+                )
+                sys.stdout.flush()
+                for repo in still_pending:
+                    if shutdown.requested:
+                        break
+                    stats.last_repo = repo
+                    try:
+                        result = inventory_one_repo(repo, api, raw)
+                    except RateLimitExhausted as e:
+                        stats.last_429_msg = str(e)
+                        program_backoff(stats, shutdown, args.run_id)
+                        continue
+                    except Exception as e:
+                        mark_error_safely(db, args.run_id, repo, repr(e))
+                        stats.processed_error += 1
+                        continue
+                    try:
+                        inserted = write_repo_atomically(db, args.run_id, repo, result)
+                    except Exception as e:
+                        mark_error_safely(db, args.run_id, repo, f"db-write: {e!r}")
+                        stats.processed_error += 1
+                        continue
+                    stats.processed_ok += 1
+                    stats.findings_added += inserted
+                    stats.last_repo_outcome = f"ok ({inserted} URLs)"
+        finally:
+            try:
+                api.close()
+            except Exception:
+                pass
+            raw.close()
+
+        # Final summary.
+        final_pending = len(fetch_pending_repos(db, args.run_id))
+        sys.stdout.write("\n" + stats.render_line() + "\n")
+        sys.stdout.write(
+            f"\nfinished. ok={stats.processed_ok:,} error={stats.processed_error:,} "
+            f"still-pending={final_pending} findings-added={stats.findings_added:,} "
+            f"program-backoffs={stats.program_backoff_count} "
+            f"elapsed={stats.elapsed_s() / 60:.1f}min\n"
+        )
+        sys.stdout.flush()
+        write_status_file(stats, args.run_id, final=True)
+        return 0 if final_pending == 0 else 1
+    finally:
+        try:
+            process_lock.release(db, args.run_id)
+        except sqlite3.Error:
+            pass
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/finish_stage2.py
+++ b/tools/finish_stage2.py
@@ -1,0 +1,456 @@
+"""Standalone Stage 2 completion: probe every unprobed URL in a bulk-scan run.
+
+For ``bulk-20260514T042627Z`` the bulk of Stage 2 was completed during the
+16-hour cache populate on 2026-05-22. Only a few thousand URLs remain
+unprobed (those not yet in ``url_check_cache``, plus any new URLs that
+``finish_stage1.py`` adds as it finishes the last 661 repos).
+
+This script:
+
+* Snapshots the set of URLs in the run's findings that are NOT yet in
+  ``url_check_cache`` (or whose cache entries have expired).
+* Runs them through ``bulk_scan.liveness.check_urls_bulk`` (the same
+  HEAD-with-GET-fallback + stealth-fallback machinery used by N1 and the
+  in-process bulk-scan runner — keeps semantics consistent with #190/#193/#198).
+* Persists each result to ``url_check_cache`` via the ``on_result`` callback
+  so a crash mid-batch loses at most the URLs currently in flight.
+
+Concurrency: SAFE to run while ``finish_stage1.py`` and/or
+``detect_languages.py`` are running. Does NOT take the bulk-scan lock. Writes
+only to ``url_check_cache``; reads ``bulk_scan_findings`` (which Stage 1
+appends to). The snapshot-at-start pattern means newly-added findings won't
+be picked up by this invocation; re-fire when Stage 1 finishes to mop up.
+
+Rate limiting: Stage 2 hits arbitrary destination hosts (not a single API).
+Per-host 429s and timeouts are handled inside ``network.check_url`` and
+recorded as status codes in the cache — they are valid responses, not
+failures. We do NOT escalate-backoff on 429s here because that would
+penalize all probes for one host's throttling.
+
+What we DO watch for: sustained LOCAL failures (DNS broken, Wi-Fi off,
+TCP-reset wave). When the recent error rate exceeds 50% over the last
+~200 probes, the program pauses ``2 -> 5 -> 10 -> 20 -> 40 -> 80`` minutes
+(escalating, never decays — see #249) so it doesn't churn an entire night
+of dead probes if the laptop drops off the network. The pause counter
+never resets — same pattern as the other stage finishers.
+
+Observability: status line every 60s with overall progress, current rate,
+ETA, and HTTP-status-family breakdown. Mirror to
+``data/finish-stage2-status.txt``.
+
+Usage::
+
+    poetry run python tools/finish_stage2.py
+    poetry run python tools/finish_stage2.py --run-id <other-run>
+    poetry run python tools/finish_stage2.py --workers 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import signal
+import sqlite3
+import sys
+import threading
+import time
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+
+# #265 — eager-import the chatty modules so each module's setup_logging()
+# call fires BEFORE main()'s setLevel(ERROR) loop. Without these, the
+# silencing runs on loggers with no handlers, then setup_logging fires
+# during lazy import and resets level=INFO + adds a StreamHandler, defeating
+# the silencing.
+from gh_link_auditor import (  # noqa: E402
+    archive_client,  # noqa: F401
+    github_resolver,  # noqa: F401
+    link_detective,  # noqa: F401
+    policy_checker,  # noqa: F401
+    redirect_resolver,  # noqa: F401
+)
+from gh_link_auditor.bulk_scan import liveness  # noqa: E402
+from gh_link_auditor.bulk_scan.config import (  # noqa: E402
+    LIVENESS_CACHE_TTL_HOURS,
+    LIVENESS_WORKER_COUNT,
+)
+from gh_link_auditor.unified_db import UnifiedDatabase  # noqa: E402
+
+DEFAULT_RUN_ID = "bulk-20260514T042627Z"
+STATUS_FILE = _PROJECT_ROOT / "data" / "finish-stage2-status.txt"
+LOG_INTERVAL_S = 60
+BATCH_SIZE = 500  # urls per batch; status + program-level checks fire between batches
+# Outer backoff (minutes) on local-network failures.
+PROGRAM_BACKOFF_MINUTES = [2, 5, 10, 20, 40, 80]
+# Window of recent probe outcomes used to detect "the network died" vs
+# "one host is throttling." 200 probes is enough to dampen single-host noise.
+ERROR_RATE_WINDOW = 200
+ERROR_RATE_THRESHOLD = 0.50  # >50% local errors over the window -> pause
+
+
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Stats:
+    started_monotonic: float = field(default_factory=time.monotonic)
+    total: int = 0
+    done: int = 0
+    by_family: dict[str, int] = field(default_factory=dict)  # '2xx', '3xx', '4xx', '5xx', 'none', 'error'
+    recent_outcomes: deque = field(default_factory=lambda: deque(maxlen=ERROR_RATE_WINDOW))
+    top_error_hosts: dict[str, int] = field(default_factory=dict)
+    program_backoff_count: int = 0
+    last_url: str = ""
+    last_outcome: str = ""
+    last_pause_msg: str = ""
+
+    def record(self, url: str, result: dict) -> None:
+        self.done += 1
+        self.last_url = url
+        code = result.get("status_code")
+        status = result.get("status", "")
+        if code is None:
+            family = "none" if status not in ("error",) else "error"
+        elif 200 <= code < 300:
+            family = "2xx"
+        elif 300 <= code < 400:
+            family = "3xx"
+        elif 400 <= code < 500:
+            family = "4xx"
+        elif 500 <= code < 600:
+            family = "5xx"
+        else:
+            family = "other"
+        self.by_family[family] = self.by_family.get(family, 0) + 1
+        # 'error' means we couldn't even get a status code — DNS, TCP, etc.
+        # Those are the local-network failures we watch.
+        is_local_error = (family == "error") or (family == "none" and status == "error")
+        self.recent_outcomes.append(is_local_error)
+        if is_local_error:
+            from urllib.parse import urlparse
+
+            try:
+                host = urlparse(url).netloc or "?"
+            except Exception:
+                host = "?"
+            self.top_error_hosts[host] = self.top_error_hosts.get(host, 0) + 1
+        self.last_outcome = f"{family}({code})" if code is not None else family
+
+    def elapsed_s(self) -> float:
+        return time.monotonic() - self.started_monotonic
+
+    def per_min(self) -> float:
+        e = self.elapsed_s()
+        if e <= 0 or self.done == 0:
+            return 0.0
+        return self.done / (e / 60.0)
+
+    def remaining(self) -> int:
+        return max(0, self.total - self.done)
+
+    def eta_str(self) -> str:
+        rate = self.per_min()
+        if rate <= 0:
+            return "?"
+        m = self.remaining() / rate
+        return f"{m:.0f}m" if m < 60 else f"{m / 60:.1f}h"
+
+    def family_str(self) -> str:
+        order = ("2xx", "3xx", "4xx", "5xx", "none", "error", "other")
+        parts = [f"{k}={self.by_family.get(k, 0):,}" for k in order if self.by_family.get(k)]
+        return " ".join(parts) if parts else "-"
+
+    def top_error_hosts_str(self, n: int = 3) -> str:
+        items = sorted(self.top_error_hosts.items(), key=lambda kv: kv[1], reverse=True)[:n]
+        return " ".join(f"{h}={c}" for h, c in items) if items else "-"
+
+    def recent_error_rate(self) -> float:
+        if not self.recent_outcomes:
+            return 0.0
+        return sum(self.recent_outcomes) / len(self.recent_outcomes)
+
+    def render_line(self) -> str:
+        now = datetime.now().strftime("%H:%M:%S")
+        pct = (100.0 * self.done / self.total) if self.total else 0.0
+        bo = f" pauses={self.program_backoff_count}" if self.program_backoff_count else ""
+        return (
+            f"[{now}] stage2 {self.done:,}/{self.total:,} ({pct:.1f}%) "
+            f"{self.family_str()} rate={self.per_min():.0f}/min ETA={self.eta_str()}{bo} "
+            f"err_rate={100 * self.recent_error_rate():.0f}%"
+        )
+
+
+# ---------------------------------------------------------------------------
+
+
+class GracefulShutdown:
+    def __init__(self) -> None:
+        self.requested = False
+        signal.signal(signal.SIGINT, self._handler)
+        try:
+            signal.signal(signal.SIGTERM, self._handler)
+        except (AttributeError, ValueError):
+            pass
+
+    def _handler(self, signum: int, frame: object) -> None:  # noqa: ARG002
+        self.requested = True
+        sys.stdout.write(f"\n[!] shutdown signal {signum} — finishing in-flight probes and exiting\n")
+        sys.stdout.flush()
+
+
+def write_status_file(stats: Stats, run_id: str, *, final: bool = False) -> None:
+    STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    body = [
+        f"run_id: {run_id}",
+        f"status: {'finished' if final else 'running'}",
+        f"started: {datetime.fromtimestamp(time.time() - stats.elapsed_s(), tz=timezone.utc).isoformat()}",
+        f"now: {datetime.now(timezone.utc).isoformat()}",
+        f"elapsed_min: {stats.elapsed_s() / 60:.1f}",
+        f"total_urls: {stats.total}",
+        f"probed: {stats.done}",
+        f"remaining: {stats.remaining()}",
+        f"rate_per_min: {stats.per_min():.1f}",
+        f"eta: {stats.eta_str()}",
+        f"families: {stats.family_str()}",
+        f"recent_local_error_rate: {100 * stats.recent_error_rate():.1f}%",
+        f"top_error_hosts: {stats.top_error_hosts_str(8)}",
+        f"program_pauses_so_far: {stats.program_backoff_count}",
+        f"last_url: {stats.last_url}",
+        f"last_outcome: {stats.last_outcome}",
+        f"last_pause_msg: {stats.last_pause_msg}",
+    ]
+    STATUS_FILE.write_text("\n".join(body) + "\n", encoding="utf-8")
+
+
+def status_emitter(stats: Stats, run_id: str, shutdown: GracefulShutdown) -> None:
+    last = 0.0
+    while not shutdown.requested:
+        now = time.monotonic()
+        if now - last >= LOG_INTERVAL_S:
+            sys.stdout.write(stats.render_line() + "\n")
+            sys.stdout.flush()
+            write_status_file(stats, run_id)
+            last = now
+        time.sleep(1)
+
+
+# ---------------------------------------------------------------------------
+
+
+def fetch_urls_needing_probe(db: UnifiedDatabase, run_id: str) -> list[str]:
+    """Distinct dead_urls in the run that aren't in url_check_cache (or have expired).
+
+    Reads bulk_scan_findings (placeholder rows from Stage 1, plus any earlier
+    runs' findings — we filter to this run for correctness). Uses a single
+    LEFT JOIN so we walk findings once rather than per-URL.
+    """
+    now_iso = datetime.now(timezone.utc).isoformat()
+    rows = db._conn.execute(
+        """
+        SELECT DISTINCT bsf.dead_url AS url
+        FROM bulk_scan_findings bsf
+        LEFT JOIN url_check_cache ucc ON ucc.url = bsf.dead_url
+        WHERE bsf.run_id = ?
+          AND bsf.method = 'pending'
+          AND (ucc.url IS NULL OR ucc.expires_at <= ?)
+        """,
+        (run_id, now_iso),
+    ).fetchall()
+    return [r["url"] for r in rows]
+
+
+def program_backoff(stats: Stats, shutdown: GracefulShutdown, run_id: str) -> None:
+    idx = min(stats.program_backoff_count, len(PROGRAM_BACKOFF_MINUTES) - 1)
+    minutes = PROGRAM_BACKOFF_MINUTES[idx]
+    stats.program_backoff_count += 1
+    msg = (
+        f"[!] local-network errors at {100 * stats.recent_error_rate():.0f}% over last "
+        f"{len(stats.recent_outcomes)} probes — pausing program for {minutes} minutes "
+        f"(escalation #{stats.program_backoff_count}). Top hosts: "
+        f"{stats.top_error_hosts_str(5)}"
+    )
+    stats.last_pause_msg = msg
+    sys.stdout.write("\n" + msg + "\n")
+    sys.stdout.flush()
+    write_status_file(stats, run_id)
+    for _ in range(minutes * 60 // 5):
+        if shutdown.requested:
+            return
+        time.sleep(5)
+
+
+# ---------------------------------------------------------------------------
+
+
+def probe_batch(
+    db: UnifiedDatabase,
+    urls: list[str],
+    workers: int,
+    stats: Stats,
+    db_lock: threading.Lock,
+) -> None:
+    """Probe one batch of URLs and persist results as they come in.
+
+    Uses a private ThreadPoolExecutor (rather than calling
+    ``liveness.check_urls_bulk`` directly) so we can persist results from the
+    main thread and update stats with proper locking — the existing helper
+    invokes ``on_result`` on the main thread already, but we want fine-grained
+    control over the cache write + the recent-outcomes deque.
+    """
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        futures = {ex.submit(liveness._probe_one, u): u for u in urls}
+        for fut in as_completed(futures):
+            url, result = fut.result()
+            # Write cache + record stats from the main loop (sqlite-safe).
+            with db_lock:
+                try:
+                    db.cache_url_check(
+                        url,
+                        http_status=result.get("status_code"),
+                        final_url=result.get("final_url"),
+                        is_bot_blocked=bool(result.get("is_bot_blocked")),
+                        ttl_hours=LIVENESS_CACHE_TTL_HOURS,
+                    )
+                except sqlite3.Error as e:
+                    logging.getLogger(__name__).warning("cache write failed for %s: %s", url, e)
+            stats.record(url, result)
+
+
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Resume Stage 2 (URL liveness probes) for a bulk-scan run.")
+    parser.add_argument("--run-id", default=DEFAULT_RUN_ID)
+    parser.add_argument(
+        "--db",
+        default=str(Path.home() / ".ghla" / "ghla.db"),
+        help="path to ghla.db (default: ~/.ghla/ghla.db)",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=LIVENESS_WORKER_COUNT,
+        help=f"parallel probe workers (default: {LIVENESS_WORKER_COUNT})",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=BATCH_SIZE,
+        help=f"URLs per batch between status/backoff checks (default: {BATCH_SIZE})",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress per-minute status lines (status file still updates)",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s :: %(message)s",
+        force=True,
+    )
+    # Silence verbose modules — same set as finish_stage3.py per #256.
+    for noisy in (
+        "httpx",
+        "httpcore",
+        "urllib3",
+        "archive_client",
+        "github_resolver",
+        "link_detective",
+        "redirect_resolver",
+        "policy_checker",
+    ):
+        logging.getLogger(noisy).setLevel(logging.ERROR)
+
+    db_path = Path(args.db)
+    if not db_path.exists():
+        sys.stderr.write(f"DB not found: {db_path}\n")
+        return 2
+
+    db = UnifiedDatabase(str(db_path))
+    shutdown = GracefulShutdown()
+    stats = Stats()
+    db_lock = threading.Lock()
+
+    try:
+        row = db._conn.execute("SELECT status FROM bulk_scan_runs WHERE run_id = ?", (args.run_id,)).fetchone()
+        if row is None:
+            sys.stderr.write(f"run not found: {args.run_id!r}\n")
+            return 4
+
+        urls = fetch_urls_needing_probe(db, args.run_id)
+        stats.total = len(urls)
+        sys.stdout.write(
+            f"run_id: {args.run_id}\n"
+            f"urls needing probe: {stats.total:,}\n"
+            f"workers: {args.workers}\n"
+            f"batch size: {args.batch_size}\n"
+            f"cache TTL: {LIVENESS_CACHE_TTL_HOURS}h\n"
+            f"DB: {db_path}\n"
+            f"status file: {STATUS_FILE}\n"
+            f"PID: {os.getpid()}\n\n"
+        )
+        sys.stdout.flush()
+
+        if not urls:
+            sys.stdout.write(
+                "nothing to probe — every URL in this run's findings is already in url_check_cache (within TTL).\n"
+            )
+            return 0
+
+        if not args.quiet:
+            t = threading.Thread(
+                target=status_emitter,
+                args=(stats, args.run_id, shutdown),
+                daemon=True,
+            )
+            t.start()
+
+        # Walk in batches so the status + backoff checks fire between batches.
+        i = 0
+        while i < len(urls) and not shutdown.requested:
+            batch = urls[i : i + args.batch_size]
+            probe_batch(db, batch, args.workers, stats, db_lock)
+            i += len(batch)
+
+            # After each batch: if local-network errors dominate, pause.
+            # (Per-host 429s don't count as local errors — those are valid
+            #  status codes and live in the 4xx family.)
+            if len(stats.recent_outcomes) >= ERROR_RATE_WINDOW and stats.recent_error_rate() >= ERROR_RATE_THRESHOLD:
+                program_backoff(stats, shutdown, args.run_id)
+                # Clear the window so we don't immediately re-trigger on the
+                # same evidence after a pause.
+                stats.recent_outcomes.clear()
+
+        # Final summary.
+        sys.stdout.write("\n" + stats.render_line() + "\n")
+        # Re-snapshot to see if Stage 1 added more URLs while we worked.
+        leftover = len(fetch_urls_needing_probe(db, args.run_id))
+        sys.stdout.write(
+            f"\nfinished. probed={stats.done:,} pauses={stats.program_backoff_count} "
+            f"still-needing-probe={leftover} elapsed={stats.elapsed_s() / 60:.1f}min\n"
+        )
+        sys.stdout.write(f"\nfamily breakdown: {stats.family_str()}\n")
+        if stats.top_error_hosts:
+            sys.stdout.write(f"top local-error hosts: {stats.top_error_hosts_str(10)}\n")
+        sys.stdout.flush()
+        write_status_file(stats, args.run_id, final=True)
+        return 0 if leftover == 0 else 1
+    finally:
+        try:
+            db.close()
+        except sqlite3.Error:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/finish_stage3.py
+++ b/tools/finish_stage3.py
@@ -1,0 +1,555 @@
+"""Standalone Stage 3 completion: investigate dead URLs in a bulk-scan run.
+
+For ``bulk-20260514T042627Z`` this is the actual unfinished work — Stage 3
+has never touched this run's ~440k pending findings. After Stage 2's cache
+classification, roughly ~321k of those URLs are alive (skip path), ~16-30k
+have non-English source-repo docs (skip path once ``detect_languages.py``
+finishes), and the remaining ~60k actually-dead URLs need investigation.
+
+Design rules (the same ones the user spelled out, no exceptions):
+
+* **No quality stop-loss.** This program does not abort itself based on
+  finding quality. It runs until everything is processed or the operator
+  signals shutdown.
+* **No DELETE.** Per LLD-244 the Stage 1 placeholder row stays; we just
+  flip its ``investigation_state`` and insert derived-candidate rows when
+  the investigation surfaces tier-1 candidates.
+* **Atomic per-finding transaction.** ``UPDATE investigation_state`` and
+  any candidate ``INSERT``s land in the same SQLite transaction; a crash
+  mid-finding rolls back so the finding stays ``'pending'`` for retry.
+* **Parallel investigations.** ``investigate_one`` creates a fresh
+  ``LinkDetective`` per call (zero shared state), so a thread pool is safe.
+  Default 8 workers; configurable.
+* **Pre-loaded language + liveness maps.** Stage 3 makes no DB call inside
+  the per-finding loop except for the atomic write. Language and liveness
+  come from in-memory dicts populated once at startup.
+
+Concurrency: SAFE to run while ``finish_stage1.py``, ``finish_stage2.py``,
+or ``detect_languages.py`` are running on the same DB. Does NOT take the
+bulk-scan lock. Writes only to the ``bulk_scan_findings`` rows we own (one
+per ``id``); inserts new candidate rows. SQLite serializes any actual
+write collision and Python ``threading.Lock`` guards stat updates.
+
+Rate limiting: per-investigation HTTP calls (Wikipedia API, GitHub API,
+liveness-verify HEAD) are made inside ``LinkDetective`` which has its own
+retry policies for those clients. We don't add an outer escalation here
+because failure modes are heterogeneous (one host throttling vs. broad
+network issue) and silenced inside LinkDetective. We DO surface an
+anomaly signal: if the "no candidate" rate over the recent window
+spikes above 95%, the status line flags it loudly so the operator can
+investigate. Rate of false-zero results = best proxy we have without
+rewriting LinkDetective's exception surface.
+
+Observability: status line every 60s with state-bucket breakdown.
+
+Usage::
+
+    poetry run python tools/finish_stage3.py
+    poetry run python tools/finish_stage3.py --workers 16
+    poetry run python tools/finish_stage3.py --run-id <other-run>
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import signal
+import sqlite3
+import sys
+import threading
+import time
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+# Match pyproject's [tool.pytest.ini_options] pythonpath = [".", "src"] —
+# LinkDetective's transitive imports use `from src.logging_config import ...`
+# (a pre-packaging path style). Without the project root on sys.path, every
+# LinkDetective construction raises ModuleNotFoundError and investigate_one
+# swallows it as "no candidate". Hotfix until the broken imports are migrated
+# to `from gh_link_auditor.logging_config import ...`.
+sys.path.insert(0, str(_PROJECT_ROOT))
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+
+# #265 — eager-import the LinkDetective module chain so each module's
+# setup_logging() call (which sets logger.level=INFO and adds a handler)
+# fires BEFORE main()'s setLevel(ERROR) loop. Without these, investigate_one
+# lazy-imports them in worker threads AFTER the silencing has already run on
+# loggers that had no handlers yet — setup_logging then resets them to INFO
+# and the operator console fills with archive_client CDX warnings.
+from gh_link_auditor import (  # noqa: E402
+    archive_client,  # noqa: F401
+    github_resolver,  # noqa: F401
+    link_detective,  # noqa: F401
+    policy_checker,  # noqa: F401
+    redirect_resolver,  # noqa: F401
+)
+from gh_link_auditor.bulk_scan import investigation  # noqa: E402
+from gh_link_auditor.bulk_scan.config import INCLUDE_LANGUAGES  # noqa: E402
+from gh_link_auditor.bulk_scan.host_blocklist import is_blocklisted_host  # noqa: E402
+from gh_link_auditor.unified_db import UnifiedDatabase  # noqa: E402
+
+DEFAULT_RUN_ID = "bulk-20260514T042627Z"
+STATUS_FILE = _PROJECT_ROOT / "data" / "finish-stage3-status.txt"
+LOG_INTERVAL_S = 60
+DEFAULT_WORKERS = 8
+# "No candidate rate is anomalously high" alarm — surfaced on the status
+# line, does not pause the program. 95% means: of the last 500 actual
+# investigations, ≥475 produced zero candidates. That's not impossible on
+# truly junk corpora but is the strongest single signal that a needed
+# upstream (GH API, Wikipedia, network) is silently failing.
+ANOMALY_WINDOW = 500
+ANOMALY_THRESHOLD = 0.95
+
+
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Stats:
+    started_monotonic: float = field(default_factory=time.monotonic)
+    total: int = 0
+    skipped_blocklist: int = 0
+    skipped_language: int = 0
+    skipped_alive: int = 0
+    investigated_no_cand: int = 0
+    investigated_with_cand: int = 0
+    candidates_inserted: int = 0
+    errors: int = 0
+    # Track the no-candidate ratio over a rolling window of REAL investigations
+    # (excluding skip paths). True = no candidate; False = candidate found.
+    recent_no_cand: deque = field(default_factory=lambda: deque(maxlen=ANOMALY_WINDOW))
+    last_url: str = ""
+    last_outcome: str = ""
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def processed(self) -> int:
+        return (
+            self.skipped_blocklist
+            + self.skipped_language
+            + self.skipped_alive
+            + self.investigated_no_cand
+            + self.investigated_with_cand
+            + self.errors
+        )
+
+    def remaining(self) -> int:
+        return max(0, self.total - self.processed())
+
+    def elapsed_s(self) -> float:
+        return time.monotonic() - self.started_monotonic
+
+    def per_min(self) -> float:
+        e = self.elapsed_s()
+        if e <= 0 or self.processed() == 0:
+            return 0.0
+        return self.processed() / (e / 60.0)
+
+    def eta_str(self) -> str:
+        rate = self.per_min()
+        if rate <= 0:
+            return "?"
+        m = self.remaining() / rate
+        return f"{m:.0f}m" if m < 60 else f"{m / 60:.1f}h"
+
+    def no_cand_rate(self) -> float:
+        """Fraction of recent REAL investigations that produced zero candidates."""
+        if not self.recent_no_cand:
+            return 0.0
+        return sum(self.recent_no_cand) / len(self.recent_no_cand)
+
+    def anomaly_flag(self) -> str:
+        if len(self.recent_no_cand) >= ANOMALY_WINDOW and self.no_cand_rate() >= ANOMALY_THRESHOLD:
+            return f" !ANOMALY no-cand-rate={100 * self.no_cand_rate():.0f}%"
+        return ""
+
+    def render_line(self) -> str:
+        now = datetime.now().strftime("%H:%M:%S")
+        pct = (100.0 * self.processed() / self.total) if self.total else 0.0
+        return (
+            f"[{now}] stage3 {self.processed():,}/{self.total:,} ({pct:.1f}%) "
+            f"alive={self.skipped_alive:,} lang={self.skipped_language:,} "
+            f"block={self.skipped_blocklist:,} "
+            f"no_cand={self.investigated_no_cand:,} with_cand={self.investigated_with_cand:,} "
+            f"cands+={self.candidates_inserted:,} "
+            f"rate={self.per_min():.0f}/min ETA={self.eta_str()}{self.anomaly_flag()}"
+        )
+
+
+# ---------------------------------------------------------------------------
+
+
+class GracefulShutdown:
+    def __init__(self) -> None:
+        self.requested = False
+        signal.signal(signal.SIGINT, self._handler)
+        try:
+            signal.signal(signal.SIGTERM, self._handler)
+        except (AttributeError, ValueError):
+            pass
+
+    def _handler(self, signum: int, frame: object) -> None:  # noqa: ARG002
+        self.requested = True
+        sys.stdout.write(f"\n[!] shutdown signal {signum} — letting in-flight investigations drain\n")
+        sys.stdout.flush()
+
+
+def write_status_file(stats: Stats, run_id: str, *, final: bool = False) -> None:
+    STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    body = [
+        f"run_id: {run_id}",
+        f"status: {'finished' if final else 'running'}",
+        f"started: {datetime.fromtimestamp(time.time() - stats.elapsed_s(), tz=timezone.utc).isoformat()}",
+        f"now: {datetime.now(timezone.utc).isoformat()}",
+        f"elapsed_min: {stats.elapsed_s() / 60:.1f}",
+        f"total: {stats.total}",
+        f"processed: {stats.processed()}",
+        f"remaining: {stats.remaining()}",
+        f"rate_per_min: {stats.per_min():.1f}",
+        f"eta: {stats.eta_str()}",
+        f"skipped_alive: {stats.skipped_alive}",
+        f"skipped_language: {stats.skipped_language}",
+        f"investigated_no_candidate: {stats.investigated_no_cand}",
+        f"investigated_with_candidate: {stats.investigated_with_cand}",
+        f"candidates_inserted: {stats.candidates_inserted}",
+        f"errors: {stats.errors}",
+        f"recent_no_cand_rate: {100 * stats.no_cand_rate():.1f}%",
+        f"anomaly: {bool(stats.anomaly_flag())}",
+        f"last_url: {stats.last_url}",
+        f"last_outcome: {stats.last_outcome}",
+    ]
+    STATUS_FILE.write_text("\n".join(body) + "\n", encoding="utf-8")
+
+
+def status_emitter(stats: Stats, run_id: str, shutdown: GracefulShutdown) -> None:
+    last = 0.0
+    while not shutdown.requested:
+        now = time.monotonic()
+        if now - last >= LOG_INTERVAL_S:
+            sys.stdout.write(stats.render_line() + "\n")
+            sys.stdout.flush()
+            write_status_file(stats, run_id)
+            last = now
+        time.sleep(1)
+
+
+# ---------------------------------------------------------------------------
+
+
+def load_repo_languages(db: UnifiedDatabase, run_id: str) -> dict[str, str | None]:
+    rows = db._conn.execute(
+        "SELECT repo_full_name, detected_language FROM bulk_scan_repos WHERE run_id = ?",
+        (run_id,),
+    ).fetchall()
+    return {r["repo_full_name"]: r["detected_language"] for r in rows}
+
+
+def language_excluded(detected: str | None) -> bool:
+    """Return True if the repo should be skipped because of language.
+
+    Matches the existing ``runner._is_repo_language_included`` semantics:
+    NULL and 'unknown' pass through to investigation; any other non-en
+    code is excluded.
+    """
+    if detected is None or detected == "unknown":
+        return False
+    return detected not in INCLUDE_LANGUAGES
+
+
+def load_findings_with_liveness(
+    db: UnifiedDatabase,
+    run_id: str,
+) -> list[dict]:
+    """Snapshot all pending findings + their cached liveness in one query."""
+    rows = db._conn.execute(
+        """
+        SELECT bsf.id, bsf.repo_full_name, bsf.source_file, bsf.line_number,
+               bsf.dead_url, ucc.http_status
+        FROM bulk_scan_findings bsf
+        LEFT JOIN url_check_cache ucc ON ucc.url = bsf.dead_url
+        WHERE bsf.run_id = ?
+          AND bsf.method = 'pending'
+          AND bsf.investigation_state = 'pending'
+        """,
+        (run_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def is_alive_status(code: int | None) -> bool:
+    """200-399 = alive. NULL (never probed) = NOT alive (we investigate)."""
+    return code is not None and 200 <= code < 400
+
+
+# ---------------------------------------------------------------------------
+
+
+def compute_outcome(
+    finding: dict,
+    repo_languages: dict[str, str | None],
+) -> tuple[str, list[dict]]:
+    """Pure compute — returns (state_label, candidates).
+
+    Runs in a worker thread. NO DB I/O. The sqlite3 module raises
+    ProgrammingError if a connection is used from any thread other than
+    the one that created it (default ``check_same_thread=True``), so all
+    DB writes are done in the main thread by ``write_outcome``.
+
+    Returns one of:
+        ('skipped_language', [])
+        ('skipped_alive', [])
+        ('investigated_no_candidate', [])
+        ('investigated_with_candidate', [<tier1 candidates>])
+        ('error', [])
+    """
+    repo = finding["repo_full_name"]
+    url = finding["dead_url"]
+    code = finding["http_status"]
+
+    # #258 — skip hosts on the static blocklist before any other check.
+    # Stage 3 wastes no cycles re-investigating anti-bot walls or
+    # browser-verified-broken hosts. Findings remain in the DB; the
+    # removal-PR derivation pass uses them downstream where applicable.
+    if is_blocklisted_host(url):
+        return ("skipped_blocklist", [])
+    if language_excluded(repo_languages.get(repo)):
+        return ("skipped_language", [])
+    if is_alive_status(code):
+        return ("skipped_alive", [])
+    try:
+        candidates = investigation.investigate_one(url, code if code is not None else "error")
+        tier1 = investigation.filter_tier1(candidates)
+    except Exception:
+        return ("error", [])
+    if not tier1:
+        return ("investigated_no_candidate", [])
+    return ("investigated_with_candidate", tier1)
+
+
+def write_outcome(
+    db: UnifiedDatabase,
+    run_id: str,
+    finding: dict,
+    state: str,
+    candidates: list[dict],
+    stats: Stats,
+) -> None:
+    """Apply one finding's outcome to the DB. Runs in the main thread only.
+
+    Atomic transaction: state UPDATE + any candidate INSERTs land together
+    so a crash mid-write rolls back to leave the finding 'pending' for retry.
+    """
+    fid = finding["id"]
+    repo = finding["repo_full_name"]
+    url = finding["dead_url"]
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    if state == "error":
+        stats.errors += 1
+        stats.last_url = url
+        stats.last_outcome = "error"
+        return
+
+    inserted = 0
+    with db._conn:
+        db._conn.execute(
+            "UPDATE bulk_scan_findings SET investigation_state = ?, "
+            "investigation_completed_at = ?, "
+            "investigation_attempts = investigation_attempts + 1 "
+            "WHERE id = ?",
+            (state, now_iso, fid),
+        )
+        for c in candidates:
+            conf = investigation.compute_confidence(c)
+            db._conn.execute(
+                "INSERT INTO bulk_scan_findings "
+                "(run_id, repo_full_name, source_file, line_number, dead_url, "
+                " candidate_url, method, tier, similarity_score, verified_live, "
+                " confidence, surfaced, created_at, investigation_state) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 'derived_candidate')",
+                (
+                    run_id,
+                    repo,
+                    finding["source_file"],
+                    finding["line_number"],
+                    url,
+                    c["candidate_url"],
+                    c["method"],
+                    c["tier"],
+                    c["similarity_score"],
+                    1 if c.get("verified_live") else 0,
+                    conf,
+                    now_iso,
+                ),
+            )
+            inserted += 1
+
+    # Stats update — single-threaded already, but the lock is cheap and
+    # protects against any future change that adds a second writer.
+    with stats.lock:
+        if state == "skipped_blocklist":
+            stats.skipped_blocklist += 1
+        elif state == "skipped_language":
+            stats.skipped_language += 1
+        elif state == "skipped_alive":
+            stats.skipped_alive += 1
+        elif state == "investigated_no_candidate":
+            stats.investigated_no_cand += 1
+            stats.recent_no_cand.append(True)
+        elif state == "investigated_with_candidate":
+            stats.investigated_with_cand += 1
+            stats.candidates_inserted += inserted
+            stats.recent_no_cand.append(False)
+        stats.last_url = url
+        stats.last_outcome = state
+
+
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run Stage 3 (investigation) for a bulk-scan run.")
+    parser.add_argument("--run-id", default=DEFAULT_RUN_ID)
+    parser.add_argument(
+        "--db",
+        default=str(Path.home() / ".ghla" / "ghla.db"),
+        help="path to ghla.db (default: ~/.ghla/ghla.db)",
+    )
+    parser.add_argument("--workers", type=int, default=DEFAULT_WORKERS)
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress per-minute status lines (status file still updates)",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s :: %(message)s",
+        force=True,
+    )
+    # Silence verbose modules. The LinkDetective modules emit WARNING-level
+    # noise for normal-background events (Wayback CDX timeouts, GitHub 403s
+    # that are retried internally, etc.) — they drown out the once-per-minute
+    # status line. Bump to ERROR. #256 tracks the deeper handler-dedup fix.
+    for noisy in (
+        "httpx",
+        "httpcore",
+        "urllib3",
+        "archive_client",
+        "github_resolver",
+        "link_detective",
+        "redirect_resolver",
+        "policy_checker",
+    ):
+        logging.getLogger(noisy).setLevel(logging.ERROR)
+
+    db_path = Path(args.db)
+    if not db_path.exists():
+        sys.stderr.write(f"DB not found: {db_path}\n")
+        return 2
+
+    db = UnifiedDatabase(str(db_path))
+    shutdown = GracefulShutdown()
+    stats = Stats()
+
+    try:
+        row = db._conn.execute("SELECT status FROM bulk_scan_runs WHERE run_id = ?", (args.run_id,)).fetchone()
+        if row is None:
+            sys.stderr.write(f"run not found: {args.run_id!r}\n")
+            return 4
+
+        sys.stdout.write("loading language map + findings + liveness snapshots…\n")
+        sys.stdout.flush()
+        repo_languages = load_repo_languages(db, args.run_id)
+        findings = load_findings_with_liveness(db, args.run_id)
+
+        stats.total = len(findings)
+        sys.stdout.write(
+            f"run_id: {args.run_id}\n"
+            f"pending findings: {stats.total:,}\n"
+            f"repos w/ language data: {sum(1 for v in repo_languages.values() if v):,}/{len(repo_languages):,}\n"
+            f"workers: {args.workers}\n"
+            f"DB: {db_path}\n"
+            f"status file: {STATUS_FILE}\n"
+            f"PID: {os.getpid()}\n\n"
+        )
+        sys.stdout.flush()
+
+        if not findings:
+            sys.stdout.write("nothing pending — Stage 3 already complete for this run.\n")
+            return 0
+
+        if not args.quiet:
+            t = threading.Thread(
+                target=status_emitter,
+                args=(stats, args.run_id, shutdown),
+                daemon=True,
+            )
+            t.start()
+
+        # Worker threads run compute_outcome (pure compute, no DB I/O).
+        # Main thread consumes futures via as_completed and calls write_outcome
+        # for each. This matches the pattern used in finish_stage2.py and
+        # sidesteps sqlite3's default check_same_thread=True restriction.
+        with ThreadPoolExecutor(max_workers=args.workers) as ex:
+            futures = {ex.submit(compute_outcome, f, repo_languages): f for f in findings}
+            for fut in as_completed(futures):
+                if shutdown.requested:
+                    for f2 in futures:
+                        if not f2.done():
+                            f2.cancel()
+                    break
+                finding = futures[fut]
+                try:
+                    state, candidates = fut.result()
+                except Exception as e:
+                    with stats.lock:
+                        stats.errors += 1
+                        stats.last_outcome = f"top-level: {type(e).__name__}"
+                    continue
+                # Main-thread DB write — sqlite connection used only from
+                # the thread that created it (default check_same_thread=True
+                # — the worker-thread write was the bug from the prior run).
+                try:
+                    write_outcome(db, args.run_id, finding, state, candidates, stats)
+                except Exception as e:
+                    with stats.lock:
+                        stats.errors += 1
+                        stats.last_outcome = f"write: {type(e).__name__}: {e}"
+
+        sys.stdout.write("\n" + stats.render_line() + "\n")
+        leftover_row = db._conn.execute(
+            "SELECT COUNT(*) AS n FROM bulk_scan_findings "
+            "WHERE run_id = ? AND method = 'pending' AND investigation_state = 'pending'",
+            (args.run_id,),
+        ).fetchone()
+        leftover = int(leftover_row["n"])
+        sys.stdout.write(
+            f"\nfinished. skip_alive={stats.skipped_alive:,} skip_lang={stats.skipped_language:,} "
+            f"no_cand={stats.investigated_no_cand:,} with_cand={stats.investigated_with_cand:,} "
+            f"candidates_inserted={stats.candidates_inserted:,} errors={stats.errors:,} "
+            f"still-pending={leftover:,} elapsed={stats.elapsed_s() / 60:.1f}min\n"
+        )
+        if stats.anomaly_flag():
+            sys.stdout.write(
+                f"\n!! anomaly flag was tripped — final no-cand rate "
+                f"{100 * stats.no_cand_rate():.0f}%. Recheck whether GH API, "
+                "Wikipedia, or local network was failing during the run.\n"
+            )
+        sys.stdout.flush()
+        write_status_file(stats, args.run_id, final=True)
+        return 0 if leftover == 0 else 1
+    finally:
+        try:
+            db.close()
+        except sqlite3.Error:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`finish_stage1/2/3.py` and `detect_languages.py` all do `logging.getLogger(\"archive_client\").setLevel(logging.ERROR)` in `main()` to silence LinkDetective's chatty module loggers. The silencing wasn't working — every Stage 3 run filled the operator console with ~50-100 CDX warnings per minute, drowning the per-minute status line.

**Root cause:** `investigation.investigate_one()` does `from gh_link_auditor.link_detective import LinkDetective` *lazily inside the function*. So the LinkDetective chain (link_detective → archive_client / github_resolver / policy_checker / redirect_resolver) only loads when the **first worker actually calls `investigate_one`** — long after `main()`'s `setLevel(ERROR)` loop has already run on loggers with no handlers and `propagate=True`. When `setup_logging` fires during the lazy import, it **resets `level` to INFO** and adds a StreamHandler. Spam ensues.

Diagnostic probe (before the fix):

```
=== after import (before silencing) ===
level: 0 (NOTSET)   ← setup_logging never ran
propagate: True
handlers: 0
```

Probe (after the fix):

```
=== after eager imports (before silencing) ===
level: 20 (INFO)    ← setup_logging did run
propagate: False
handlers: 2
```

Then `setLevel(ERROR)` actually overrides the INFO that setup_logging set, and WARNING records are filtered.

## Fix

Add an eager-import block to each of the four tools, right after the `sys.path` setup, naming all five LinkDetective-chain modules:

```python
from gh_link_auditor import (  # noqa: E402
    archive_client,  # noqa: F401
    github_resolver,  # noqa: F401
    link_detective,  # noqa: F401
    policy_checker,  # noqa: F401
    redirect_resolver,  # noqa: F401
)
```

The comment block above explains why — without it, future maintainers won't know these imports are load-bearing.

## Files committed (first-time commits)

- `tools/finish_stage1.py`
- `tools/finish_stage2.py`
- `tools/finish_stage3.py`
- `tools/detect_languages.py`
- `src/gh_link_auditor/bulk_scan/host_blocklist.py` (required dep of finish_stage3 — the 16-host blocklist from the overnight session)

All five were untracked in the working tree from the prior session.

## Verification

- Diagnostic probe (committed locally for this session; not in the PR): confirms before/after logger state.
- **Live operator restart**: after applying the fix in the working tree and restarting Stage 3, the operator confirmed the spam is gone.
- Full suite: **2158 passed, 1 skipped** (no behavioral change).
- `ruff format --check .` + `ruff check .` clean.

## Closes

Closes #265

## Test plan

- [x] Diagnostic probe shows logger state changes as expected
- [x] Operator-side restart of Stage 3 confirmed clean console
- [x] Full suite passes
- [x] Lint + format clean
- [ ] Post-merge: future Stage 1/2/3 + detect_languages runs all stay clean

## Out of scope

- Refactoring `setup_logging` to respect pre-existing levels — separate design conversation.
- Committing the other 6 untracked tools (probes, `derive_host_blocklist.py`) — those belong to the upcoming #258 phase 1 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)