### PR TITLE
feat(stage3-status): yield% + 5m rate + last-cand on the status line

### DIFF
--- a/docs/reports/active/10268-implementation-report.md
+++ b/docs/reports/active/10268-implementation-report.md
@@ -1,0 +1,78 @@
+# Implementation Report: #268/#269/#270 status-line observability bundle
+
+## Summary
+
+Three small `tools/finish_stage3.py` status-line improvements, bundled because they all touch the same `Stats` class + `render_line()` + `write_status_file()` and ship as one operator-facing surface change:
+
+- **#268** — show yield% + skipped/investigated split inline (do the math the operator was doing in their head)
+- **#269** — show recent (5-minute) rate alongside lifetime rate (catch slowdowns the lifetime smooths away)
+- **#270** — show time-since-last-candidate (single best "is the pipeline alive?" signal)
+
+## Before / after
+
+**Before:**
+
+```
+[10:11:28] stage3 27/107,669 (0.0%) alive=0 lang=0 block=0 no_cand=27 with_cand=0 cands+=0 rate=27/min ETA=66h
+```
+
+**After:**
+
+```
+[10:11:28] stage3 27/107,669 (0.0%) skipped=0 investigated=27 yield=0.0% cands+=0 rate=27/min (5m: 0/min) ETA=66h last_cand=never
+```
+
+Same width-ish; every field is now a decision input.
+
+## Changes
+
+### `tools/finish_stage3.py`
+
+**`Stats` (dataclass):**
+- new field `last_cand_monotonic: float | None = None` (#270)
+- new field `rate_window: deque` with `maxlen=5` (#269)
+- new methods `investigated()`, `skipped()`, `yield_pct()` (#268)
+- new methods `recent_rate_per_min()`, `record_rate_sample()` (#269)
+- new method `time_since_last_cand_str()` (#270) — formats as `12s` / `8m` / `1.2h` / `never`
+
+**`render_line()`** rewritten:
+- `alive=N lang=N block=N` → `skipped=K`
+- `no_cand=N with_cand=N` → `investigated=K yield=X.X%`
+- `rate=N/min` → `rate=N/min (5m: M/min)`
+- new tail `last_cand=Tval`
+- `yield=n/a` when no real investigations yet (avoids divide-by-zero)
+- `last_cand=never` when no candidate has surfaced yet
+
+**`write_status_file()`** gains keys:
+- `recent_rate_per_min`
+- `skipped_blocklist` (was previously dropped — bug fix)
+- `skipped_total`
+- `investigated_total`
+- `yield_pct`
+- `seconds_since_last_candidate`
+
+**`write_outcome()`:** stamps `stats.last_cand_monotonic = time.monotonic()` when a candidate is recorded.
+
+**`status_emitter()`:** calls `stats.record_rate_sample()` once per tick before rendering, so each printed line uses fresh sample data.
+
+## ASCII discipline
+
+PowerShell on Windows mojibakes em-dash characters. Using `n/a` for "no investigations yet" and `never` for "no candidates yet" instead of `—`. Same convention as #226's avoidance of Unicode box-drawing in CI/Gemini prompts.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `tools/finish_stage3.py` | Stats helpers + render_line + status file format |
+
+No tests added — `Stats` is heavy to import (eager-loads LinkDetective chain), and the math methods are obviously correct. Verified by smoke-test that exercises three states (fresh, mid-run, lots-skipped-no-cand).
+
+## Test count
+
+Unchanged: **2158 passed, 1 skipped** (no test touched).
+
+## Out of scope
+
+- Apply the same observability work to `finish_stage1.py`, `finish_stage2.py`, `detect_languages.py`. They don't have the "candidates" concept, so #270 doesn't apply; #268's yield doesn't either. #269 (recent rate) would help, but each script has a different `Stats` shape. Follow-up if useful.
+- Extract `Stats` to a separate module so it's unit-testable without the LinkDetective import chain. Refactor scope creep.
+- A multi-line periodic dump (every 5 min, more detail). Different design; possibly useful but the operator's current need is the one-liner being scannable.

--- a/docs/reports/active/10268-test-report.md
+++ b/docs/reports/active/10268-test-report.md
@@ -1,0 +1,60 @@
+# Test Report: #268/#269/#270 status-line observability bundle
+
+## Verification
+
+This bundle adds observability fields to `tools/finish_stage3.py`'s status line and status file. Pure arithmetic + string formatting + a deque sliding window. Verified by:
+
+1. **Smoke test** — three Stats states exercised: fresh / mid-run-5-candidates / lots-skipped-no-candidates.
+2. **Full suite** — 2158 passed, 1 skipped (no regressions; no test touched).
+3. **Manual eyeball** — output matches the design in the LLD-style sketch.
+
+### Smoke test output
+
+```
+CASE 1 (fresh — nothing processed):
+  [13:00:58] stage3 0/100,000 (0.0%) skipped=0 investigated=0 yield=n/a cands+=0 rate=0/min (5m: 0/min) ETA=? last_cand=never
+
+CASE 2 (100 invs, 5 cand, started 5m ago, last cand 8m ago):
+  [13:00:58] stage3 100/100,000 (0.1%) skipped=0 investigated=100 yield=5.0% cands+=5 rate=20/min (5m: 20/min) ETA=83.3h last_cand=8m
+
+CASE 3 (200 invs, 0 cand, lots skipped):
+  [13:00:58] stage3 280/100,000 (0.3%) skipped=80 investigated=200 yield=0.0% cands+=0 rate=28/min (5m: 28/min) ETA=59.4h last_cand=never
+```
+
+All three cases render cleanly. `yield=n/a` in case 1, `yield=0.0%` in case 3 (200 invs, 0 cand). `last_cand=never` until a candidate surfaces, then `8m` etc. `recent_rate` falls back to lifetime when fewer than 2 samples exist.
+
+### Suite regression
+
+```
+$ poetry run pytest -q --tb=line
+2158 passed, 1 skipped, 1 warning in 139.29s
+```
+
+Same count as post-#267.
+
+### Lint + format
+
+```
+$ ruff check tools/finish_stage3.py
+All checks passed!
+$ ruff format tools/finish_stage3.py
+1 file left unchanged
+```
+
+## What's NOT tested
+
+- A pytest unit test of `Stats.yield_pct()` / `recent_rate_per_min()` / `time_since_last_cand_str()`. The `Stats` class lives inside `finish_stage3.py` which eager-loads the entire LinkDetective chain at module import (#265). Standing up a test that imports just `Stats` would either require refactoring `Stats` into a separate module or paying the heavy import cost on every test run. The methods are pure arithmetic; the smoke test exercises the rendering correctness. A proper unit-testable home for `Stats` is a follow-up refactor.
+- Integration test with a live Stage 3 run. The operator restarts Stage 3 manually; the next per-minute status line shows the new format.
+
+## CI verification
+
+Standard gate: Test, Lint, auto-review, pr-sentinel. The tool isn't imported by tests or the package, so the only CI signal is Lint catching syntax/import breakage.
+
+## Operator action
+
+After merge: stop the current `finish_stage3.py` run, restart with the same command. The next status line will use the new format. Watch `last_cand=` — if it stays at `never` for >10 min after restart, the pipeline isn't producing candidates and we need to dig. Watch `yield=` — should hover around 0.5-1% on this corpus based on the 14-candidates-in-75-min sample from the current run.
+
+## Out of scope
+
+- Multi-line periodic dump (every 5 min, more detail). Different design.
+- Same treatment for the other three tool scripts (`finish_stage1`, `finish_stage2`, `detect_languages`). They have different `Stats` shapes and no "candidates" concept; not a 1:1 port.

--- a/tools/finish_stage3.py
+++ b/tools/finish_stage3.py
@@ -126,6 +126,15 @@ class Stats:
     last_url: str = ""
     last_outcome: str = ""
     lock: threading.Lock = field(default_factory=threading.Lock)
+    # #270 — monotonic timestamp of the last `investigated_with_candidate`
+    # event. None until the first candidate surfaces. Used by render_line
+    # to show "time since last candidate" so the operator can tell whether
+    # the pipeline has gone quiet vs. is still producing.
+    last_cand_monotonic: float | None = None
+    # #269 — rolling (monotonic_ts, processed_count) samples for a 5-minute
+    # recent rate. status_emitter appends one entry per LOG_INTERVAL_S tick
+    # before rendering. maxlen=5 ⇒ up to ~5 minutes of history.
+    rate_window: deque = field(default_factory=lambda: deque(maxlen=5))
 
     def processed(self) -> int:
         return (
@@ -140,6 +149,21 @@ class Stats:
     def remaining(self) -> int:
         return max(0, self.total - self.processed())
 
+    def investigated(self) -> int:
+        """Real investigations (excludes skip paths)."""
+        return self.investigated_no_cand + self.investigated_with_cand
+
+    def skipped(self) -> int:
+        """All skip paths summed (alive + language + blocklist)."""
+        return self.skipped_alive + self.skipped_language + self.skipped_blocklist
+
+    def yield_pct(self) -> float:
+        """Tier-1 yield as a percentage. Undefined when no real investigations."""
+        n = self.investigated()
+        if n == 0:
+            return 0.0
+        return 100.0 * self.investigated_with_cand / n
+
     def elapsed_s(self) -> float:
         return time.monotonic() - self.started_monotonic
 
@@ -149,12 +173,38 @@ class Stats:
             return 0.0
         return self.processed() / (e / 60.0)
 
+    def recent_rate_per_min(self) -> float:
+        """#269 — per-minute rate over the rate_window (last ~5 min)."""
+        if len(self.rate_window) < 2:
+            return self.per_min()
+        ts0, p0 = self.rate_window[0]
+        ts1, p1 = self.rate_window[-1]
+        dt = ts1 - ts0
+        if dt <= 0:
+            return self.per_min()
+        return (p1 - p0) / (dt / 60.0)
+
+    def record_rate_sample(self) -> None:
+        """Called by status_emitter once per tick before rendering."""
+        self.rate_window.append((time.monotonic(), self.processed()))
+
     def eta_str(self) -> str:
         rate = self.per_min()
         if rate <= 0:
             return "?"
         m = self.remaining() / rate
         return f"{m:.0f}m" if m < 60 else f"{m / 60:.1f}h"
+
+    def time_since_last_cand_str(self) -> str:
+        """#270 — formatted '8m' / '12s' / '1.2h' or 'never' when never."""
+        if self.last_cand_monotonic is None:
+            return "never"
+        delta = time.monotonic() - self.last_cand_monotonic
+        if delta < 60:
+            return f"{delta:.0f}s"
+        if delta < 3600:
+            return f"{delta / 60:.0f}m"
+        return f"{delta / 3600:.1f}h"
 
     def no_cand_rate(self) -> float:
         """Fraction of recent REAL investigations that produced zero candidates."""
@@ -170,13 +220,15 @@ class Stats:
     def render_line(self) -> str:
         now = datetime.now().strftime("%H:%M:%S")
         pct = (100.0 * self.processed() / self.total) if self.total else 0.0
+        invs = self.investigated()
+        yield_str = f"yield={self.yield_pct():.1f}%" if invs else "yield=n/a"
         return (
             f"[{now}] stage3 {self.processed():,}/{self.total:,} ({pct:.1f}%) "
-            f"alive={self.skipped_alive:,} lang={self.skipped_language:,} "
-            f"block={self.skipped_blocklist:,} "
-            f"no_cand={self.investigated_no_cand:,} with_cand={self.investigated_with_cand:,} "
+            f"skipped={self.skipped():,} investigated={invs:,} {yield_str} "
             f"cands+={self.candidates_inserted:,} "
-            f"rate={self.per_min():.0f}/min ETA={self.eta_str()}{self.anomaly_flag()}"
+            f"rate={self.per_min():.0f}/min (5m: {self.recent_rate_per_min():.0f}/min) "
+            f"ETA={self.eta_str()} last_cand={self.time_since_last_cand_str()}"
+            f"{self.anomaly_flag()}"
         )
 
 
@@ -200,6 +252,10 @@ class GracefulShutdown:
 
 def write_status_file(stats: Stats, run_id: str, *, final: bool = False) -> None:
     STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if stats.last_cand_monotonic is None:
+        sec_since_cand = ""
+    else:
+        sec_since_cand = f"{time.monotonic() - stats.last_cand_monotonic:.0f}"
     body = [
         f"run_id: {run_id}",
         f"status: {'finished' if final else 'running'}",
@@ -210,15 +266,21 @@ def write_status_file(stats: Stats, run_id: str, *, final: bool = False) -> None
         f"processed: {stats.processed()}",
         f"remaining: {stats.remaining()}",
         f"rate_per_min: {stats.per_min():.1f}",
+        f"recent_rate_per_min: {stats.recent_rate_per_min():.1f}",
         f"eta: {stats.eta_str()}",
         f"skipped_alive: {stats.skipped_alive}",
         f"skipped_language: {stats.skipped_language}",
+        f"skipped_blocklist: {stats.skipped_blocklist}",
+        f"skipped_total: {stats.skipped()}",
         f"investigated_no_candidate: {stats.investigated_no_cand}",
         f"investigated_with_candidate: {stats.investigated_with_cand}",
+        f"investigated_total: {stats.investigated()}",
+        f"yield_pct: {stats.yield_pct():.2f}",
         f"candidates_inserted: {stats.candidates_inserted}",
         f"errors: {stats.errors}",
         f"recent_no_cand_rate: {100 * stats.no_cand_rate():.1f}%",
         f"anomaly: {bool(stats.anomaly_flag())}",
+        f"seconds_since_last_candidate: {sec_since_cand}",
         f"last_url: {stats.last_url}",
         f"last_outcome: {stats.last_outcome}",
     ]
@@ -230,6 +292,8 @@ def status_emitter(stats: Stats, run_id: str, shutdown: GracefulShutdown) -> Non
     while not shutdown.requested:
         now = time.monotonic()
         if now - last >= LOG_INTERVAL_S:
+            # #269 — sample BEFORE rendering so recent_rate uses the latest point.
+            stats.record_rate_sample()
             sys.stdout.write(stats.render_line() + "\n")
             sys.stdout.flush()
             write_status_file(stats, run_id)
@@ -404,6 +468,9 @@ def write_outcome(
             stats.investigated_with_cand += 1
             stats.candidates_inserted += inserted
             stats.recent_no_cand.append(False)
+            # #270 — stamp the time of this candidate so render_line can show
+            # "minutes since last candidate" for operator's pipeline-alive check.
+            stats.last_cand_monotonic = time.monotonic()
         stats.last_url = url
         stats.last_outcome = state
 


### PR DESCRIPTION
## Summary

Three small observability improvements to `tools/finish_stage3.py`'s status line, bundled because they all touch the same `Stats` class.

**Before:**

```
[10:11:28] stage3 27/107,669 (0.0%) alive=0 lang=0 block=0 no_cand=27 with_cand=0 cands+=0 rate=27/min ETA=66h
```

**After:**

```
[10:11:28] stage3 27/107,669 (0.0%) skipped=0 investigated=27 yield=0.0% cands+=0 rate=27/min (5m: 0/min) ETA=66h last_cand=never
```

Same width; every field is now a decision input.

| Change | Closes |
|---|---|
| `skipped=K investigated=M yield=X.X%` (do the math the operator was doing in their head) | #268 |
| `rate=L/min (5m: R/min)` (catch slowdowns the lifetime smooths away) | #269 |
| `last_cand=Tval` — `never` / `12s` / `8m` / `1.2h` (single best ""is the pipeline alive?"" signal) | #270 |

## Stats class additions

- `last_cand_monotonic: float | None` — stamped by `write_outcome` when a candidate is recorded
- `rate_window: deque[(monotonic_ts, processed)]` — populated by `status_emitter`, maxlen 5
- pure helpers: `investigated()`, `skipped()`, `yield_pct()`, `recent_rate_per_min()`, `record_rate_sample()`, `time_since_last_cand_str()`

## Status file gains

`recent_rate_per_min`, `investigated_total`, `skipped_total`, `yield_pct`, `seconds_since_last_candidate`, and `skipped_blocklist` (which was previously dropped — bug fix while I was in there).

## ASCII discipline

PowerShell on Windows mojibakes em-dash. Using `yield=n/a` and `last_cand=never` instead of `—`. Same convention as the Gemini-prompt rule.

## Verification

- Smoke test exercises three Stats states (fresh / mid-run-with-cands / lots-skipped-no-cand): all render cleanly.
- Full suite: **2158 passed, 1 skipped** (no regressions).
- `ruff format --check` + `ruff check` clean.

## Closes

Closes #268
Closes #269
Closes #270

## Test plan

- [x] Smoke test all three Stats states
- [x] Full suite passes
- [x] Lint + format clean
- [ ] Post-merge: operator restarts Stage 3, the next per-minute status line uses the new format. Headlines to watch:
  - `yield=` should hover ~0.5-1% on this corpus (matches the 14/2230 we just measured)
  - `last_cand=` should stay under ~10m most of the time; sustained ""never"" or ""1h+"" means dig in
  - `(5m: N/min)` should track close to the lifetime rate; large divergence = recent slowdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)