### PR TITLE
chore(db): mark legacy unsafe derived_candidate rows

### DIFF
--- a/tests/unit/tools/test_cleanup_unsafe_candidates.py
+++ b/tests/unit/tools/test_cleanup_unsafe_candidates.py
@@ -1,0 +1,225 @@
+"""Tests for tools/cleanup_unsafe_candidates.py (#275)."""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from gh_link_auditor.unified_db import UnifiedDatabase
+from tools import cleanup_unsafe_candidates as mod
+
+
+def _make_row(**overrides) -> dict:
+    base = {
+        "id": 1,
+        "run_id": "test-run",
+        "repo_full_name": "owner/repo",
+        "source_file": "README.md",
+        "line_number": 5,
+        "dead_url": "https://old.example.com",
+        "candidate_url": "https://new.example.com",
+        "method": "github_api_redirect",
+        "tier": 1,
+        "similarity_score": 1.0,
+        "verified_live": 1,
+        "confidence": 1.0,
+        "surfaced": 0,
+        "created_at": "2026-05-23T15:00:00+00:00",
+        "investigation_state": "derived_candidate",
+    }
+    base.update(overrides)
+    return base
+
+
+def _insert(udb: UnifiedDatabase, **overrides) -> int:
+    row = _make_row(**overrides)
+    cur = udb._conn.execute(
+        """INSERT INTO bulk_scan_findings
+           (run_id, repo_full_name, source_file, line_number, dead_url, candidate_url,
+            method, tier, similarity_score, verified_live, confidence, surfaced,
+            created_at, investigation_state)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            row["run_id"],
+            row["repo_full_name"],
+            row["source_file"],
+            row["line_number"],
+            row["dead_url"],
+            row["candidate_url"],
+            row["method"],
+            row["tier"],
+            row["similarity_score"],
+            row["verified_live"],
+            row["confidence"],
+            row["surfaced"],
+            row["created_at"],
+            row["investigation_state"],
+        ),
+    )
+    udb._conn.commit()
+    return cur.lastrowid
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test.db")
+
+
+def _make_args(**overrides) -> argparse.Namespace:
+    defaults = {"db": "/tmp/x", "apply": False}
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestLoadUnsafeRows:
+    def test_finds_unbalanced_paren(self, db_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert(
+                udb,
+                dead_url="https://en.wikipedia.org/wiki/Okapi_BM25)'s",
+                candidate_url="https://en.wikipedia.org/wiki/Okapi_BM25",
+            )
+            unsafe = mod._load_unsafe_rows(udb)
+        assert len(unsafe) == 1
+        assert unsafe[0]["reason"] == "unbalanced_paren"
+
+    def test_finds_markdown_suffix(self, db_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert(
+                udb,
+                dead_url='https://example.com/page"',
+                candidate_url="https://example.com/page",
+            )
+            unsafe = mod._load_unsafe_rows(udb)
+        assert len(unsafe) == 1
+        assert unsafe[0]["reason"] == "dead_url_suffix_has_markdown_chars"
+
+    def test_ignores_safe_candidates(self, db_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert(
+                udb,
+                dead_url="https://docs.example.com/old/index.html",
+                candidate_url="https://docs.example.com/new/index.html",
+            )
+            _insert(
+                udb,
+                dead_url="https://sumo.dlr.de/docs/Installing/index.htm",
+                candidate_url="https://sumo.dlr.de/docs/Installing/",
+            )
+            unsafe = mod._load_unsafe_rows(udb)
+        assert unsafe == []
+
+    def test_skips_already_surfaced(self, db_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert(
+                udb,
+                surfaced=1,
+                dead_url="https://en.wikipedia.org/wiki/Foo)'s",
+                candidate_url="https://en.wikipedia.org/wiki/Foo",
+            )
+            unsafe = mod._load_unsafe_rows(udb)
+        assert unsafe == []
+
+    def test_skips_non_derived_state(self, db_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert(
+                udb,
+                investigation_state="pending",
+                dead_url="https://en.wikipedia.org/wiki/Foo)'s",
+                candidate_url="https://en.wikipedia.org/wiki/Foo",
+            )
+            unsafe = mod._load_unsafe_rows(udb)
+        assert unsafe == []
+
+
+class TestMarkDropped:
+    def test_marks_rows(self, db_path):
+        with UnifiedDatabase(db_path) as udb:
+            id1 = _insert(udb)
+            id2 = _insert(udb)
+            mod._mark_dropped(udb, [id1, id2])
+            r1 = udb._conn.execute(
+                "SELECT investigation_state FROM bulk_scan_findings WHERE id = ?",
+                (id1,),
+            ).fetchone()
+            r2 = udb._conn.execute(
+                "SELECT investigation_state FROM bulk_scan_findings WHERE id = ?",
+                (id2,),
+            ).fetchone()
+        assert r1["investigation_state"] == "dropped_unsafe_url"
+        assert r2["investigation_state"] == "dropped_unsafe_url"
+
+    def test_empty_noop(self, db_path):
+        with UnifiedDatabase(db_path) as udb:
+            mod._mark_dropped(udb, [])
+
+
+class TestCleanup:
+    def test_dry_run_does_not_mutate(self, db_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert(
+                udb,
+                dead_url="https://en.wikipedia.org/wiki/Foo)'s",
+                candidate_url="https://en.wikipedia.org/wiki/Foo",
+            )
+        rc = mod.cleanup(_make_args(db=db_path, apply=False))
+        assert rc == 0
+        with UnifiedDatabase(db_path) as udb:
+            row = udb._conn.execute("SELECT investigation_state FROM bulk_scan_findings").fetchone()
+            assert row["investigation_state"] == "derived_candidate"
+
+    def test_apply_mutates(self, db_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert(
+                udb,
+                dead_url="https://en.wikipedia.org/wiki/Foo)'s",
+                candidate_url="https://en.wikipedia.org/wiki/Foo",
+            )
+            _insert(
+                udb,
+                dead_url="https://safe.example.com/a",
+                candidate_url="https://safe.example.com/b",
+            )
+        rc = mod.cleanup(_make_args(db=db_path, apply=True))
+        assert rc == 0
+        with UnifiedDatabase(db_path) as udb:
+            states = [
+                r["investigation_state"]
+                for r in udb._conn.execute("SELECT investigation_state FROM bulk_scan_findings ORDER BY id").fetchall()
+            ]
+        assert states == ["dropped_unsafe_url", "derived_candidate"]
+
+    def test_idempotent(self, db_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert(
+                udb,
+                dead_url="https://en.wikipedia.org/wiki/Foo)'s",
+                candidate_url="https://en.wikipedia.org/wiki/Foo",
+            )
+        mod.cleanup(_make_args(db=db_path, apply=True))
+        # Second run finds nothing
+        rc = mod.cleanup(_make_args(db=db_path, apply=True))
+        assert rc == 0
+
+    def test_no_unsafe_rows_clean_exit(self, db_path):
+        with UnifiedDatabase(db_path):
+            pass
+        rc = mod.cleanup(_make_args(db=db_path, apply=True))
+        assert rc == 0
+
+
+class TestBuildParser:
+    def test_defaults(self):
+        args = mod._build_parser().parse_args([])
+        assert args.apply is False
+
+    def test_apply_flag(self):
+        args = mod._build_parser().parse_args(["--apply"])
+        assert args.apply is True
+
+
+class TestMain:
+    def test_main_dry_run_empty_db(self, db_path):
+        rc = mod.main(["--db", db_path])
+        assert rc == 0

--- a/tools/cleanup_unsafe_candidates.py
+++ b/tools/cleanup_unsafe_candidates.py
@@ -1,0 +1,129 @@
+"""One-time DB cleanup: mark legacy unsafe derived_candidate rows (#275).
+
+PR #274 added a safety filter in ``derive_replacement_prs._is_safely_replaceable``
+to skip candidates whose ``str.replace(dead, candidate)`` would corrupt the
+surrounding markdown (extractor caught trailing junk into the URL). #274 also
+fixed ``bulk_scan.inventory._clean_url_tail`` so future scans don't produce
+these rows. But existing rows from prior runs remain in the DB as
+``investigation_state='derived_candidate'`` and clutter every tool A summary
+with ``(repo, all_candidates_unsafe)`` skip lines.
+
+This script marks those legacy rows ``investigation_state='dropped_unsafe_url'``
+so tool A's query (``WHERE investigation_state='derived_candidate'``) stops
+picking them up. Idempotent — re-running is a no-op.
+
+Usage::
+
+    poetry run python tools/cleanup_unsafe_candidates.py            # dry-run
+    poetry run python tools/cleanup_unsafe_candidates.py --apply    # mutate DB
+    poetry run python tools/cleanup_unsafe_candidates.py --db PATH  # alternate DB
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+
+from gh_link_auditor.unified_db import DEFAULT_DB_PATH, UnifiedDatabase  # noqa: E402
+from tools.derive_replacement_prs import _is_safely_replaceable  # noqa: E402
+
+DROPPED_STATE = "dropped_unsafe_url"
+
+
+def _load_unsafe_rows(udb: UnifiedDatabase) -> list[dict]:
+    """Find every derived_candidate row that fails the safety filter."""
+    rows = udb._conn.execute(
+        """SELECT id, repo_full_name, dead_url, candidate_url, source_file, line_number, method
+           FROM bulk_scan_findings
+           WHERE investigation_state = 'derived_candidate' AND surfaced = 0
+           ORDER BY repo_full_name, id"""
+    ).fetchall()
+    unsafe: list[dict] = []
+    for r in rows:
+        ok, reason = _is_safely_replaceable(r["dead_url"], r["candidate_url"])
+        if not ok:
+            row = dict(r)
+            row["reason"] = reason
+            unsafe.append(row)
+    return unsafe
+
+
+def _mark_dropped(udb: UnifiedDatabase, ids: list[int]) -> None:
+    """Set investigation_state='dropped_unsafe_url' for the given row ids."""
+    if not ids:
+        return
+    placeholders = ",".join(["?"] * len(ids))
+    udb._conn.execute(
+        f"UPDATE bulk_scan_findings SET investigation_state = ? WHERE id IN ({placeholders})",  # noqa: S608
+        [DROPPED_STATE, *ids],
+    )
+    udb._conn.commit()
+
+
+def _print_preview(unsafe: list[dict]) -> None:
+    by_reason: dict[str, int] = {}
+    by_repo: dict[str, int] = {}
+    for r in unsafe:
+        by_reason[r["reason"]] = by_reason.get(r["reason"], 0) + 1
+        by_repo[r["repo_full_name"]] = by_repo.get(r["repo_full_name"], 0) + 1
+
+    print(f"unsafe rows: {len(unsafe)} across {len(by_repo)} repos")
+    print()
+    print("by reason:")
+    for reason, n in sorted(by_reason.items(), key=lambda x: -x[1]):
+        print(f"  {reason}: {n}")
+    print()
+    print("rows (first 20):")
+    for r in unsafe[:20]:
+        loc = r["source_file"]
+        if r.get("line_number"):
+            loc = f"{loc}:{r['line_number']}"
+        print(f"  [{r['id']:>5}] {r['repo_full_name']}  {loc}  ({r['reason']})")
+        print(f"          dead: {r['dead_url']}")
+        print(f"          cand: {r['candidate_url']}")
+    if len(unsafe) > 20:
+        print(f"  ... and {len(unsafe) - 20} more")
+
+
+def cleanup(args: argparse.Namespace) -> int:
+    with UnifiedDatabase(args.db) as udb:
+        unsafe = _load_unsafe_rows(udb)
+
+        if not unsafe:
+            print("no unsafe rows found. nothing to do.")
+            return 0
+
+        _print_preview(unsafe)
+
+        if not args.apply:
+            print()
+            print("[dry-run] no changes made. re-run with --apply to mutate the DB.")
+            return 0
+
+        ids = [r["id"] for r in unsafe]
+        _mark_dropped(udb, ids)
+        print()
+        print(f"marked {len(ids)} rows as investigation_state='{DROPPED_STATE}'.")
+
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Mark legacy unsafe derived_candidate rows (#275).")
+    p.add_argument("--db", default=str(DEFAULT_DB_PATH), help="path to ghla.db")
+    p.add_argument("--apply", action="store_true", help="mutate the DB (default is dry-run)")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    return cleanup(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR #274 added a runtime safety filter that catches corruption-injection candidates (dead_url ``URL)'s`` with candidate ``URL`` — the str.replace would delete `)'s` from the README). #274 also fixed ``_clean_url_tail`` so future bulk-scan runs don't produce these rows.

But **21 legacy rows across 14 repos** already existed in ``bulk_scan_findings`` from prior runs. They cluttered every tool A summary with ``(repo, all_candidates_unsafe)`` skip lines and confused the operator after a successful submission ("did I do something wrong?").

## What this ships

``tools/cleanup_unsafe_candidates.py`` — one-time maintenance script that:

1. Iterates ``derived_candidate`` rows with ``surfaced=0``
2. Applies the same ``_is_safely_replaceable`` filter from tool A (import + reuse, no duplication)
3. Marks failing rows as ``investigation_state='dropped_unsafe_url'``
4. Default mode is ``--dry-run`` (prints affected rows by id, repo, location, reason); ``--apply`` mutates
5. Idempotent — re-running ``--apply`` is a no-op

## Live impact

Already run against `~/.ghla/ghla.db` post-merge of #274:

```
unsafe rows: 21 across 14 repos
by reason:
  unbalanced_paren: 21
[examples] AmenRa/retriv  README.md:70    Okapi_BM25)'s
           AnubisLMS/Anubis  ...:11        Remote_procedure_call)is
           GSA/https  pages/certificates.md:110  Certificate_Transparency)**
           ... (12 more)
```

After ``--apply``: tool A's dry-run reports **zero ``all_candidates_unsafe`` skips**.

## Tests

| Class | Tests | Covers |
|---|---:|---|
| ``TestLoadUnsafeRows`` | 5 | Finds unbalanced-paren, finds markdown-suffix, ignores safe candidates, skips surfaced=1, skips non-derived state |
| ``TestMarkDropped`` | 2 | Update applies, empty list is no-op |
| ``TestCleanup`` | 4 | Dry-run no mutate, apply mutates, idempotent, empty-DB clean exit |
| ``TestBuildParser`` / ``TestMain`` | 3 | CLI surface |
| **Total** | **14** | |

Full suite: **2,235 passed, 1 skipped**.

## Closes

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)