### PR TITLE
test(flaky): stub asyncio.sleep in test_low_watermark_sleeps

### DIFF
--- a/docs/reports/active/10246-implementation-report.md
+++ b/docs/reports/active/10246-implementation-report.md
@@ -1,0 +1,52 @@
+# Implementation Report: #246 flaky test_low_watermark_sleeps
+
+## Summary
+
+`tests/unit/batch/test_rate_limiter.py::TestBackpressure::test_low_watermark_sleeps` set `X-RateLimit-Reset` to `now + 60s`, then called `asyncio.run(rl.acquire())` which awaits a real `asyncio.sleep(60)`. CI's `pytest-timeout = 60s` raced that exact sleep duration — on a slow runner, normal test-setup overhead pushed the actual wall-clock past 60s and the test timed out.
+
+This caused the spurious CI failure on PR #271 (the post-#268 status-line bundle) and forced a close/reopen to retrigger CI. Issue #246 was filed previously identifying this exact race; this PR fixes it.
+
+## Fix
+
+Stub `asyncio.sleep` with `monkeypatch` so `acquire()` returns immediately while still recording what duration it asked for. The test's contract is unchanged: it verifies (a) backpressure activated, (b) `acquire()` requested a positive sleep. Removing the actual wall-clock wait removes the race.
+
+```python
+async def _fake_sleep(seconds: float) -> None:
+    sleeps.append(seconds)
+
+monkeypatch.setattr(
+    "gh_link_auditor.batch.rate_limiter.asyncio.sleep",
+    _fake_sleep,
+)
+
+asyncio.run(rl.acquire())
+
+assert sleeps, "expected at least one asyncio.sleep call"
+assert sleeps[0] > 0
+```
+
+Patching the module-attribute path (`rate_limiter.asyncio.sleep`) keeps the patch scoped to the rate_limiter's usage. `asyncio.run()` itself does not call `asyncio.sleep`, so the patch is safe.
+
+## Test count
+
+Unchanged: **2158 passed, 1 skipped**.
+
+## Suite time
+
+- Before: ~125s (the flaky test slept ~60s when it passed)
+- After: ~68s (the test runs in 0.16s)
+
+That's ~46% faster — a nice bonus, but the real win is determinism.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `tests/unit/batch/test_rate_limiter.py` | swap real `asyncio.sleep` for a recording stub via `monkeypatch.setattr` |
+
+No library code changed. The `AdaptiveRateLimiter.acquire()` contract is unchanged.
+
+## Out of scope
+
+- The other backpressure test (`test_between_watermarks_proportional_delay`) uses a 10s reset window and goes through the `delay = ratio * min(max_delay, 10.0)` path — actually sleeps ~5.5s of wall-clock. Not flaky (well under the 60s timeout), but ALSO not great for suite speed. Could mock the same way as a follow-up if suite time matters more.
+- Refactoring `AdaptiveRateLimiter.acquire()` to accept an injected sleep function would let tests run with no asyncio at all. Bigger change; not needed for the fix.

--- a/docs/reports/active/10246-test-report.md
+++ b/docs/reports/active/10246-test-report.md
@@ -1,0 +1,59 @@
+# Test Report: #246 flaky test_low_watermark_sleeps
+
+## Verification
+
+### Targeted
+
+```
+$ poetry run pytest tests/unit/batch/test_rate_limiter.py::TestBackpressure::test_low_watermark_sleeps -v
+PASSED [100%]
+1 passed in 0.16s
+```
+
+0.16s vs. the previous ~60s.
+
+### Full rate_limiter file
+
+```
+$ poetry run pytest tests/unit/batch/test_rate_limiter.py -v
+8 passed in 5.32s
+```
+
+All 8 tests in the file still green.
+
+### Full suite
+
+```
+$ poetry run pytest -q --tb=line
+2158 passed, 1 skipped, 1 warning in 68.67s
+```
+
+No regressions. Suite time dropped from ~125s to ~68s because the flaky test no longer wastes 60s on every clean run.
+
+### Lint + format
+
+```
+$ ruff format --check tests/unit/batch/test_rate_limiter.py
+1 file already formatted
+$ ruff check tests/unit/batch/test_rate_limiter.py
+All checks passed!
+```
+
+## Reliability
+
+The previous test was racing the timeout because real `asyncio.sleep(60)` + test setup overhead occasionally exceeded the 60s pytest-timeout marker on slow CI runners. With `asyncio.sleep` stubbed, there's no wall-clock dependency — the test completes in deterministic sub-millisecond time. No timeout race possible.
+
+I ran the test 10 times locally in a tight loop (`for i in {1..10}; do pytest tests/unit/batch/test_rate_limiter.py::TestBackpressure::test_low_watermark_sleeps; done`); all 10 passed in well under 1s each.
+
+## CI verification
+
+Standard gate: Test, Lint, auto-review, pr-sentinel. The Test job, which is what was failing intermittently, should now pass deterministically.
+
+## What's NOT tested
+
+- A test that proves the test itself is no longer flaky under load. The original failure mode requires a slow CI runner with co-tenant noise; locally I can't reliably reproduce it. The structural fix (no wall-clock dependency) eliminates the race by construction.
+
+## Out of scope
+
+- Mocking `asyncio.sleep` in `test_between_watermarks_proportional_delay` too (currently sleeps ~5.5s). Not racing the timeout, so not in scope here. Could be done for suite-speed reasons in a follow-up.
+- Refactoring `acquire()` to accept an injected sleep callable. Bigger change; not required for this fix.

--- a/tests/unit/batch/test_rate_limiter.py
+++ b/tests/unit/batch/test_rate_limiter.py
@@ -17,8 +17,16 @@ from gh_link_auditor.batch.rate_limiter import AdaptiveRateLimiter
 class TestBackpressure:
     """T070: Backpressure at low watermark (REQ-4)."""
 
-    def test_low_watermark_sleeps(self) -> None:
-        """acquire() sleeps when remaining < low_watermark."""
+    def test_low_watermark_sleeps(self, monkeypatch) -> None:
+        """acquire() sleeps when remaining < low_watermark.
+
+        #246 — Previously this test awaited a real ``asyncio.sleep(60)`` to
+        observe a positive elapsed wall-clock. That raced the pytest-timeout
+        of 60s on slow CI runners. We now stub ``asyncio.sleep`` to record
+        its argument and return immediately; the contract being verified is
+        unchanged: backpressure was activated, and acquire() asked to sleep
+        for a positive duration.
+        """
         rl = AdaptiveRateLimiter(low_watermark=100, high_watermark=1000)
         rl.update_from_headers(
             {
@@ -27,12 +35,23 @@ class TestBackpressure:
             }
         )
 
-        start = time.monotonic()
-        asyncio.run(rl.acquire())
-        elapsed = time.monotonic() - start
+        sleeps: list[float] = []
 
-        # Should have slept some positive amount
-        assert elapsed > 0.0
+        async def _fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr(
+            "gh_link_auditor.batch.rate_limiter.asyncio.sleep",
+            _fake_sleep,
+        )
+
+        asyncio.run(rl.acquire())
+
+        # acquire() asked for a positive sleep (because remaining < low_watermark
+        # and reset is ~60s out) — exact value depends on monotonic clock drift
+        # between header parsing and acquire(), but must be > 0.
+        assert sleeps, "expected at least one asyncio.sleep call"
+        assert sleeps[0] > 0
         snapshot = rl.snapshot()
         assert snapshot["backpressure_active"] is True
 


### PR DESCRIPTION
## Summary

`test_low_watermark_sleeps` set `X-RateLimit-Reset = now + 60s`, then awaited a real `asyncio.sleep(60)` inside `acquire()`. The pytest-timeout was also 60s — any slow CI runner with test-setup overhead would push past the timeout, causing a `Failed: Timeout (>60.0s)` error. This is exactly what happened on PR #271 and forced a close/reopen to retrigger CI.

## Fix

Monkeypatch `asyncio.sleep` to a recording stub that returns immediately. The test's contract is preserved:

```python
async def _fake_sleep(seconds: float) -> None:
    sleeps.append(seconds)

monkeypatch.setattr(
    ""gh_link_auditor.batch.rate_limiter.asyncio.sleep"",
    _fake_sleep,
)

asyncio.run(rl.acquire())

assert sleeps, ""expected at least one asyncio.sleep call""
assert sleeps[0] > 0
snapshot = rl.snapshot()
assert snapshot[""backpressure_active""] is True
```

Same two assertions as before (positive sleep requested, backpressure activated) — but no wall-clock dependency, so no timeout race.

## Speed bonus

- Targeted test: ~60s → **0.16s**
- Full suite: ~125s → **68s** (46% faster)

The flaky test was wasting 60s on every successful run. Now it doesn't.

## Closes

Closes #246

## Test plan

- [x] Targeted test passes in 0.16s
- [x] All 8 tests in `test_rate_limiter.py` still green
- [x] Full suite 2158 passed (no regressions)
- [x] `ruff format --check` + `ruff check` clean
- [ ] CI Test job passes deterministically (no more close/reopen needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)