### PR TITLE
feat(preflight): LLD + prereq extensions for Phase B (#282, #315, #316)

### DIFF
--- a/docs/lld/active/LLD-281.md
+++ b/docs/lld/active/LLD-281.md
@@ -1,0 +1,226 @@
+# LLD-281: Phase B preflight feature
+
+**Issue:** #281 (umbrella; 33 sub-issues #282–#314)
+**Status:** Approved
+**Date:** 2026-05-24
+
+## Overview
+
+`tools/preflight_check.py` runs 10 hard gates + a 100-point scored evaluation on every candidate before `tools/derive_replacement_prs.py` calls `n6_submit_pr`. No fork, no push, no PR until preflight passes. The defense becomes the system rather than operator vigilance (which caught the 2026-05-23 AndreaVidali corruption-injection near-miss only because the operator personally read the proposed change).
+
+Phase A (#278 / PR #279) protected the public surface. Phase B protects the upstream maintainer from us.
+
+## Architecture
+
+```
+[derive_replacement_prs.derive_and_submit]
+        |
+        v (safe_rows after _is_safely_replaceable filter, line 323-332)
+        |
+[run_preflight(candidate, db, threshold)]
+        |
+        +---> 10 hard gates (any fail -> drop, log, continue)
+        +---> 12 scored components (sum >= threshold or skip)
+        +---> markdown + JSON report to data/preflight-reports/
+        |
+        v (PreflightVerdict.PASS only)
+        |
+[n6_submit_pr] -- fork + commit + PR
+```
+
+`run_preflight` returns a `PreflightReport` with `verdict` (one of `PASS / HARD_GATE_FAILED / NEEDS_OPERATOR_REVIEW / SCORE_TOO_LOW`), `score`, `gate_results`, `score_breakdown`, `evidence`, and timestamps. Tool A's `derive_and_submit` dispatches on `verdict` and only invokes N6 on `PASS`.
+
+## Hard gates (10 — any failure drops the candidate)
+
+Each gate is a callable `gate_<name>(repo, candidate, db, *deps) -> GateResult(passed, reason, evidence)`.
+
+1. **Anti-AI text** (#288) — subagent classifies repo public files + maintainer's profile + last 50 issue/PR comments as `clean | uncertain | hostile`. `hostile` fails; `uncertain` escalates.
+2. **Repo archived/disabled** (#289) — `gh api repos/{owner}/{repo}` `.archived` or `.disabled` true → fail. Requires #316 (`RepoQuality.archived`/`disabled`).
+3. **Blacklist** (#290) — `unified_db.is_blacklisted(repo_url, maintainer)`. Plumbing already exists; #290 simply passes `maintainer`. Full maintainer-blacklist auto-population comes from #208 (independent path).
+4. **Dead URL no longer present** (#291) — fetch current upstream file via `GitHubContentsClient`, run `extract_urls_from_text`, confirm `dead_url` is still there.
+5. **Dead URL is now alive** (#292) — fresh `network.check_url(dead_url)` — if 2xx, the URL was resurrected and the PR would be a no-op. 1-hour `url_check_cache` TTL.
+6. **Candidate URL not 2xx** (#293) — fresh `network.check_url(candidate_url)` — if not 2xx, the replacement is itself broken. 1-hour TTL.
+7. **Candidate redirects to unrelated content** (#294) — uses `final_url` (from #315) to fetch the landing page; subagent verdict `clean | partial | unrelated`. `unrelated` fails. Per operator: pure URL redirects landing on the right page are FINE.
+8. **Duplicate PR already open** (#295) — `gh api repos/{owner}/{repo}/pulls --state=open`, scan bodies + diffs for either URL.
+9. **Markdown corruption** (#296) — delegate to existing `tools.derive_replacement_prs._is_safely_replaceable`. The AndreaVidali catcher.
+10. **Stars below floor** (#297) — operator floor: 20. Requires `RepoQuality.stars` (already surfaced).
+
+## Scored components (must total ≥ 90 / 100 to surface)
+
+### Correctness (75 pt)
+
+| ID | Name (issue) | Pts | Notes |
+|---|---|---:|---|
+| C1 | URL verbatim match in current file (#298) | 10 | byte-exact |
+| C2 | Dead URL occurrence count (#299) | 10 | 1 = full; 2+ = 5 + surface |
+| C3 | Dead URL fresh HTTP status (#300) | 10 | 4xx = full; 5xx = 5; same-as-candidate (no-op) = 0 |
+| C4 | Candidate URL fresh HTTP status (#301) | 10 | 200 = full; redirect→2xx = 8 (uses `final_url` from #315) |
+| C5 | Content equivalence fuzzy (#302) | 15 | subagent: `clean=15` / `partial=8` / `unrelated=0` |
+| C6 | Replace simulation produces valid markdown (#303) | 10 | commonmark parse OR balanced-bracket heuristic |
+| C7 | Surrounding context preserved (#304) | 10 | `difflib` char-diff: only URL changed |
+
+### Receptivity (25 pt)
+
+| ID | Name (issue) | Pts | Notes |
+|---|---|---:|---|
+| R1 | Stars tiered (#305) | 5 | ≥1000=5, ≥500=4, ≥100=3, ≥50=2, ≥20=1, <20=0 |
+| R2 | Recency tiered (#306) | 5 | ≤7d=5, ≤30d=4, ≤90d=3, ≤180d=1, else 0 |
+| R3 | Outsider PR merge rate (#307) | 5 | last 10 closed, author != owner; 7-day cache |
+| R4 | Maintainer structure (#308) | 5 | multi-committer OR CODEOWNERS OR org = 5; solo = 2 |
+| R5 | License permissive (#309) | 5 | MIT / Apache-2.0 / BSD-* / MPL-2.0 / ISC = 5; non-permissive = 2; none = 0 |
+
+## Subagent invocation (gates 1, 7; score C5)
+
+The universal `C:\Users\mcwiz\Projects\CLAUDE.md` mandates:
+
+> **NEVER use `@anthropic-ai/sdk` or ask for API keys.** Use `claude --print` with `CLAUDECODE=""` env for all LLM calls. User has Max subscription.
+
+Implementation in `src/gh_link_auditor/preflight/subagent.py`:
+
+```python
+class RealSubagent:
+    def run(self, prompt_path: Path, context: dict) -> SubagentVerdict:
+        prompt = prompt_path.read_text(encoding="utf-8") + "\n\n" + json.dumps(context)
+        env = {**os.environ, "CLAUDECODE": ""}
+        try:
+            result = subprocess.run(
+                ["claude", "--print", prompt],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return SubagentVerdict.UNCERTAIN
+        if result.returncode != 0:
+            return SubagentVerdict.UNCERTAIN
+        return _parse_verdict_token(result.stdout.strip())
+```
+
+Subagent prompts are in `prompts/preflight/{ai_scan,content_equiv,redirect_target}.txt`. Each prompt explicitly requests a single-token response (`clean | uncertain | hostile` or `clean | partial | unrelated`); responses outside that grammar are treated as `UNCERTAIN`.
+
+**Fallback when `claude` is unavailable** (CI without LLM access, cron-driven tool A run): fall back to `hostile_classifier.ANTI_AI_PHRASES` keyword pre-scan. Hits → `UNCERTAIN` (operator escalation; no auto-pass). Clean → score as if subagent said `CLEAN` (safer side).
+
+Test surface: `tests/fakes/subagent.py:FakeSubagent` (typed, recordable, no MagicMock) for unit tests. Integration test under `@pytest.mark.live` invokes `RealSubagent` against the real `claude` CLI.
+
+## Caching (4 new tables; schema v8 → v9)
+
+| Cache | TTL | Key |
+|---|---|---|
+| `preflight_pr_stats_cache` | 7 days | `repo_full_name` |
+| `preflight_repo_meta_cache` | 24 hours | `repo_full_name` |
+| `preflight_ai_scan_cache` | until file changes | `(repo, file_path, file_sha)` |
+| `url_check_cache` (existing) | extend | accept `ttl_hours=1` for preflight-time recheck |
+
+Migration: `_migrate_v8_to_v9()` added to `_migrate` chain in `unified_db.py`. 3 new `CREATE TABLE IF NOT EXISTS` statements. The existing `url_check_cache` gets `ttl_hours` parameter on the read/write API; default stays 24 for backward compatibility.
+
+## Tool A integration
+
+`tools/derive_replacement_prs.derive_and_submit` (line 323–332):
+
+```python
+from tools.preflight_check import run_preflight, PreflightVerdict
+
+# After safe_rows filter, before _build_state + n6_submit_pr:
+for candidate in safe_rows:
+    report = run_preflight(repo_full_name, candidate, db=udb, threshold=args.preflight_threshold)
+    _save_report(report, args.preflight_log_dir)
+
+    if report.verdict == PreflightVerdict.HARD_GATE_FAILED:
+        skipped.append((repo_full_name, f"preflight_gate_{report.gate_failure_name}"))
+        continue
+    if report.verdict == PreflightVerdict.NEEDS_OPERATOR_REVIEW:
+        skipped.append((repo_full_name, "preflight_needs_review"))
+        continue
+    if report.score < args.preflight_threshold:
+        skipped.append((repo_full_name, f"preflight_score_{report.score}"))
+        continue
+
+    n6_fn(_build_state(repo_full_name, [candidate]))
+```
+
+New CLI flags on `derive_replacement_prs.py`:
+
+- `--preflight-threshold N` (default 90)
+- `--preflight-log-dir PATH` (default `data/preflight-reports/`)
+- `--preflight-report-only` — run preflight on every candidate, write reports, exit 0 without N6
+- `--skip-preflight` — BAD ESCAPE; injects a banner warning into every report
+
+## Reports
+
+Per candidate, two files at `data/preflight-reports/{run_id}-{YYYYMMDD-HHMMSS}-{owner}_{repo}.{md,json}`. Markdown includes hard-gate PASS/FAIL with evidence, score breakdown, operator-clickable links (dead URL, candidate URL, source line `#L14`, maintainer profile, recent PRs), proposed file change before/after, verdict + threshold. JSON is the same data, every dataclass field serialized.
+
+`data/preflight-reports/` is gitignored with a `.gitkeep` so the directory exists.
+
+A `NEEDS_OPERATOR_REVIEW` verdict prepends a prominent banner to the top of the markdown — operator sees it before any other content. Tool A's printed summary groups these skips separately from `preflight_gate_*` / `preflight_score_*` skips.
+
+## Testing strategy (per project rule: NO MagicMock)
+
+Four test categories:
+
+1. **Pure-function unit tests** (`tests/unit/tools/test_preflight_check.py` + per-gate / per-score files under `tests/unit/preflight/`). Each gate + score: pass case + fail case + edge cases. Uses `tests/fakes/` patterns (FakeGitHubClient, FakeGitHubContentsClient, FakeHTTPResponse, FakeSubagent). No MagicMock.
+
+2. **Recorded-fixture integration tests** (#310, `tests/integration/test_preflight_fixtures.py`). 6 scenarios under `tests/fixtures/preflight/{passing-andreavidali, archived-repo, anti-ai-repo, dead-url-resurrected, low-stars, duplicate-pr}/` with synthetic-or-recorded GitHub + HTTP responses. Asserts correct verdict for each scenario.
+
+3. **Live integration test** (#311, `tests/integration/test_preflight_live.py`). `@pytest.mark.live`, opt-in via `pytest --live`. Real GitHub API + real `claude --print`. Asserts AndreaVidali candidate scores ≥ 90.
+
+4. **Subagent-prompt golden-file regression** (#312, `tests/integration/test_preflight_prompts.py`). Each prompt rendered with a `FakeSubagent` recorder; rendered text compared to `tests/golden/preflight/{ai_scan,content_equiv,redirect_target}_rendered.txt`. `pytest --update-goldens` flag to regenerate when prompts intentionally change.
+
+Coverage gate: ≥95% line coverage on `tools/preflight_check.py` and `src/gh_link_auditor/preflight/*`.
+
+## New files (across the full Phase B implementation)
+
+- `tools/preflight_check.py`
+- `src/gh_link_auditor/preflight/__init__.py`
+- `src/gh_link_auditor/preflight/subagent.py`
+- `src/gh_link_auditor/preflight/report.py`
+- `src/gh_link_auditor/preflight/gates.py`
+- `src/gh_link_auditor/preflight/scores.py`
+- `tests/fakes/subagent.py`
+- `tests/unit/tools/test_preflight_check.py`
+- `tests/unit/preflight/test_gates.py`
+- `tests/unit/preflight/test_scores.py`
+- `tests/integration/test_preflight_fixtures.py`
+- `tests/integration/test_preflight_live.py`
+- `tests/integration/test_preflight_prompts.py`
+- `tests/golden/preflight/{ai_scan,content_equiv,redirect_target}_rendered.txt`
+- `tests/fixtures/preflight/<6 scenarios>/...`
+- `prompts/preflight/{ai_scan,content_equiv,redirect_target}.txt`
+- `data/preflight-reports/.gitkeep`
+
+## Modified files
+
+- `src/gh_link_auditor/network.py` — `RequestResult.final_url` (#315; this PR-α)
+- `src/gh_link_auditor/repo_quality.py` — `RepoQuality.{archived,disabled,license}` (#316; this PR-α)
+- `src/gh_link_auditor/unified_db.py` — 4 cache tables + v8→v9 migration (#285)
+- `tools/derive_replacement_prs.py` — preflight gate insertion + 4 CLI flags (#284)
+- `.gitignore` — `data/preflight-reports/`
+
+## Acceptance criteria
+
+Per #281:
+
+- All 33 sub-issues + 2 prereq issues (#315, #316) merged
+- `tools/preflight_check.py` exists with full CLI surface
+- 10 hard gates wired with pass/fail unit tests
+- 12 score components wired with full/partial/zero unit tests
+- Subagent uses real `claude --print` in integration tests
+- 4 cache tables created via `unified_db` migration; respects TTL
+- Tool A flags wired; preflight blocks N6 unless verdict allows
+- Reports written to `data/preflight-reports/` (markdown + JSON, gitignored)
+- ≥95% line coverage on new preflight code
+- Full pytest suite green; ruff format + check clean
+- No MagicMock anywhere
+- End-to-end verification (#314) against 87 candidates; operator reviews top-3 + bottom-3
+- Operator files PR #1 via `--auto-approve --max-prs 1 --campaign-allowed`; confirms PR matches preflight report
+
+## Test Plan (for this PR-α)
+
+This LLD + the two extensions (`network.RequestResult.final_url` and `RepoQuality.{archived,disabled,license}`) ship as PR-α. Subsequent PRs implement the preflight tool itself.
+
+New tests in this PR:
+
+- `tests/unit/test_network.py::TestCheckUrlFinalUrl` — final URL populated on direct 2xx; final URL populated on redirect; final URL is None on connection failure
+- `tests/unit/test_repo_quality.py::TestFetchRepoMetadataExtended` — archived field surfaced; disabled field surfaced; license SPDX surfaced; missing license returns None; backward compat (existing tests still pass)
+- `tests/fakes/http.py::FakeURLResponse` — extended to accept `url` parameter

--- a/docs/reports/active/10282-implementation-report.md
+++ b/docs/reports/active/10282-implementation-report.md
@@ -1,0 +1,75 @@
+# 10282 - Implementation Report
+
+**Issues:** #282 (LLD), #315 (network final_url), #316 (RepoQuality fields)
+**Branch:** `282-lld-and-prereq-extensions`
+**Worktree:** `gh-link-auditor-282`
+**Umbrella:** #281 (Phase B preflight)
+
+## Summary
+
+PR-α of the Phase B preflight execution plan. Ships:
+
+1. The design doc (LLD-281) capturing the full Phase B feature in the repo's public LLD surface — including the `claude --print` subagent invocation pattern (the universal-CLAUDE-md-mandated alternative to the Claude Code session-only Agent tool).
+2. Two small source extensions that subsequent gate / score implementations depend on:
+   - `network.RequestResult.final_url` for redirect-aware preflight (gate #7 / #294 + score C4 / #301).
+   - `RepoQuality.{archived, disabled, license}` for archived/disabled gating (gate #2 / #289) and license scoring (R5 / #309).
+
+No new behavior is exposed; the extensions are passive — they only add a key / fields that nothing reads yet.
+
+## Files
+
+### New
+- `docs/lld/active/LLD-281.md` — full Phase B design doc; mirrors the LLD-036 format
+
+### Modified
+- `src/gh_link_auditor/network.py`
+  - `RequestResult` TypedDict gets `final_url: NotRequired[str | None]` (kept `NotRequired` so existing call sites that build `RequestResult` dicts without this key remain valid)
+  - `_make_request` returns a 5-tuple now (added `final_url`); pulls `response.url` (or `exc.url`) when a response was received, `None` on connection-level failures
+  - `check_url` propagates `final_url` into all 3 `RequestResult` constructions (success / permanent failure / retry-exhausted)
+  - `_headless_browser_get` populates `final_url` from `page.url` after navigation; defensive `getattr(page, "url", None)` so the existing test fakes that don't expose `url` keep working
+- `src/gh_link_auditor/repo_quality.py`
+  - `RepoQuality` dataclass gets `archived: bool = False`, `disabled: bool = False`, `license: str | None = None`
+  - `fetch_repo_metadata` jq query extended to surface `.archived`, `.disabled`, `.license.spdx_id`
+- `tests/fakes/http.py`
+  - `FakeURLResponse` accepts a `url` parameter (default `None`) and exposes it as the `.url` attribute — matches the urllib response API
+- `tests/unit/test_network.py`
+  - 3 `TestMakeRequestEdgeCases` tests updated to unpack the new 5-tuple
+  - `TestCheckUrlFullFlow::test_check_url_default_configs` keyset assertion extended with `final_url`
+  - NEW `TestCheckUrlFinalUrl` class: 5 tests covering direct 2xx, redirect target, fallback to requested URL, DNS failure (None), HTTPError carrying url
+- `tests/unit/test_repo_quality.py`
+  - `TestFetchRepoMetadata::test_fetches_stars_and_pushed_at` updated to include the new jq fields (backward-compat sanity)
+  - NEW `TestFetchRepoMetadataExtended` class: 5 tests covering archived / disabled / license SPDX / missing license / missing-keys defaults
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `git grep -i -E '(A\+\+\|PRs filed\|contribution graph\|green square\|naked ambition)'` | 0 hits (Phase A still clean) |
+| `poetry run pytest -q` | 2247 passed, 1 skipped (was 2237 before; +10 from new tests) |
+| `poetry run ruff format --check .` | 234 files already formatted |
+| `poetry run ruff check .` | All checks passed |
+| `LLD-281.md` exists | Yes; references all 33 sub-issues + 2 prereqs |
+| `final_url` populated in `check_url` success path | Yes (covered by `test_final_url_matches_requested_when_no_redirect`) |
+| `final_url` reflects redirect target | Yes (covered by `test_final_url_reflects_redirect_target`) |
+| `RepoQuality.archived` / `.disabled` / `.license` populated | Yes (covered by `TestFetchRepoMetadataExtended`) |
+
+## Out of scope (deferred to subsequent PRs)
+
+- Actual preflight tool (`tools/preflight_check.py`) — PR-β scaffolds it
+- Cache tables — PR-β
+- Subagent infrastructure — PR-β
+- Tool A integration — PR-γ
+- Hard gates — PR-δ / ε
+- Score components — PR-η / θ
+- Recorded-fixture + live tests — PR-ι
+- E2E verification of 87 candidates — #314, deferred for operator review
+
+## Operator decisions reflected in LLD
+
+- Stars floor: 20
+- Threshold: 90/100
+- Subagent mode: `claude --print` with `CLAUDECODE=""` (per universal CLAUDE.md mandate; supersedes the issue body's "Agent tool" wording, which is Claude-Code-session-only)
+- Outsider PR merge rate: 7-day cache
+- Live URL re-verification: PRIOR TO FORK, mandatory
+- Multi-occurrence dead URL: flag + surface (don't refuse)
+- Real testing: NO MagicMock, `tests/fakes/` patterns

--- a/docs/reports/active/10282-test-report.md
+++ b/docs/reports/active/10282-test-report.md
@@ -1,0 +1,77 @@
+# 10282 - Test Report
+
+**Issues:** #282, #315, #316
+**Branch:** `282-lld-and-prereq-extensions`
+
+## Test count
+
+| Stage | Count |
+|---|---|
+| Before this PR | 2237 passed, 1 skipped |
+| After this PR | 2247 passed, 1 skipped |
+| Net | +10 new tests |
+
+## New tests
+
+### `tests/unit/test_network.py::TestCheckUrlFinalUrl` (5 tests, #315)
+
+1. `test_final_url_matches_requested_when_no_redirect` — direct 2xx returns `final_url == requested URL`
+2. `test_final_url_reflects_redirect_target` — when `response.url` differs from requested URL, `final_url` carries the destination
+3. `test_final_url_falls_back_to_requested_when_response_lacks_url` — fake response with `url=None` falls back to the requested URL
+4. `test_final_url_none_on_dns_failure` — DNS failure → `final_url is None`
+5. `test_final_url_populated_on_http_error` — HTTPError carries `exc.url`, so `final_url` populates even on 4xx
+
+### `tests/unit/test_repo_quality.py::TestFetchRepoMetadataExtended` (5 tests, #316)
+
+1. `test_archived_repo_surfaces_true` — `archived: true` in jq output → `quality.archived is True`
+2. `test_disabled_repo_surfaces_true` — `disabled: true` + `license: null` → `quality.disabled is True`, `quality.license is None`
+3. `test_license_spdx_is_captured` — `Apache-2.0` SPDX id captured
+4. `test_missing_license_returns_none` — explicit `license: null` returns None
+5. `test_default_archived_disabled_when_keys_missing` — older jq output omitting new keys defaults to `False` / `None` (backward compat)
+
+## Modified existing tests
+
+### `tests/unit/test_network.py`
+
+1. `TestMakeRequestEdgeCases::test_socket_timeout_direct` — 4-tuple unpack → 5-tuple; assert `final_url is None`
+2. `TestMakeRequestEdgeCases::test_broken_pipe` — same
+3. `TestMakeRequestEdgeCases::test_unexpected_exception` — same
+4. `TestCheckUrlFullFlow::test_check_url_default_configs` — `expected_keys` set now includes `"final_url"`
+
+### `tests/unit/test_repo_quality.py`
+
+1. `TestFetchRepoMetadata::test_fetches_stars_and_pushed_at` — jq mock JSON updated to include the new `archived`/`disabled`/`license` fields (forward-compatible with the new query); existing assertions on `stars` / `pushed_at` / `contributors` unchanged
+
+## Modified test fakes
+
+`tests/fakes/http.py`:
+
+- `FakeURLResponse.__init__` now accepts an optional `url: str | None = None` kwarg
+- Exposes `self.url` so tests can simulate redirect-resolved URLs without MagicMock
+
+## No regressions
+
+`poetry run pytest -q` reports **2247 passed, 1 skipped** (was 2237 passed, 1 skipped before this PR). The single skipped test pre-dates this work (live/integration marker). No tests were silenced, deleted, or `xfail`'d.
+
+## Lint
+
+| Check | Result |
+|---|---|
+| `poetry run ruff format --check .` | 234 files already formatted (1 file auto-fixed in `tests/unit/test_repo_quality.py` during this PR; verified clean after) |
+| `poetry run ruff check .` | All checks passed |
+
+## Coverage on new production code
+
+| Symbol | Tests covering it |
+|---|---|
+| `network.RequestResult.final_url` field | All `TestCheckUrlFinalUrl` tests + the keyset assertion in `test_check_url_default_configs` |
+| `network._make_request` 5-tuple return | `TestMakeRequestEdgeCases` (error paths) + every `TestCheckUrl*` test (success paths via `check_url`) |
+| `network._headless_browser_get` `final_url` population | Existing `TestHeadlessBrowserGet` tests now exercise the defensive `getattr(page, "url", None)` path implicitly |
+| `RepoQuality.{archived, disabled, license}` fields | `TestFetchRepoMetadataExtended` (5 tests) + `test_fetches_stars_and_pushed_at` (passthrough sanity) |
+| `repo_quality.fetch_repo_metadata` extended jq + assignment | Same |
+
+All new lines are exercised; project hard rule ≥95% met.
+
+## Phase A regression check
+
+`git grep -i -E '(A\+\+|PRs filed|contribution graph|green square|naked ambition)'` on tracked files in the worktree returns **0 hits**. Phase A scrub remains clean.

--- a/src/gh_link_auditor/network.py
+++ b/src/gh_link_auditor/network.py
@@ -18,7 +18,7 @@ import time
 import urllib.error
 import urllib.request
 from email.utils import parsedate_to_datetime
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 from urllib.parse import urlparse
 
 # ---------------------------------------------------------------------------
@@ -53,6 +53,10 @@ class RequestResult(TypedDict):
     response_time_ms: int | None  # Response time in milliseconds
     retries: int  # Number of retries attempted
     error: str | None  # Error description if not ok
+    # Final URL after any redirect chain (#315 — used by preflight gate #7 / score C4).
+    # Optional via NotRequired so pre-#315 call sites that build RequestResult dicts
+    # without this key remain valid TypedDict constructions.
+    final_url: NotRequired[str | None]
 
 
 # ---------------------------------------------------------------------------
@@ -260,7 +264,7 @@ def _make_request(
     url: str,
     method: str,
     config: RequestConfig,
-) -> tuple[int | None, str | None, int | None, str | None]:
+) -> tuple[int | None, str | None, int | None, str | None, str | None]:
     """Make a single HTTP request (internal helper).
 
     Args:
@@ -269,13 +273,15 @@ def _make_request(
         config: Request configuration.
 
     Returns:
-        Tuple of ``(status_code, error_type, response_time_ms, retry_after_header)``.
+        Tuple of ``(status_code, error_type, response_time_ms, retry_after_header, final_url)``.
 
         - ``status_code``: HTTP status code, or ``None`` on connection-level errors.
         - ``error_type``: One of ``"timeout"``, ``"dns_failure"``,
           ``"connection_reset"``, ``"invalid"``, or ``None`` on success/HTTP error.
         - ``response_time_ms``: Wall-clock response time in milliseconds, or ``None``.
         - ``retry_after_header``: Raw ``Retry-After`` header value, or ``None``.
+        - ``final_url``: Final URL after any redirects (#315). ``None`` on
+          connection-level errors that produced no response.
     """
     ctx = _create_ssl_context(config["verify_ssl"])
     headers = {"User-Agent": config["user_agent"]}
@@ -286,29 +292,31 @@ def _make_request(
         with urllib.request.urlopen(req, timeout=config["timeout"], context=ctx) as response:
             elapsed_ms = int((time.monotonic() - start) * 1000)
             retry_after = response.headers.get("Retry-After")
-            return response.status, None, elapsed_ms, retry_after
+            final_url = getattr(response, "url", None) or url
+            return response.status, None, elapsed_ms, retry_after, final_url
     except urllib.error.HTTPError as exc:
         elapsed_ms = int((time.monotonic() - start) * 1000)
         retry_after = exc.headers.get("Retry-After") if exc.headers else None
-        return exc.code, None, elapsed_ms, retry_after
+        final_url = getattr(exc, "url", None) or url
+        return exc.code, None, elapsed_ms, retry_after, final_url
     except urllib.error.URLError as exc:
         elapsed_ms = int((time.monotonic() - start) * 1000)
         reason_str = str(exc.reason)
         if "timed out" in reason_str or isinstance(exc.reason, socket.timeout):
-            return None, "timeout", elapsed_ms, None
+            return None, "timeout", elapsed_ms, None, None
         # DNS / name resolution failures
         if isinstance(exc.reason, OSError):
-            return None, "dns_failure", elapsed_ms, None
-        return None, "dns_failure", elapsed_ms, None
+            return None, "dns_failure", elapsed_ms, None, None
+        return None, "dns_failure", elapsed_ms, None, None
     except socket.timeout:
         elapsed_ms = int((time.monotonic() - start) * 1000)
-        return None, "timeout", elapsed_ms, None
+        return None, "timeout", elapsed_ms, None, None
     except (http.client.RemoteDisconnected, ConnectionResetError, BrokenPipeError):
         elapsed_ms = int((time.monotonic() - start) * 1000)
-        return None, "connection_reset", elapsed_ms, None
+        return None, "connection_reset", elapsed_ms, None, None
     except Exception:
         elapsed_ms = int((time.monotonic() - start) * 1000)
-        return None, "invalid", elapsed_ms, None
+        return None, "invalid", elapsed_ms, None, None
 
 
 # ---------------------------------------------------------------------------
@@ -452,8 +460,10 @@ def _headless_browser_get(url: str, timeout_s: float = 20.0) -> RequestResult:
             response_time_ms=0,
             retries=0,
             error=f"playwright unavailable: {exc}",
+            final_url=None,
         )
 
+    final_landing_url: str | None = None
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch(channel="chrome", headless=True)
@@ -468,6 +478,9 @@ def _headless_browser_get(url: str, timeout_s: float = 20.0) -> RequestResult:
                 )
                 final_status = response.status if response is not None else None
                 final_title = (page.title() or "").lower()
+                # Capture the final URL after any client-side / HTTP redirects (#315).
+                # getattr-with-default keeps test fakes that don't expose `url` working.
+                final_landing_url = getattr(page, "url", None) or url
             finally:
                 browser.close()
     except Exception as exc:  # noqa: BLE001 — third-party error surface is wide
@@ -480,6 +493,7 @@ def _headless_browser_get(url: str, timeout_s: float = 20.0) -> RequestResult:
             response_time_ms=elapsed_ms,
             retries=0,
             error=f"headless probe failed: {exc}",
+            final_url=final_landing_url,
         )
 
     elapsed_ms = int((time.monotonic() - start) * 1000)
@@ -493,6 +507,7 @@ def _headless_browser_get(url: str, timeout_s: float = 20.0) -> RequestResult:
             response_time_ms=elapsed_ms,
             retries=0,
             error="still on JS challenge page after networkidle",
+            final_url=final_landing_url,
         )
 
     return RequestResult(
@@ -503,6 +518,7 @@ def _headless_browser_get(url: str, timeout_s: float = 20.0) -> RequestResult:
         response_time_ms=elapsed_ms,
         retries=0,
         error=None,
+        final_url=final_landing_url,
     )
 
 
@@ -547,7 +563,7 @@ def check_url(
 
     # Use a while loop (per reviewer suggestion) for cleaner retry/fallback logic.
     while True:
-        status_code, error_type, response_time_ms, retry_after_header = _make_request(
+        status_code, error_type, response_time_ms, retry_after_header, final_url = _make_request(
             url,
             method,
             request_config,
@@ -563,6 +579,7 @@ def check_url(
                 response_time_ms=response_time_ms,
                 retries=retries,
                 error=None,
+                final_url=final_url,
             )
 
         retry_ok, try_get = should_retry(status_code, error_type)
@@ -618,6 +635,7 @@ def check_url(
                 response_time_ms=response_time_ms,
                 retries=retries,
                 error=_build_error_message(status_code, error_type),
+                final_url=final_url,
             )
 
         # Retryable — check if we have retries left
@@ -637,4 +655,5 @@ def check_url(
             response_time_ms=response_time_ms,
             retries=retries,
             error=_build_error_message(status_code, error_type),
+            final_url=final_url,
         )

--- a/src/gh_link_auditor/repo_quality.py
+++ b/src/gh_link_auditor/repo_quality.py
@@ -25,6 +25,11 @@ class RepoQuality:
     contributors: int = 0
     contributing_text: str = ""
     warnings: list[str] | None = None
+    # Preflight-required fields (#316): used by hard gate #2 (archived/disabled),
+    # hard gate #10 (stars floor — already surfaced above), and score R5 (license).
+    archived: bool = False
+    disabled: bool = False
+    license: str | None = None
 
     def __post_init__(self) -> None:
         if self.warnings is None:
@@ -39,7 +44,8 @@ def fetch_repo_metadata(owner: str, repo: str) -> RepoQuality:
         repo: Repository name.
 
     Returns:
-        RepoQuality with stars, pushed_at, and contributor count.
+        RepoQuality with stars, pushed_at, contributor count, archived/disabled
+        flags, and SPDX license id (#316).
     """
     quality = RepoQuality()
 
@@ -51,7 +57,11 @@ def fetch_repo_metadata(owner: str, repo: str) -> RepoQuality:
                 "api",
                 f"repos/{owner}/{repo}",
                 "--jq",
-                "{stars: .stargazers_count, pushed_at: .pushed_at}",
+                (
+                    "{stars: .stargazers_count, pushed_at: .pushed_at, "
+                    "archived: .archived, disabled: .disabled, "
+                    "license: (.license.spdx_id // null)}"
+                ),
             ],
             capture_output=True,
             text=True,
@@ -64,6 +74,10 @@ def fetch_repo_metadata(owner: str, repo: str) -> RepoQuality:
             data = json.loads(result.stdout)
             quality.stars = data.get("stars", 0)
             quality.pushed_at = data.get("pushed_at", "")
+            quality.archived = bool(data.get("archived", False))
+            quality.disabled = bool(data.get("disabled", False))
+            license_value = data.get("license")
+            quality.license = license_value if isinstance(license_value, str) else None
     except (FileNotFoundError, subprocess.TimeoutExpired):
         logger.warning("Failed to fetch repo metadata for %s/%s", owner, repo)
 

--- a/tests/fakes/http.py
+++ b/tests/fakes/http.py
@@ -47,10 +47,14 @@ class FakeURLResponse:
         data: bytes,
         status: int = 200,
         headers: dict[str, str] | None = None,
+        url: str | None = None,
     ) -> None:
         self._data = data
         self.status = status
         self.headers = headers or {}
+        # Final URL after any redirects — matches urllib.request.urlopen()
+        # response.url. Used by preflight gate #7 + score C4 (#315).
+        self.url = url
 
     def read(self) -> bytes:
         """Return response body as bytes."""

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -1209,7 +1209,7 @@ class TestMakeRequestEdgeCases:
             "gh_link_auditor.network.urllib.request.urlopen",
             side_effect=socket.timeout("timed out"),
         ):
-            status_code, error_type, response_time_ms, retry_after = _make_request(
+            status_code, error_type, response_time_ms, retry_after, final_url = _make_request(
                 "https://example.com",
                 "HEAD",
                 config,
@@ -1218,6 +1218,7 @@ class TestMakeRequestEdgeCases:
         assert status_code is None
         assert error_type == "timeout"
         assert response_time_ms is not None
+        assert final_url is None  # No response → no final URL (#315)
 
     def test_broken_pipe(self):
         """BrokenPipeError is classified as connection_reset."""
@@ -1226,7 +1227,7 @@ class TestMakeRequestEdgeCases:
             "gh_link_auditor.network.urllib.request.urlopen",
             side_effect=BrokenPipeError("Broken pipe"),
         ):
-            status_code, error_type, response_time_ms, retry_after = _make_request(
+            status_code, error_type, response_time_ms, retry_after, final_url = _make_request(
                 "https://example.com",
                 "HEAD",
                 config,
@@ -1234,6 +1235,7 @@ class TestMakeRequestEdgeCases:
 
         assert status_code is None
         assert error_type == "connection_reset"
+        assert final_url is None  # Connection reset → no final URL (#315)
 
     def test_unexpected_exception(self):
         """Unexpected exception returns 'invalid' error type."""
@@ -1242,7 +1244,7 @@ class TestMakeRequestEdgeCases:
             "gh_link_auditor.network.urllib.request.urlopen",
             side_effect=RuntimeError("Something unexpected"),
         ):
-            status_code, error_type, response_time_ms, retry_after = _make_request(
+            status_code, error_type, response_time_ms, retry_after, final_url = _make_request(
                 "https://example.com",
                 "HEAD",
                 config,
@@ -1250,6 +1252,7 @@ class TestMakeRequestEdgeCases:
 
         assert status_code is None
         assert error_type == "invalid"
+        assert final_url is None  # Unexpected exception → no final URL (#315)
 
 
 # ---------------------------------------------------------------------------
@@ -1333,6 +1336,82 @@ class TestCheckUrlFullFlow:
 
         assert result["status"] == "ok"
         assert isinstance(result, dict)
-        # Verify all required keys are present
-        expected_keys = {"url", "status", "status_code", "method", "response_time_ms", "retries", "error"}
+        # Verify all required keys are present, including final_url (#315)
+        expected_keys = {
+            "url",
+            "status",
+            "status_code",
+            "method",
+            "response_time_ms",
+            "retries",
+            "error",
+            "final_url",
+        }
         assert set(result.keys()) == expected_keys
+
+
+# ---------------------------------------------------------------------------
+# #315: final_url exposure for preflight gate #7 / score C4
+# ---------------------------------------------------------------------------
+
+
+class TestCheckUrlFinalUrl:
+    """#315: ``RequestResult.final_url`` is populated by ``check_url``."""
+
+    def test_final_url_matches_requested_when_no_redirect(self, no_retry_backoff_config):
+        """Direct 2xx with no redirect → final_url == requested url."""
+        resp = FakeURLResponse(data=b"", status=200, url="https://example.com")
+        with mock.patch("gh_link_auditor.network.urllib.request.urlopen", return_value=resp):
+            result = check_url("https://example.com", backoff_config=no_retry_backoff_config)
+
+        assert result["status"] == "ok"
+        assert result["final_url"] == "https://example.com"
+
+    def test_final_url_reflects_redirect_target(self, no_retry_backoff_config):
+        """When response.url differs from the requested URL, final_url is the destination."""
+        resp = FakeURLResponse(data=b"", status=200, url="https://example.com/canonical/")
+        with mock.patch("gh_link_auditor.network.urllib.request.urlopen", return_value=resp):
+            result = check_url("https://example.com/old-path", backoff_config=no_retry_backoff_config)
+
+        assert result["status"] == "ok"
+        assert result["url"] == "https://example.com/old-path"
+        assert result["final_url"] == "https://example.com/canonical/"
+
+    def test_final_url_falls_back_to_requested_when_response_lacks_url(self, no_retry_backoff_config):
+        """A response object without ``url`` attribute falls back to the requested URL."""
+        # FakeURLResponse with url=None should yield final_url == requested URL.
+        resp = FakeURLResponse(data=b"", status=200, url=None)
+        with mock.patch("gh_link_auditor.network.urllib.request.urlopen", return_value=resp):
+            result = check_url("https://example.com", backoff_config=no_retry_backoff_config)
+
+        assert result["final_url"] == "https://example.com"
+
+    def test_final_url_none_on_dns_failure(self, no_retry_backoff_config):
+        """DNS failure produces no response → final_url is None."""
+        with mock.patch(
+            "gh_link_auditor.network.urllib.request.urlopen",
+            side_effect=urllib.error.URLError(socket.gaierror("name resolution failed")),
+        ):
+            result = check_url("https://nonexistent.invalid", backoff_config=no_retry_backoff_config)
+
+        assert result["status"] == "failed"
+        assert result["final_url"] is None
+
+    def test_final_url_populated_on_http_error(self, no_retry_backoff_config):
+        """HTTPError carries a url too — final_url should reflect where the error came from."""
+        http_error = urllib.error.HTTPError(
+            "https://example.com/missing",
+            404,
+            "Not Found",
+            {},
+            None,
+        )
+        with mock.patch(
+            "gh_link_auditor.network.urllib.request.urlopen",
+            side_effect=http_error,
+        ):
+            result = check_url("https://example.com/missing", backoff_config=no_retry_backoff_config)
+
+        assert result["status"] == "error"
+        assert result["status_code"] == 404
+        assert result["final_url"] == "https://example.com/missing"

--- a/tests/unit/test_repo_quality.py
+++ b/tests/unit/test_repo_quality.py
@@ -27,7 +27,13 @@ class TestFetchRepoMetadata:
     """Tests for fetch_repo_metadata()."""
 
     def test_fetches_stars_and_pushed_at(self) -> None:
-        repo_data = _MockCompleted('{"stars": 15000, "pushed_at": "2026-03-01T12:00:00Z"}')
+        # #316: jq now also surfaces archived / disabled / license. The legacy
+        # stars + pushed_at fields still populate the same way; pre-existing
+        # keys are unchanged.
+        repo_data = _MockCompleted(
+            '{"stars": 15000, "pushed_at": "2026-03-01T12:00:00Z", '
+            '"archived": false, "disabled": false, "license": "BSD-3-Clause"}'
+        )
         contrib_data = _MockCompleted("30")
 
         with patch("subprocess.run", side_effect=[repo_data, contrib_data]):
@@ -51,6 +57,71 @@ class TestFetchRepoMetadata:
             quality = fetch_repo_metadata("org", "repo")
 
         assert quality.stars == 0
+
+
+class TestFetchRepoMetadataExtended:
+    """#316: archived / disabled / license fields surfaced by the extended jq query."""
+
+    def test_archived_repo_surfaces_true(self) -> None:
+        repo_data = _MockCompleted(
+            '{"stars": 100, "pushed_at": "2024-01-01T00:00:00Z", "archived": true, "disabled": false, "license": "MIT"}'
+        )
+        contrib_data = _MockCompleted("3")
+
+        with patch("subprocess.run", side_effect=[repo_data, contrib_data]):
+            quality = fetch_repo_metadata("org", "repo")
+
+        assert quality.archived is True
+        assert quality.disabled is False
+
+    def test_disabled_repo_surfaces_true(self) -> None:
+        repo_data = _MockCompleted(
+            '{"stars": 5, "pushed_at": "2024-01-01T00:00:00Z", "archived": false, "disabled": true, "license": null}'
+        )
+        contrib_data = _MockCompleted("1")
+
+        with patch("subprocess.run", side_effect=[repo_data, contrib_data]):
+            quality = fetch_repo_metadata("org", "repo")
+
+        assert quality.disabled is True
+        assert quality.archived is False
+        assert quality.license is None
+
+    def test_license_spdx_is_captured(self) -> None:
+        repo_data = _MockCompleted(
+            '{"stars": 200, "pushed_at": "2026-04-01T00:00:00Z", '
+            '"archived": false, "disabled": false, "license": "Apache-2.0"}'
+        )
+        contrib_data = _MockCompleted("10")
+
+        with patch("subprocess.run", side_effect=[repo_data, contrib_data]):
+            quality = fetch_repo_metadata("org", "repo")
+
+        assert quality.license == "Apache-2.0"
+
+    def test_missing_license_returns_none(self) -> None:
+        repo_data = _MockCompleted(
+            '{"stars": 3, "pushed_at": "2026-01-01T00:00:00Z", "archived": false, "disabled": false, "license": null}'
+        )
+        contrib_data = _MockCompleted("1")
+
+        with patch("subprocess.run", side_effect=[repo_data, contrib_data]):
+            quality = fetch_repo_metadata("org", "repo")
+
+        assert quality.license is None
+
+    def test_default_archived_disabled_when_keys_missing(self) -> None:
+        # Backward compat: if older jq output (or a partial response) omits the
+        # new fields, defaults are False / None — never raises.
+        repo_data = _MockCompleted('{"stars": 50, "pushed_at": "2025-12-01T00:00:00Z"}')
+        contrib_data = _MockCompleted("5")
+
+        with patch("subprocess.run", side_effect=[repo_data, contrib_data]):
+            quality = fetch_repo_metadata("org", "repo")
+
+        assert quality.archived is False
+        assert quality.disabled is False
+        assert quality.license is None
 
 
 class TestFetchContributingGuidelines:


### PR DESCRIPTION
## Summary

PR-α of the Phase B preflight execution plan. Ships:

1. **LLD-281** capturing the full Phase B feature design — 10 hard gates, 12 score components, the `claude --print` subagent pattern (replacing the issue body's "Agent tool" wording per universal CLAUDE.md mandate), caching strategy, tool A integration, 4-category testing strategy.
2. **`network.RequestResult.final_url`** — needed by gate #7 (#294) + score C4 (#301) to know where redirects land.
3. **`RepoQuality.{archived, disabled, license}`** — needed by gate #2 (#289), gate #10 (#297; stars already surfaced), and score R5 (#309).

No new runtime behavior; the extensions are passive (add keys / fields that nothing reads yet).

## Files

| File | Change |
|---|---|
| `docs/lld/active/LLD-281.md` | NEW — full Phase B LLD |
| `src/gh_link_auditor/network.py` | `RequestResult.final_url` (`NotRequired`); `_make_request` 5-tuple return; `check_url` + `_headless_browser_get` propagate `final_url` |
| `src/gh_link_auditor/repo_quality.py` | `RepoQuality` gains `archived` / `disabled` / `license`; `fetch_repo_metadata` jq extended |
| `tests/fakes/http.py` | `FakeURLResponse` accepts + exposes `url` |
| `tests/unit/test_network.py` | +5 `TestCheckUrlFinalUrl` tests; 4 existing tests updated for 5-tuple / new key |
| `tests/unit/test_repo_quality.py` | +5 `TestFetchRepoMetadataExtended` tests; 1 existing test updated for new jq fields |
| `docs/reports/active/10282-implementation-report.md` | NEW |
| `docs/reports/active/10282-test-report.md` | NEW |

## Test plan

- [x] `poetry run pytest -q` → **2247 passed**, 1 skipped (was 2237; +10 from new tests)
- [x] `poetry run ruff format --check .` → 234 files already formatted
- [x] `poetry run ruff check .` → all checks passed
- [x] `git grep -i -E '(A\+\+|PRs filed|contribution graph|green square|naked ambition)'` → 0 hits (Phase A still clean)
- [x] `final_url` populated in success / redirect / HTTPError paths; `None` on connection failure
- [x] `RepoQuality.{archived, disabled, license}` populate from jq; default safely when keys missing
- [x] Tests use `tests/fakes/` patterns; no MagicMock

## Scope

This PR is intentionally narrow — the LLD and two passive extensions. PR-β onward (#283 / #285 / #286 / #287, then #284, then the gates / scores / tests / ops) builds on top.

Closes #282
Closes #315
Closes #316
