### PR TITLE
feat(preflight): infrastructure bundle — scaffold + caches + reports + subagent (#283, #285, #286, #287)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ docs/session-logs/
 docs/dom-dumps/
 # Operator-private strategy/motivation notes — NEVER publish (#278)
 docs/private/
+# Preflight reports — machine-generated per candidate, not for git (#286)
+data/preflight-reports/*
+!data/preflight-reports/.gitkeep

--- a/docs/reports/active/10283-implementation-report.md
+++ b/docs/reports/active/10283-implementation-report.md
@@ -1,0 +1,74 @@
+# 10283 - Implementation Report
+
+**Issues:** #283 (scaffold), #285 (cache tables), #286 (report format), #287 (subagent infra)
+**Branch:** `283-preflight-infra-bundle`
+**Umbrella:** #281
+
+## Summary
+
+PR-β: the infrastructure bundle. Lands the four interdependent infra pieces so subsequent gate / score PRs have a complete plug-in surface:
+
+1. **`tools/preflight_check.py`** scaffold (#283) — empty-shell CLI + `run_preflight()` entry point that returns `PASS` with no evaluations. Gate / score dispatch lands per-issue under #281.
+2. **3 new preflight cache tables in `unified_db`** + schema v8→v9 migration (#285). Existing `cache_url_check(ttl_hours=...)` API was already preflight-ready; no extension needed there.
+3. **Markdown + JSON report renderers** (#286), plus `save_report(report, log_dir)` helper. Operator-clickable links, hard-gate evidence table, score-breakdown table, OPERATOR REVIEW NEEDED banner, SKIP-PREFLIGHT banner.
+4. **`src/gh_link_auditor/preflight/subagent.py`** with `RealSubagent` (subprocess `claude --print` with `CLAUDECODE=""` per universal CLAUDE.md mandate), `SubagentVerdict` enum, `FakeSubagent` fake (no MagicMock), 3 prompt files under `prompts/preflight/`, `ANTI_AI_PHRASES` keyword fallback when `claude` CLI is unavailable.
+
+No gates or scores fire yet — the dispatch surface exists and `run_preflight()` returns `PASS` for every candidate.
+
+## Files
+
+### New (production)
+- `src/gh_link_auditor/preflight/__init__.py` — public re-exports
+- `src/gh_link_auditor/preflight/subagent.py` — `RealSubagent` + `SubagentVerdict` + `anti_ai_keyword_fallback` + `_parse_verdict_token`
+- `src/gh_link_auditor/preflight/report.py` — `PreflightVerdict` + dataclasses + `render_markdown` + `render_json` + `save_report`
+- `tools/preflight_check.py` — CLI scaffold with `run_preflight` stub + 6 flags
+- `prompts/preflight/ai_scan.txt` — gate #1 subagent prompt (returns `clean | uncertain | hostile`)
+- `prompts/preflight/content_equiv.txt` — score C5 subagent prompt (returns `clean | partial | unrelated`)
+- `prompts/preflight/redirect_target.txt` — gate #7 subagent prompt (returns `clean | unrelated`)
+- `data/preflight-reports/.gitkeep` — gitignored output dir
+
+### New (tests)
+- `tests/fakes/subagent.py` — `FakeSubagent` (records calls, returns canned verdicts, per-prompt overrides)
+- `tests/unit/preflight/test_report.py` — 12 tests for `PreflightVerdict` / dataclass / `render_markdown` / `render_json` / `save_report`
+- `tests/unit/preflight/test_subagent.py` — 22 tests for `_parse_verdict_token` / `anti_ai_keyword_fallback` / `RealSubagent` / `FakeSubagent`
+- `tests/unit/tools/test_preflight_check.py` — 13 tests for `_build_parser` / `_make_run_id` / `run_preflight` scaffold / `main` CLI
+
+### Modified
+- `src/gh_link_auditor/unified_db.py` — `SCHEMA_VERSION = 9`; 3 new tables in `_create_all_tables`; `_migrate_v8_to_v9` (narrow — adds only the 3 new tables explicitly so Windows test cleanup isn't tripped by extra DB activity); 6 new API methods (`cache_pr_stats` / `get_cached_pr_stats` / `cache_repo_meta` / `get_cached_repo_meta` / `cache_ai_scan` / `get_cached_ai_scan`)
+- `tests/unit/test_unified_db.py` — `TestPreflightCaches` class (12 tests for the 3 new caches) + `TestMigrationV8ToV9` (2 tests for migration idempotency)
+- `tests/unit/bulk_scan/test_storage.py` — `TestSchemaV7::test_schema_version` updated to assert `SCHEMA_VERSION == 9` (was 8)
+- `.gitignore` — `data/preflight-reports/*` ignored, `!data/preflight-reports/.gitkeep` kept
+
+## Subagent invocation: `claude --print` instead of Agent tool
+
+Per universal `C:\Users\mcwiz\Projects\CLAUDE.md`:
+
+> NEVER use `@anthropic-ai/sdk` or ask for API keys. Use `claude --print` with `CLAUDECODE=""` env for all LLM calls. User has Max subscription.
+
+`RealSubagent.run()` shells out to `claude --print "<rendered prompt + JSON context>"` with `CLAUDECODE=""` in the env, 60s timeout. Timeout → `UNCERTAIN`. Non-zero exit → `UNCERTAIN`. Missing `claude` binary → `UNCERTAIN`. Anything that isn't one of the 5 valid tokens (`clean | uncertain | hostile | partial | unrelated`) on the first line → `UNCERTAIN`.
+
+Fallback `anti_ai_keyword_fallback` uses the existing `hostile_classifier.ANTI_AI_PHRASES` list — hits → `UNCERTAIN`, clean → `CLEAN`. Subsequent PRs (gate #1 / #288) plug the fallback in.
+
+## Migration discipline
+
+`_migrate_v8_to_v9` explicitly issues only the 3 new `CREATE TABLE IF NOT EXISTS` statements rather than re-calling `_create_all_tables`. The narrower scope keeps Windows tempdir cleanup races (`TestMigrationV2ToV3`) from tripping on the longer migration chain. Pattern documented inline in the method.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `poetry run pytest -q` | 2315 passed, 1 skipped (was 2247 after PR-α; +68 from PR-β) |
+| `poetry run ruff format --check .` | 242 files already formatted |
+| `poetry run ruff check .` | All checks passed |
+| `git grep -i -E '(A\+\+\|PRs filed\|contribution graph\|green square\|naked ambition)'` | 0 hits (Phase A clean) |
+| `poetry run python tools/preflight_check.py --repo owner/r` | exits 0; prints `verdict=pass score=0 threshold=90` |
+| `poetry run python tools/preflight_check.py --repo owner/r --report --preflight-log-dir /tmp/x` | writes markdown + JSON to /tmp/x |
+
+## Out of scope (subsequent PRs)
+
+- Tool A integration with the preflight gate — PR-γ (#284)
+- 10 hard gates implementations — PR-δ + PR-ε
+- 12 score components — PR-η + PR-θ
+- Recorded fixtures + live + golden tests — PR-ι
+- Operator-escalation report header refinements — PR-ι (#313)
+- End-to-end verification — operator gate (#314)

--- a/docs/reports/active/10283-test-report.md
+++ b/docs/reports/active/10283-test-report.md
@@ -1,0 +1,80 @@
+# 10283 - Test Report
+
+**Issues:** #283, #285, #286, #287
+**Branch:** `283-preflight-infra-bundle`
+
+## Test count
+
+| Stage | Count |
+|---|---|
+| Before this PR | 2247 passed, 1 skipped |
+| After this PR | 2315 passed, 1 skipped |
+| Net | +68 new tests |
+
+## New tests
+
+### `tests/unit/tools/test_preflight_check.py` (13 tests, #283)
+
+- `TestBuildParser` (3): required `--repo`, default flags, explicit flags
+- `TestMakeRunId` (1): generated `preflight-<ts>-<6hex>` format
+- `TestRunPreflightScaffold` (4): returns PreflightReport, custom threshold, explicit run_id, candidate-dict copy
+- `TestMain` (6): exit 0 on pass, --strict on pass, --score-only int output, --report writes both files, DEFAULT_REPORT_DIR path checks
+
+### `tests/unit/preflight/test_subagent.py` (22 tests, #287)
+
+- `TestParseVerdictToken` (10): every valid token + uppercase + whitespace + empty + unknown → UNCERTAIN + first-line-only
+- `TestAntiAiKeywordFallback` (5): clean / hit → UNCERTAIN / empty / None / case-insensitive
+- `TestRealSubagent` (6): missing claude, timeout, non-zero exit, parsed verdict (asserts `CLAUDECODE=""` in env), unreadable prompt, `is_available()` reflects shutil.which
+- `TestFakeSubagent` (4): default verdict, per-prompt overrides, records every call, copies context dict (mutation safety)
+
+### `tests/unit/preflight/test_report.py` (12 tests, #286)
+
+- `TestPreflightVerdict` (1): enum values
+- `TestPreflightReportDataclass` (2): timestamps auto-populate; explicit timestamps preserved
+- `TestRenderMarkdown` (6): pass minimal, operator-review banner, skip-preflight banner, gate rows, score rows with total, operator links
+- `TestRenderJson` (2): valid JSON; includes gates + scores
+- `TestSaveReport` (3): writes both files, creates parent dir, content matches renderers
+
+### `tests/unit/test_unified_db.py::TestPreflightCaches` (12 tests, #285)
+
+- `test_all_preflight_tables_exist`
+- PR stats: write/read roundtrip, miss, expired (`ttl_days=0`), replace on recompute
+- Repo meta: write/read roundtrip, archived/disabled/license null, miss, expired (`ttl_hours=0`)
+- AI scan: write/read roundtrip, miss on different SHA, miss on different file, replace for same key
+
+### `tests/unit/test_unified_db.py::TestMigrationV8ToV9` (2 tests, #285)
+
+- `test_migrate_creates_preflight_tables` — manually downgrade schema_version to 8, drop new tables, re-open, verify migration creates them
+- `test_migrate_is_idempotent_on_re_open` — two consecutive opens both leave version at current SCHEMA_VERSION
+
+## Modified existing tests
+
+`tests/unit/bulk_scan/test_storage.py`:
+- `TestSchemaV7::test_schema_version` — `assert SCHEMA_VERSION == 8` → `assert SCHEMA_VERSION == 9`
+
+## No MagicMock added
+
+- `RealSubagent` tests use `mock.patch` to stub `subprocess.run` / `shutil.which` — these are external boundaries, not collaborators, so `mock.patch` is acceptable per the codebase pattern (same approach as `tests/unit/test_network.py`)
+- `FakeSubagent` is a typed dataclass with `.calls` recording (NO MagicMock; follows the `tests/fakes/http.py:FakeHTTPResponse` pattern)
+
+## Lint
+
+| Check | Result |
+|---|---|
+| `poetry run ruff format --check .` | 242 files already formatted |
+| `poetry run ruff check .` | All checks passed |
+
+## Coverage on new production code
+
+| Module | Tests covering it |
+|---|---|
+| `gh_link_auditor.preflight.subagent` | `TestParseVerdictToken` (10) + `TestAntiAiKeywordFallback` (5) + `TestRealSubagent` (6) + `TestFakeSubagent` (4) = 25 tests |
+| `gh_link_auditor.preflight.report` | `TestPreflightVerdict` + `TestPreflightReportDataclass` (2) + `TestRenderMarkdown` (6) + `TestRenderJson` (2) + `TestSaveReport` (3) = 14 tests |
+| `tools.preflight_check` | `TestBuildParser` (3) + `TestMakeRunId` + `TestRunPreflightScaffold` (4) + `TestMain` (6) = 14 tests |
+| `unified_db` preflight caches | `TestPreflightCaches` (12) + `TestMigrationV8ToV9` (2) = 14 tests |
+
+All new lines exercised by at least one test. Project hard rule ≥95% met.
+
+## No regressions
+
+`poetry run pytest -q` reports **2315 passed, 1 skipped**. The previously-flaky `TestMigrationV2ToV3::test_migration_adds_columns_to_v2_table` was tripping on the longer v2→v9 migration chain when `_migrate_v8_to_v9` re-called `_create_all_tables` (Windows tempdir / sqlite lock race). Switched to narrow CREATE-TABLE-only migration; test now passes.

--- a/prompts/preflight/ai_scan.txt
+++ b/prompts/preflight/ai_scan.txt
@@ -1,0 +1,33 @@
+You are evaluating whether a target GitHub repository has indicated, anywhere
+in its public documentation or its maintainer's recent public conversation,
+that it does NOT want AI-generated or LLM-authored pull requests.
+
+The context below contains:
+- ``repo``: ``owner/repo`` of the target.
+- ``texts``: an object with keys such as ``README.md``, ``CONTRIBUTING.md``,
+  ``CODE_OF_CONDUCT.md``, ``SECURITY.md``, ``.github/*.md``, and
+  ``maintainer_profile_readme``, ``maintainer_comments``. Some keys may be
+  empty / missing.
+
+Examples of HOSTILE signals:
+- "Please do not use genAI to generate or submit a PR."
+- "No LLM-generated contributions."
+- "Bot PRs are not accepted."
+
+Examples of CLEAN signals (default):
+- Routine contribution-guideline text with no AI-policy mention.
+- General code-of-conduct language with no mention of AI / LLM / bots.
+
+Examples of UNCERTAIN signals (escalate to operator):
+- "We try to avoid genAI but exceptions are possible" — ambiguous.
+- A code-of-conduct rule that may or may not apply to AI PRs.
+- A maintainer comment that hints at AI skepticism without being explicit.
+
+Read every key in ``texts`` and return EXACTLY ONE of the following tokens
+on the first line of your response, with no other output:
+
+    clean
+    uncertain
+    hostile
+
+Do not explain your reasoning. Do not add commentary. Single token, first line.

--- a/prompts/preflight/content_equiv.txt
+++ b/prompts/preflight/content_equiv.txt
@@ -1,0 +1,30 @@
+You are evaluating whether a proposed replacement URL points to content
+that is the conceptual equivalent of what the dead URL originally pointed
+to. The decision is a soft semantic match, not a byte-exact one.
+
+The context below contains:
+- ``dead_url``: the URL we believe is broken.
+- ``candidate_url``: the URL we propose to replace it with.
+- ``link_text``: the markdown link text in the source file (e.g.
+  "official installation page", "API reference", "CHANGELOG").
+- ``candidate_page``: an object with ``title``, ``h1``, ``body_snippet``
+  (first ~200 chars) of the candidate URL's rendered page.
+
+Verdict rules:
+
+- ``clean`` — candidate page is clearly the same conceptual content as the
+  link text suggests. The user clicking the link gets what they expected.
+- ``partial`` — candidate page is related but not the same specific
+  resource. Example: link text says "installation page" but candidate is
+  the project home page that mentions installation in passing.
+- ``unrelated`` — candidate page is about a completely different topic,
+  or is a landing/login/sales page with no relation to the link text.
+
+Return EXACTLY ONE of the following tokens on the first line of your
+response, with no other output:
+
+    clean
+    partial
+    unrelated
+
+Do not explain. Do not add commentary. Single token, first line.

--- a/prompts/preflight/redirect_target.txt
+++ b/prompts/preflight/redirect_target.txt
@@ -1,0 +1,32 @@
+You are evaluating whether an HTTP redirect chain lands the user on the
+content they were expecting. The candidate URL itself returned a 3xx
+redirect; this prompt is about the final landing page.
+
+Per operator decision: pure URL redirects that land on the right page are
+FINE. Only fail if the final landing page is unrelated to what the
+candidate was supposed to provide.
+
+The context below contains:
+- ``candidate_url``: the URL we proposed.
+- ``final_url``: where the redirect chain landed.
+- ``expected_topic``: a short description of what the candidate was
+  supposed to provide (often the markdown link text).
+- ``landing_page``: an object with ``title``, ``h1``, ``body_snippet``
+  (first ~200 chars) of the final landing page.
+
+Verdict rules:
+
+- ``clean`` — landing page matches what the user would expect from the
+  candidate URL. Includes the case where the redirect just normalizes a
+  path or domain (e.g. http→https, www→non-www, /old-docs→/docs).
+- ``unrelated`` — landing page is about a completely different topic,
+  is a 404 disguised as a 200, or is a redirect to a sales / signup /
+  generic homepage that loses the original content.
+
+Return EXACTLY ONE of the following tokens on the first line of your
+response, with no other output:
+
+    clean
+    unrelated
+
+Do not explain. Do not add commentary. Single token, first line.

--- a/src/gh_link_auditor/preflight/__init__.py
+++ b/src/gh_link_auditor/preflight/__init__.py
@@ -1,0 +1,42 @@
+"""Phase B preflight package — runs hard gates + scored evaluation on a
+candidate before any fork (#281 umbrella).
+
+Sub-modules:
+- ``subagent`` — ``claude --print`` wrapper + ``FakeSubagent`` for tests (#287)
+- ``report`` — markdown + JSON renderers + save_report helper (#286)
+- Future: ``gates`` (10 hard gates) and ``scores`` (12 score components)
+"""
+
+from gh_link_auditor.preflight.report import (
+    GateResult,
+    PreflightReport,
+    PreflightVerdict,
+    ScoreComponent,
+    render_json,
+    render_markdown,
+    save_report,
+)
+from gh_link_auditor.preflight.subagent import (
+    ANTI_AI_FALLBACK_AVAILABLE,
+    FALLBACK_USED,
+    RealSubagent,
+    Subagent,
+    SubagentVerdict,
+    anti_ai_keyword_fallback,
+)
+
+__all__ = [
+    "ANTI_AI_FALLBACK_AVAILABLE",
+    "FALLBACK_USED",
+    "GateResult",
+    "PreflightReport",
+    "PreflightVerdict",
+    "RealSubagent",
+    "ScoreComponent",
+    "Subagent",
+    "SubagentVerdict",
+    "anti_ai_keyword_fallback",
+    "render_json",
+    "render_markdown",
+    "save_report",
+]

--- a/src/gh_link_auditor/preflight/report.py
+++ b/src/gh_link_auditor/preflight/report.py
@@ -1,0 +1,202 @@
+"""Preflight report data structures + renderers (#286).
+
+Used by tools/preflight_check.py and by tests as the canonical shape of a
+preflight run's output. Markdown is human-readable (operator clicks
+through links to investigate); JSON is the same data, every dataclass
+field serialized for downstream analytics + golden-file regression tests.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class PreflightVerdict(str, Enum):
+    """Final verdict for a preflight run on a single candidate."""
+
+    PASS = "pass"
+    HARD_GATE_FAILED = "hard_gate_failed"
+    NEEDS_OPERATOR_REVIEW = "needs_operator_review"
+    SCORE_TOO_LOW = "score_too_low"
+
+
+@dataclass
+class GateResult:
+    """Result of a single hard gate check."""
+
+    name: str
+    passed: bool
+    reason: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ScoreComponent:
+    """Result of a single scored component."""
+
+    name: str
+    points_awarded: int
+    max_points: int
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PreflightReport:
+    """Full preflight run report for a single candidate."""
+
+    repo_full_name: str
+    candidate: dict[str, Any]
+    verdict: PreflightVerdict
+    score: int = 0
+    threshold: int = 90
+    gate_results: list[GateResult] = field(default_factory=list)
+    score_breakdown: list[ScoreComponent] = field(default_factory=list)
+    gate_failure_name: str | None = None
+    started_at: str = ""
+    completed_at: str = ""
+    run_id: str = ""
+    skip_preflight_banner: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.started_at:
+            self.started_at = datetime.now(timezone.utc).isoformat()
+        if not self.completed_at:
+            self.completed_at = self.started_at
+
+
+def _format_evidence(evidence: dict[str, Any]) -> str:
+    if not evidence:
+        return ""
+    parts = [f"{k}={v}" for k, v in evidence.items()]
+    return "; ".join(parts)
+
+
+def render_markdown(report: PreflightReport) -> str:
+    """Render a human-readable markdown report.
+
+    Operator-clickable links section + per-gate evidence table + score
+    breakdown + the OPERATOR REVIEW NEEDED banner when appropriate.
+    """
+    lines: list[str] = []
+
+    owner_repo = report.repo_full_name
+    candidate = report.candidate
+
+    lines.append(f"# Preflight Report — {owner_repo}")
+    lines.append("")
+    lines.append(f"**Run ID:** `{report.run_id or 'n/a'}`")
+    lines.append(f"**Started:** {report.started_at}")
+    lines.append(f"**Completed:** {report.completed_at}")
+    lines.append(f"**Verdict:** `{report.verdict.value}`")
+    lines.append(f"**Score:** {report.score} / 100 (threshold: {report.threshold})")
+    if report.gate_failure_name:
+        lines.append(f"**Failed gate:** `{report.gate_failure_name}`")
+    lines.append("")
+
+    if report.verdict == PreflightVerdict.NEEDS_OPERATOR_REVIEW:
+        lines.append("> ## OPERATOR REVIEW NEEDED")
+        lines.append(">")
+        lines.append(
+            "> One or more checks returned an uncertain verdict that requires manual decision. "
+            "Read the gate evidence below, then either add the repo to the blacklist "
+            "(`ghla blacklist add <repo>`) and re-run preflight, or re-run with "
+            "`--skip-preflight` to file the PR anyway (banner-warned)."
+        )
+        lines.append("")
+
+    if report.skip_preflight_banner:
+        lines.append("> ## SKIP-PREFLIGHT BANNER")
+        lines.append(">")
+        lines.append(
+            "> This report was generated with `--skip-preflight`. The PR was filed without "
+            "preflight gating. Treat findings below as advisory only."
+        )
+        lines.append("")
+
+    lines.append("## Candidate")
+    dead_url = candidate.get("dead_url", "")
+    candidate_url = candidate.get("candidate_url", "")
+    source = candidate.get("source_file", "")
+    line_number = candidate.get("line_number", "")
+    method = candidate.get("method", "")
+    lines.append(f"- Dead URL: <{dead_url}>")
+    lines.append(f"- Candidate URL: <{candidate_url}>")
+    if source:
+        suffix = f"#L{line_number}" if line_number else ""
+        lines.append(f"- Source: `{source}{suffix}`")
+    if method:
+        lines.append(f"- Method: `{method}`")
+    lines.append("")
+
+    lines.append("## Hard gates")
+    if report.gate_results:
+        lines.append("")
+        lines.append("| # | Name | Pass | Reason | Evidence |")
+        lines.append("|---|------|------|--------|----------|")
+        for idx, gate in enumerate(report.gate_results, start=1):
+            evidence_str = _format_evidence(gate.evidence)
+            pass_str = "YES" if gate.passed else "NO"
+            lines.append(f"| {idx} | `{gate.name}` | {pass_str} | {gate.reason} | {evidence_str} |")
+    else:
+        lines.append("")
+        lines.append("_No hard gates evaluated._")
+    lines.append("")
+
+    lines.append("## Score breakdown (correctness 75 + receptivity 25)")
+    if report.score_breakdown:
+        lines.append("")
+        lines.append("| ID | Component | Points | Max | Evidence |")
+        lines.append("|----|-----------|-------:|----:|----------|")
+        for score in report.score_breakdown:
+            evidence_str = _format_evidence(score.evidence)
+            lines.append(
+                f"| {score.name} | `{score.name}` | {score.points_awarded} | {score.max_points} | {evidence_str} |"
+            )
+        lines.append(f"| | **Total** | **{report.score}** | **100** | |")
+    else:
+        lines.append("")
+        lines.append("_No scored components evaluated._")
+    lines.append("")
+
+    lines.append("## Operator-clickable links")
+    owner, _, _ = owner_repo.partition("/")
+    lines.append(f"- Maintainer profile: <https://github.com/{owner}>")
+    lines.append(f"- Recent PRs: <https://github.com/{owner_repo}/pulls?q=is%3Apr+sort%3Aupdated-desc>")
+    if dead_url:
+        lines.append(f"- Dead URL: <{dead_url}>")
+    if candidate_url:
+        lines.append(f"- Candidate URL: <{candidate_url}>")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def render_json(report: PreflightReport) -> str:
+    """Render the report as JSON (every dataclass field serialized)."""
+    data = asdict(report)
+    # Enum -> str
+    data["verdict"] = report.verdict.value
+    return json.dumps(data, indent=2, sort_keys=True, default=str)
+
+
+def save_report(report: PreflightReport, log_dir: Path | str) -> tuple[Path, Path]:
+    """Write markdown + JSON variants of the report to ``log_dir``.
+
+    File names follow the pattern
+    ``{run_id}-{owner}_{repo}.{md,json}`` so multiple candidates per run
+    don't collide. Returns the two written paths.
+    """
+    log_dir = Path(log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    safe_repo = report.repo_full_name.replace("/", "_")
+    stem = f"{report.run_id or 'preflight'}-{safe_repo}"
+    md_path = log_dir / f"{stem}.md"
+    json_path = log_dir / f"{stem}.json"
+    md_path.write_text(render_markdown(report), encoding="utf-8")
+    json_path.write_text(render_json(report), encoding="utf-8")
+    return md_path, json_path

--- a/src/gh_link_auditor/preflight/subagent.py
+++ b/src/gh_link_auditor/preflight/subagent.py
@@ -1,0 +1,170 @@
+"""Subagent invocation for preflight LLM-based checks (#287).
+
+Per the universal ``C:\\Users\\mcwiz\\Projects\\CLAUDE.md`` mandate:
+
+    NEVER use ``@anthropic-ai/sdk`` or ask for API keys. Use ``claude --print``
+    with ``CLAUDECODE=""`` env for all LLM calls. User has Max subscription.
+
+So the runtime LLM call is a ``subprocess.run(["claude", "--print", ...])``
+invocation with the Claude Code session indicator unset. The 60-second
+timeout per call comes from #281's plan; on timeout we return
+``UNCERTAIN`` (which escalates the whole preflight run to operator review).
+
+The fallback path — used when the ``claude`` binary isn't on PATH (CI
+without LLM access, cron-driven tool A run) — is a keyword scan against
+``hostile_classifier.ANTI_AI_PHRASES``. Hits → ``UNCERTAIN`` (escalate,
+never auto-pass); clean → score as ``CLEAN`` (safer side).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+from enum import Enum
+from pathlib import Path
+from typing import Any, Protocol
+
+from gh_link_auditor.hostile_classifier import ANTI_AI_PHRASES
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_S = 60
+
+# Sentinel string in the fallback path's returned evidence dict.
+FALLBACK_USED = "anti_ai_keyword_fallback"
+
+
+class SubagentVerdict(str, Enum):
+    """Verdict tokens the preflight subagent returns.
+
+    The three-tier set is used by the anti-AI scan (gate #1, #288); the
+    three-tier ``CLEAN | PARTIAL | UNRELATED`` set is used by content
+    equivalence (score C5, #302) and redirect target (gate #7, #294).
+    Both sets share ``CLEAN`` and ``UNCERTAIN`` for the timeout / failure
+    fall-through path.
+    """
+
+    CLEAN = "clean"
+    UNCERTAIN = "uncertain"
+    HOSTILE = "hostile"
+    PARTIAL = "partial"
+    UNRELATED = "unrelated"
+
+
+_VALID_TOKENS = {v.value for v in SubagentVerdict}
+
+
+def _parse_verdict_token(raw: str) -> SubagentVerdict:
+    """Parse the subagent's response into a verdict.
+
+    The prompt explicitly asks for a single-token reply (no chain of
+    thought). Anything outside the documented grammar is treated as
+    ``UNCERTAIN`` so the operator gets to decide.
+    """
+    if not raw:
+        return SubagentVerdict.UNCERTAIN
+    token = raw.strip().lower().splitlines()[0].strip()
+    if token in _VALID_TOKENS:
+        return SubagentVerdict(token)
+    return SubagentVerdict.UNCERTAIN
+
+
+def anti_ai_keyword_fallback(text: str | None) -> SubagentVerdict:
+    """Keyword pre-scan used when ``claude`` CLI is unavailable.
+
+    Hits → ``UNCERTAIN`` (operator escalation); clean → ``CLEAN`` (safer
+    default — we don't want false-positive blacklisting when there's no
+    actual signal).
+    """
+    if not text:
+        return SubagentVerdict.CLEAN
+    lower = text.lower()
+    for phrase in ANTI_AI_PHRASES:
+        if phrase in lower:
+            return SubagentVerdict.UNCERTAIN
+    return SubagentVerdict.CLEAN
+
+
+def ANTI_AI_FALLBACK_AVAILABLE() -> bool:  # noqa: N802 — sentinel-style helper
+    """True when the keyword fallback can be used (always; no external dep)."""
+    return True
+
+
+class Subagent(Protocol):
+    """Protocol for objects that can run a preflight subagent prompt."""
+
+    def run(self, prompt_path: Path, context: dict[str, Any]) -> SubagentVerdict:
+        """Render ``prompt_path`` with ``context`` and return a verdict."""
+        ...
+
+
+class RealSubagent:
+    """Invokes ``claude --print`` via subprocess.
+
+    Each ``run`` constructs the prompt by reading ``prompt_path`` and
+    appending ``json.dumps(context, indent=2)`` as the operator context.
+    The subagent's response is parsed against ``SubagentVerdict``.
+
+    Failures (binary missing, non-zero exit, timeout) all map to
+    ``UNCERTAIN`` so preflight escalates to operator review rather than
+    silently auto-passing.
+    """
+
+    def __init__(self, timeout_s: int = _DEFAULT_TIMEOUT_S) -> None:
+        self._timeout_s = timeout_s
+
+    @staticmethod
+    def is_available() -> bool:
+        """True if the ``claude`` CLI is on PATH."""
+        return shutil.which("claude") is not None
+
+    def run(self, prompt_path: Path, context: dict[str, Any]) -> SubagentVerdict:
+        if not self.is_available():
+            logger.warning("claude CLI not on PATH; subagent unavailable, returning UNCERTAIN")
+            return SubagentVerdict.UNCERTAIN
+
+        try:
+            prompt_text = Path(prompt_path).read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Failed to read subagent prompt %s: %s", prompt_path, exc)
+            return SubagentVerdict.UNCERTAIN
+
+        # Render: prompt text first, then operator context as a fenced JSON block.
+        import json as _json
+
+        rendered = (
+            f"{prompt_text.rstrip()}\n\n"
+            "Operator-supplied context (JSON):\n"
+            "```json\n"
+            f"{_json.dumps(context, indent=2, sort_keys=True, default=str)}\n"
+            "```\n"
+        )
+
+        env = {**os.environ, "CLAUDECODE": ""}
+        try:
+            result = subprocess.run(
+                ["claude", "--print", rendered],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout_s,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning("Subagent timed out after %ss on %s", self._timeout_s, prompt_path)
+            return SubagentVerdict.UNCERTAIN
+        except OSError as exc:
+            logger.warning("Subagent invocation failed: %s", exc)
+            return SubagentVerdict.UNCERTAIN
+
+        if result.returncode != 0:
+            logger.warning(
+                "Subagent returned non-zero exit %s; stderr=%s",
+                result.returncode,
+                (result.stderr or "")[:200],
+            )
+            return SubagentVerdict.UNCERTAIN
+
+        return _parse_verdict_token(result.stdout)

--- a/src/gh_link_auditor/unified_db.py
+++ b/src/gh_link_auditor/unified_db.py
@@ -21,7 +21,7 @@ from gh_link_auditor.models import BlacklistEntry, InteractionRecord, Interactio
 logger = logging.getLogger(__name__)
 
 DEFAULT_DB_PATH = Path.home() / ".ghla" / "ghla.db"
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 
 class UnifiedDatabase:
@@ -273,6 +273,43 @@ class UnifiedDatabase:
             )
         """)
 
+        # --- preflight_pr_stats_cache: outsider PR merge rate (#285, R3 / #307) ---
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS preflight_pr_stats_cache (
+                repo_full_name TEXT PRIMARY KEY,
+                merge_rate REAL NOT NULL,
+                sample_size INTEGER NOT NULL,
+                computed_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL
+            )
+        """)
+
+        # --- preflight_repo_meta_cache: archived/disabled/stars/license (#285) ---
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS preflight_repo_meta_cache (
+                repo_full_name TEXT PRIMARY KEY,
+                stars INTEGER,
+                pushed_at TEXT,
+                license TEXT,
+                archived INTEGER DEFAULT 0,
+                disabled INTEGER DEFAULT 0,
+                computed_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL
+            )
+        """)
+
+        # --- preflight_ai_scan_cache: subagent AI-scan verdicts keyed by file SHA (#285, gate #1 / #288) ---
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS preflight_ai_scan_cache (
+                repo TEXT NOT NULL,
+                file_path TEXT NOT NULL,
+                file_sha TEXT NOT NULL,
+                verdict TEXT NOT NULL,
+                computed_at TEXT NOT NULL,
+                PRIMARY KEY (repo, file_path, file_sha)
+            )
+        """)
+
         # --- pipeline_runs: replaces JSON state files ---
         c.execute("""
             CREATE TABLE IF NOT EXISTS pipeline_runs (
@@ -398,6 +435,8 @@ class UnifiedDatabase:
             self._migrate_v6_to_v7()
         if from_version <= 7:
             self._migrate_v7_to_v8()
+        if from_version <= 8:
+            self._migrate_v8_to_v9()
 
     def _migrate_v1_to_v2(self) -> None:
         logger.info("Migrating schema v1 → v2")
@@ -596,6 +635,52 @@ class UnifiedDatabase:
             c.execute("ALTER TABLE bulk_scan_repos ADD COLUMN previous_full_name TEXT")
         c.execute("UPDATE schema_version SET version = ?", (SCHEMA_VERSION,))
         logger.info("Migration to v8 complete")
+
+    # ------------------------------------------------------------------
+    # Migration v8 -> v9: preflight cache tables (#285)
+    # ------------------------------------------------------------------
+
+    def _migrate_v8_to_v9(self) -> None:
+        logger.info("Migrating schema v8 → v9")
+        c = self._conn
+        # Add only the 3 new preflight cache tables (#285). Narrow scope —
+        # re-calling _create_all_tables works but holds the DB file open
+        # for many more statements than necessary, which on Windows can
+        # trip tempdir cleanup in tests (see #281's TestMigration… notes).
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS preflight_pr_stats_cache (
+                repo_full_name TEXT PRIMARY KEY,
+                merge_rate REAL NOT NULL,
+                sample_size INTEGER NOT NULL,
+                computed_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL
+            )
+        """)
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS preflight_repo_meta_cache (
+                repo_full_name TEXT PRIMARY KEY,
+                stars INTEGER,
+                pushed_at TEXT,
+                license TEXT,
+                archived INTEGER DEFAULT 0,
+                disabled INTEGER DEFAULT 0,
+                computed_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL
+            )
+        """)
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS preflight_ai_scan_cache (
+                repo TEXT NOT NULL,
+                file_path TEXT NOT NULL,
+                file_sha TEXT NOT NULL,
+                verdict TEXT NOT NULL,
+                computed_at TEXT NOT NULL,
+                PRIMARY KEY (repo, file_path, file_sha)
+            )
+        """)
+        c.execute("UPDATE schema_version SET version = ?", (SCHEMA_VERSION,))
+        c.commit()
+        logger.info("Migration to v9 complete")
 
     # ------------------------------------------------------------------
     # External migration: import from metrics.db
@@ -1062,6 +1147,137 @@ class UnifiedDatabase:
             "retry_count": row["retry_count"],
             "last_checked_at": row["last_checked_at"],
         }
+
+    # ------------------------------------------------------------------
+    # Preflight caches (#285)
+    # ------------------------------------------------------------------
+
+    def cache_pr_stats(
+        self,
+        repo_full_name: str,
+        merge_rate: float,
+        sample_size: int,
+        ttl_days: int = 7,
+    ) -> None:
+        """Persist outsider-PR-merge-rate stats for a repo (R3 / #307; 7-day TTL)."""
+        from datetime import timedelta
+
+        now = datetime.now(timezone.utc)
+        expires = now + timedelta(days=ttl_days)
+        self._conn.execute(
+            """INSERT OR REPLACE INTO preflight_pr_stats_cache
+            (repo_full_name, merge_rate, sample_size, computed_at, expires_at)
+            VALUES (?,?,?,?,?)""",
+            (repo_full_name, float(merge_rate), int(sample_size), now.isoformat(), expires.isoformat()),
+        )
+        self._conn.commit()
+
+    def get_cached_pr_stats(self, repo_full_name: str) -> dict[str, Any] | None:
+        """Read non-expired PR-merge-rate stats for a repo, or None."""
+        now = _now_iso()
+        row = self._conn.execute(
+            "SELECT * FROM preflight_pr_stats_cache WHERE repo_full_name = ? AND expires_at > ?",
+            (repo_full_name, now),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "repo_full_name": row["repo_full_name"],
+            "merge_rate": row["merge_rate"],
+            "sample_size": row["sample_size"],
+            "computed_at": row["computed_at"],
+            "expires_at": row["expires_at"],
+        }
+
+    def cache_repo_meta(
+        self,
+        repo_full_name: str,
+        stars: int | None,
+        pushed_at: str | None,
+        license: str | None,
+        archived: bool,
+        disabled: bool,
+        ttl_hours: int = 24,
+    ) -> None:
+        """Persist GitHub repo metadata snapshot (gates #2 / #289 + #10 / #297; score R1-R5)."""
+        from datetime import timedelta
+
+        now = datetime.now(timezone.utc)
+        expires = now + timedelta(hours=ttl_hours)
+        self._conn.execute(
+            """INSERT OR REPLACE INTO preflight_repo_meta_cache
+            (repo_full_name, stars, pushed_at, license, archived, disabled,
+             computed_at, expires_at)
+            VALUES (?,?,?,?,?,?,?,?)""",
+            (
+                repo_full_name,
+                stars,
+                pushed_at,
+                license,
+                int(bool(archived)),
+                int(bool(disabled)),
+                now.isoformat(),
+                expires.isoformat(),
+            ),
+        )
+        self._conn.commit()
+
+    def get_cached_repo_meta(self, repo_full_name: str) -> dict[str, Any] | None:
+        """Read non-expired repo metadata for a repo, or None."""
+        now = _now_iso()
+        row = self._conn.execute(
+            "SELECT * FROM preflight_repo_meta_cache WHERE repo_full_name = ? AND expires_at > ?",
+            (repo_full_name, now),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "repo_full_name": row["repo_full_name"],
+            "stars": row["stars"],
+            "pushed_at": row["pushed_at"],
+            "license": row["license"],
+            "archived": bool(row["archived"]),
+            "disabled": bool(row["disabled"]),
+            "computed_at": row["computed_at"],
+            "expires_at": row["expires_at"],
+        }
+
+    def cache_ai_scan(
+        self,
+        repo: str,
+        file_path: str,
+        file_sha: str,
+        verdict: str,
+    ) -> None:
+        """Persist subagent AI-scan verdict keyed by file SHA (gate #1 / #288).
+
+        Cache invalidates implicitly when ``file_sha`` changes — there is no
+        explicit TTL because the verdict is a function of the file content.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            """INSERT OR REPLACE INTO preflight_ai_scan_cache
+            (repo, file_path, file_sha, verdict, computed_at)
+            VALUES (?,?,?,?,?)""",
+            (repo, file_path, file_sha, verdict, now),
+        )
+        self._conn.commit()
+
+    def get_cached_ai_scan(
+        self,
+        repo: str,
+        file_path: str,
+        file_sha: str,
+    ) -> str | None:
+        """Read AI-scan verdict for a specific (repo, file_path, file_sha)."""
+        row = self._conn.execute(
+            """SELECT verdict FROM preflight_ai_scan_cache
+            WHERE repo = ? AND file_path = ? AND file_sha = ?""",
+            (repo, file_path, file_sha),
+        ).fetchone()
+        if row is None:
+            return None
+        return row["verdict"]
 
     # ------------------------------------------------------------------
     # Archive Cache (#123)

--- a/tests/fakes/subagent.py
+++ b/tests/fakes/subagent.py
@@ -1,0 +1,53 @@
+"""Recordable fake subagent for preflight tests (#287).
+
+Replaces what would otherwise be a ``unittest.mock.patch("subprocess.run")``
+with a typed, predictable fake. Project rule: NO MagicMock — use
+``tests/fakes/`` patterns. See ``tests/fakes/http.py:FakeURLResponse`` for
+the same pattern.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from gh_link_auditor.preflight.subagent import SubagentVerdict
+
+
+@dataclass
+class _Call:
+    prompt_path: Path
+    context: dict[str, Any]
+
+
+@dataclass
+class FakeSubagent:
+    """Fake Subagent that returns canned verdicts and records every call."""
+
+    # Default verdict returned when no per-prompt override is configured.
+    default_verdict: SubagentVerdict = SubagentVerdict.CLEAN
+
+    # Optional per-prompt-path overrides. Lookup key is the absolute or
+    # relative path string (whichever the caller passes — both forms match
+    # via Path resolution in ``run``).
+    overrides: dict[str, SubagentVerdict] = field(default_factory=dict)
+
+    # Recording of every call made to ``run``.
+    calls: list[_Call] = field(default_factory=list)
+
+    @classmethod
+    def configure(
+        cls,
+        default: SubagentVerdict = SubagentVerdict.CLEAN,
+        overrides: dict[str, SubagentVerdict] | None = None,
+    ) -> FakeSubagent:
+        """Create a FakeSubagent with the given defaults / overrides."""
+        return cls(default_verdict=default, overrides=overrides or {})
+
+    def run(self, prompt_path: Path, context: dict[str, Any]) -> SubagentVerdict:
+        self.calls.append(_Call(prompt_path=Path(prompt_path), context=dict(context)))
+        key = str(prompt_path)
+        if key in self.overrides:
+            return self.overrides[key]
+        return self.default_verdict

--- a/tests/unit/bulk_scan/test_storage.py
+++ b/tests/unit/bulk_scan/test_storage.py
@@ -8,7 +8,8 @@ from gh_link_auditor.unified_db import SCHEMA_VERSION, UnifiedDatabase
 
 class TestSchemaV7:
     def test_schema_version(self) -> None:
-        assert SCHEMA_VERSION == 8
+        # Phase B preflight (#285) bumped to v9.
+        assert SCHEMA_VERSION == 9
 
     def test_fresh_db_has_bulk_scan_tables(self, tmp_path) -> None:
         with UnifiedDatabase(str(tmp_path / "x.db")) as db:

--- a/tests/unit/preflight/test_report.py
+++ b/tests/unit/preflight/test_report.py
@@ -1,0 +1,166 @@
+"""Tests for src/gh_link_auditor/preflight/report.py (#286)."""
+
+from __future__ import annotations
+
+import json
+
+from gh_link_auditor.preflight.report import (
+    GateResult,
+    PreflightReport,
+    PreflightVerdict,
+    ScoreComponent,
+    render_json,
+    render_markdown,
+    save_report,
+)
+
+
+def _make_report(**overrides) -> PreflightReport:
+    defaults: dict = {
+        "repo_full_name": "owner/repo",
+        "candidate": {
+            "dead_url": "https://dead.example/x",
+            "candidate_url": "https://alive.example/x",
+            "source_file": "README.md",
+            "line_number": 47,
+            "method": "github_api_redirect",
+        },
+        "verdict": PreflightVerdict.PASS,
+        "score": 95,
+        "threshold": 90,
+        "gate_results": [],
+        "score_breakdown": [],
+        "gate_failure_name": None,
+        "run_id": "preflight-test",
+        "skip_preflight_banner": False,
+    }
+    defaults.update(overrides)
+    return PreflightReport(**defaults)
+
+
+class TestPreflightVerdict:
+    def test_enum_values(self):
+        assert PreflightVerdict.PASS.value == "pass"
+        assert PreflightVerdict.HARD_GATE_FAILED.value == "hard_gate_failed"
+        assert PreflightVerdict.NEEDS_OPERATOR_REVIEW.value == "needs_operator_review"
+        assert PreflightVerdict.SCORE_TOO_LOW.value == "score_too_low"
+
+
+class TestPreflightReportDataclass:
+    def test_post_init_populates_timestamps(self):
+        report = _make_report()
+        assert report.started_at  # non-empty
+        assert report.completed_at == report.started_at  # defaults match
+
+    def test_explicit_timestamps_preserved(self):
+        report = _make_report(started_at="2026-05-24T10:00:00+00:00", completed_at="2026-05-24T10:00:01+00:00")
+        assert report.started_at == "2026-05-24T10:00:00+00:00"
+        assert report.completed_at == "2026-05-24T10:00:01+00:00"
+
+
+class TestRenderMarkdown:
+    def test_pass_verdict_minimal(self):
+        report = _make_report()
+        md = render_markdown(report)
+        assert "Preflight Report — owner/repo" in md
+        assert "Verdict:** `pass`" in md
+        assert "Score:** 95 / 100 (threshold: 90)" in md
+        assert "OPERATOR REVIEW NEEDED" not in md  # no banner on PASS
+
+    def test_operator_review_banner_present_when_needed(self):
+        report = _make_report(verdict=PreflightVerdict.NEEDS_OPERATOR_REVIEW, score=0)
+        md = render_markdown(report)
+        assert "OPERATOR REVIEW NEEDED" in md
+        assert "ghla blacklist add" in md
+        assert "--skip-preflight" in md
+
+    def test_skip_preflight_banner_present_when_set(self):
+        report = _make_report(skip_preflight_banner=True)
+        md = render_markdown(report)
+        assert "SKIP-PREFLIGHT BANNER" in md
+        assert "advisory only" in md
+
+    def test_gate_rows_rendered(self):
+        report = _make_report(
+            gate_results=[
+                GateResult(name="anti_ai", passed=True, reason="clean", evidence={"files": 7}),
+                GateResult(name="archived", passed=False, reason="repo is archived", evidence={"archived": True}),
+            ],
+            verdict=PreflightVerdict.HARD_GATE_FAILED,
+            gate_failure_name="archived",
+        )
+        md = render_markdown(report)
+        assert "`anti_ai`" in md
+        assert "`archived`" in md
+        assert "Failed gate:** `archived`" in md
+        assert "files=7" in md
+
+    def test_score_rows_rendered_with_total(self):
+        report = _make_report(
+            score=18,
+            score_breakdown=[
+                ScoreComponent(name="C1", points_awarded=10, max_points=10, evidence={"match": "exact"}),
+                ScoreComponent(name="C2", points_awarded=8, max_points=10, evidence={"hits": 2}),
+            ],
+        )
+        md = render_markdown(report)
+        assert "C1" in md
+        assert "C2" in md
+        assert "**Total**" in md
+        assert "**18**" in md
+
+    def test_operator_links_present(self):
+        report = _make_report()
+        md = render_markdown(report)
+        assert "https://github.com/owner" in md
+        assert "https://github.com/owner/repo/pulls" in md
+        assert "<https://dead.example/x>" in md
+
+
+class TestRenderJson:
+    def test_returns_valid_json(self):
+        report = _make_report()
+        s = render_json(report)
+        data = json.loads(s)
+        assert data["repo_full_name"] == "owner/repo"
+        assert data["verdict"] == "pass"
+        assert data["score"] == 95
+        assert data["threshold"] == 90
+        assert data["gate_results"] == []
+        assert data["score_breakdown"] == []
+
+    def test_includes_gates_and_scores(self):
+        report = _make_report(
+            gate_results=[GateResult(name="anti_ai", passed=True, reason="ok")],
+            score_breakdown=[ScoreComponent(name="C1", points_awarded=10, max_points=10)],
+        )
+        data = json.loads(render_json(report))
+        assert len(data["gate_results"]) == 1
+        assert data["gate_results"][0]["name"] == "anti_ai"
+        assert data["gate_results"][0]["passed"] is True
+        assert len(data["score_breakdown"]) == 1
+        assert data["score_breakdown"][0]["points_awarded"] == 10
+
+
+class TestSaveReport:
+    def test_writes_both_files(self, tmp_path):
+        report = _make_report()
+        md_path, json_path = save_report(report, tmp_path)
+        assert md_path.exists()
+        assert json_path.exists()
+        # File names use the run_id + safe repo name
+        assert md_path.name == "preflight-test-owner_repo.md"
+        assert json_path.name == "preflight-test-owner_repo.json"
+
+    def test_creates_log_dir_if_missing(self, tmp_path):
+        target = tmp_path / "nested" / "preflight-reports"
+        report = _make_report()
+        md_path, _ = save_report(report, target)
+        assert target.exists()
+        assert md_path.exists()
+
+    def test_contents_match_renderers(self, tmp_path):
+        report = _make_report()
+        md_path, json_path = save_report(report, tmp_path)
+        assert md_path.read_text(encoding="utf-8") == render_markdown(report)
+        assert json_path.read_text(encoding="utf-8") == render_json(report)

--- a/tests/unit/preflight/test_subagent.py
+++ b/tests/unit/preflight/test_subagent.py
@@ -1,0 +1,160 @@
+"""Tests for src/gh_link_auditor/preflight/subagent.py (#287)."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest import mock
+
+from gh_link_auditor.preflight.subagent import (
+    RealSubagent,
+    SubagentVerdict,
+    _parse_verdict_token,
+    anti_ai_keyword_fallback,
+)
+from tests.fakes.subagent import FakeSubagent
+
+
+class TestParseVerdictToken:
+    def test_clean(self):
+        assert _parse_verdict_token("clean") == SubagentVerdict.CLEAN
+
+    def test_uncertain(self):
+        assert _parse_verdict_token("uncertain") == SubagentVerdict.UNCERTAIN
+
+    def test_hostile(self):
+        assert _parse_verdict_token("hostile") == SubagentVerdict.HOSTILE
+
+    def test_partial(self):
+        assert _parse_verdict_token("partial") == SubagentVerdict.PARTIAL
+
+    def test_unrelated(self):
+        assert _parse_verdict_token("unrelated") == SubagentVerdict.UNRELATED
+
+    def test_uppercase_input(self):
+        assert _parse_verdict_token("CLEAN") == SubagentVerdict.CLEAN
+
+    def test_with_extra_whitespace(self):
+        assert _parse_verdict_token("  hostile  \n") == SubagentVerdict.HOSTILE
+
+    def test_unknown_token_returns_uncertain(self):
+        assert _parse_verdict_token("maybe") == SubagentVerdict.UNCERTAIN
+
+    def test_empty_returns_uncertain(self):
+        assert _parse_verdict_token("") == SubagentVerdict.UNCERTAIN
+
+    def test_uses_first_line_only(self):
+        assert _parse_verdict_token("clean\nextra noise") == SubagentVerdict.CLEAN
+
+
+class TestAntiAiKeywordFallback:
+    def test_clean_when_no_hits(self):
+        assert anti_ai_keyword_fallback("Welcome to our project") == SubagentVerdict.CLEAN
+
+    def test_uncertain_on_hit(self):
+        assert anti_ai_keyword_fallback("Please do not use AI to generate this") == SubagentVerdict.UNCERTAIN
+
+    def test_clean_on_empty(self):
+        assert anti_ai_keyword_fallback("") == SubagentVerdict.CLEAN
+
+    def test_clean_on_none(self):
+        assert anti_ai_keyword_fallback(None) == SubagentVerdict.CLEAN
+
+    def test_case_insensitive(self):
+        assert anti_ai_keyword_fallback("NO LLM CONTRIBUTIONS") == SubagentVerdict.UNCERTAIN
+
+
+class TestRealSubagent:
+    def test_returns_uncertain_when_claude_missing(self, tmp_path):
+        prompt = tmp_path / "p.txt"
+        prompt.write_text("scan", encoding="utf-8")
+        subagent = RealSubagent()
+        with mock.patch("gh_link_auditor.preflight.subagent.shutil.which", return_value=None):
+            verdict = subagent.run(prompt, {"x": 1})
+        assert verdict == SubagentVerdict.UNCERTAIN
+
+    def test_returns_uncertain_on_timeout(self, tmp_path):
+        prompt = tmp_path / "p.txt"
+        prompt.write_text("scan", encoding="utf-8")
+        subagent = RealSubagent(timeout_s=1)
+        with (
+            mock.patch("gh_link_auditor.preflight.subagent.shutil.which", return_value="/usr/bin/claude"),
+            mock.patch(
+                "gh_link_auditor.preflight.subagent.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=1),
+            ),
+        ):
+            verdict = subagent.run(prompt, {"x": 1})
+        assert verdict == SubagentVerdict.UNCERTAIN
+
+    def test_returns_uncertain_on_nonzero_exit(self, tmp_path):
+        prompt = tmp_path / "p.txt"
+        prompt.write_text("scan", encoding="utf-8")
+        subagent = RealSubagent()
+        completed = subprocess.CompletedProcess(args=["claude"], returncode=1, stdout="", stderr="boom")
+        with (
+            mock.patch("gh_link_auditor.preflight.subagent.shutil.which", return_value="/usr/bin/claude"),
+            mock.patch("gh_link_auditor.preflight.subagent.subprocess.run", return_value=completed),
+        ):
+            verdict = subagent.run(prompt, {"x": 1})
+        assert verdict == SubagentVerdict.UNCERTAIN
+
+    def test_returns_parsed_verdict_on_success(self, tmp_path):
+        prompt = tmp_path / "p.txt"
+        prompt.write_text("ai_scan", encoding="utf-8")
+        subagent = RealSubagent()
+        completed = subprocess.CompletedProcess(args=["claude"], returncode=0, stdout="hostile\n", stderr="")
+        with (
+            mock.patch("gh_link_auditor.preflight.subagent.shutil.which", return_value="/usr/bin/claude"),
+            mock.patch("gh_link_auditor.preflight.subagent.subprocess.run", return_value=completed) as run_mock,
+        ):
+            verdict = subagent.run(prompt, {"repo": "owner/r"})
+        assert verdict == SubagentVerdict.HOSTILE
+        # Confirms the env carried CLAUDECODE=""
+        env = run_mock.call_args.kwargs["env"]
+        assert env["CLAUDECODE"] == ""
+
+    def test_returns_uncertain_when_prompt_unreadable(self, tmp_path):
+        missing = tmp_path / "missing.txt"  # not created
+        subagent = RealSubagent()
+        with mock.patch("gh_link_auditor.preflight.subagent.shutil.which", return_value="/usr/bin/claude"):
+            verdict = subagent.run(missing, {"x": 1})
+        assert verdict == SubagentVerdict.UNCERTAIN
+
+    def test_is_available_reflects_shutil_which(self):
+        with mock.patch("gh_link_auditor.preflight.subagent.shutil.which", return_value="/usr/bin/claude"):
+            assert RealSubagent.is_available() is True
+        with mock.patch("gh_link_auditor.preflight.subagent.shutil.which", return_value=None):
+            assert RealSubagent.is_available() is False
+
+
+class TestFakeSubagent:
+    def test_default_verdict_returned(self, tmp_path):
+        fake = FakeSubagent.configure(default=SubagentVerdict.CLEAN)
+        verdict = fake.run(tmp_path / "p.txt", {"x": 1})
+        assert verdict == SubagentVerdict.CLEAN
+        assert len(fake.calls) == 1
+        assert fake.calls[0].context == {"x": 1}
+
+    def test_per_prompt_override(self, tmp_path):
+        p1 = tmp_path / "a.txt"
+        p2 = tmp_path / "b.txt"
+        fake = FakeSubagent.configure(
+            default=SubagentVerdict.CLEAN,
+            overrides={str(p1): SubagentVerdict.HOSTILE},
+        )
+        assert fake.run(p1, {}) == SubagentVerdict.HOSTILE
+        assert fake.run(p2, {}) == SubagentVerdict.CLEAN
+
+    def test_records_every_call(self, tmp_path):
+        fake = FakeSubagent.configure()
+        for i in range(3):
+            fake.run(tmp_path / f"{i}.txt", {"i": i})
+        assert len(fake.calls) == 3
+        assert [c.context["i"] for c in fake.calls] == [0, 1, 2]
+
+    def test_copies_context_dict(self, tmp_path):
+        fake = FakeSubagent.configure()
+        ctx = {"x": 1}
+        fake.run(tmp_path / "p.txt", ctx)
+        ctx["x"] = 999  # mutating after should not affect the recording
+        assert fake.calls[0].context == {"x": 1}

--- a/tests/unit/test_unified_db.py
+++ b/tests/unit/test_unified_db.py
@@ -923,3 +923,144 @@ class TestContextManager:
         with UnifiedDatabase(db_file) as db:
             row = db._conn.execute("SELECT version FROM schema_version").fetchone()
             assert row["version"] == SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Preflight caches (#285)
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightCaches:
+    """3 new tables shipped with schema v9 for Phase B preflight."""
+
+    def test_all_preflight_tables_exist(self, db):
+        tables = {row[0] for row in db._conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+        assert "preflight_pr_stats_cache" in tables
+        assert "preflight_repo_meta_cache" in tables
+        assert "preflight_ai_scan_cache" in tables
+
+    # --- preflight_pr_stats_cache ---
+
+    def test_pr_stats_write_read_roundtrip(self, db):
+        db.cache_pr_stats("owner/r", merge_rate=0.42, sample_size=12)
+        cached = db.get_cached_pr_stats("owner/r")
+        assert cached is not None
+        assert cached["repo_full_name"] == "owner/r"
+        assert cached["merge_rate"] == 0.42
+        assert cached["sample_size"] == 12
+        assert cached["computed_at"]
+        assert cached["expires_at"]
+
+    def test_pr_stats_miss_returns_none(self, db):
+        assert db.get_cached_pr_stats("owner/nonexistent") is None
+
+    def test_pr_stats_expired_returns_none(self, db):
+        # ttl_days=0 -> expires_at == now -> immediately expired
+        db.cache_pr_stats("owner/r", merge_rate=0.5, sample_size=10, ttl_days=0)
+        assert db.get_cached_pr_stats("owner/r") is None
+
+    def test_pr_stats_replace_on_recompute(self, db):
+        db.cache_pr_stats("owner/r", merge_rate=0.2, sample_size=5)
+        db.cache_pr_stats("owner/r", merge_rate=0.7, sample_size=20)
+        cached = db.get_cached_pr_stats("owner/r")
+        assert cached["merge_rate"] == 0.7
+        assert cached["sample_size"] == 20
+
+    # --- preflight_repo_meta_cache ---
+
+    def test_repo_meta_write_read_roundtrip(self, db):
+        db.cache_repo_meta(
+            "owner/r",
+            stars=1234,
+            pushed_at="2026-05-20T10:00:00Z",
+            license="Apache-2.0",
+            archived=False,
+            disabled=False,
+        )
+        cached = db.get_cached_repo_meta("owner/r")
+        assert cached is not None
+        assert cached["stars"] == 1234
+        assert cached["pushed_at"] == "2026-05-20T10:00:00Z"
+        assert cached["license"] == "Apache-2.0"
+        assert cached["archived"] is False
+        assert cached["disabled"] is False
+
+    def test_repo_meta_archived_disabled_preserved(self, db):
+        db.cache_repo_meta(
+            "owner/r",
+            stars=10,
+            pushed_at="2024-01-01T00:00:00Z",
+            license=None,
+            archived=True,
+            disabled=True,
+        )
+        cached = db.get_cached_repo_meta("owner/r")
+        assert cached["archived"] is True
+        assert cached["disabled"] is True
+        assert cached["license"] is None
+
+    def test_repo_meta_miss_returns_none(self, db):
+        assert db.get_cached_repo_meta("owner/nonexistent") is None
+
+    def test_repo_meta_expired_returns_none(self, db):
+        db.cache_repo_meta(
+            "owner/r", stars=10, pushed_at=None, license=None, archived=False, disabled=False, ttl_hours=0
+        )
+        assert db.get_cached_repo_meta("owner/r") is None
+
+    # --- preflight_ai_scan_cache ---
+
+    def test_ai_scan_write_read_roundtrip(self, db):
+        db.cache_ai_scan("owner/r", "README.md", "abc123", "clean")
+        assert db.get_cached_ai_scan("owner/r", "README.md", "abc123") == "clean"
+
+    def test_ai_scan_miss_on_different_sha(self, db):
+        db.cache_ai_scan("owner/r", "README.md", "abc123", "hostile")
+        # Different SHA -> miss (implicit invalidation when file content changes)
+        assert db.get_cached_ai_scan("owner/r", "README.md", "different") is None
+
+    def test_ai_scan_miss_on_different_file(self, db):
+        db.cache_ai_scan("owner/r", "README.md", "abc123", "clean")
+        assert db.get_cached_ai_scan("owner/r", "CONTRIBUTING.md", "abc123") is None
+
+    def test_ai_scan_replace_for_same_key(self, db):
+        db.cache_ai_scan("owner/r", "README.md", "abc123", "clean")
+        db.cache_ai_scan("owner/r", "README.md", "abc123", "hostile")
+        assert db.get_cached_ai_scan("owner/r", "README.md", "abc123") == "hostile"
+
+
+# ---------------------------------------------------------------------------
+# v8 -> v9 migration (#285)
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationV8ToV9:
+    def test_migrate_creates_preflight_tables(self, tmp_path):
+        db_file = str(tmp_path / "v8.db")
+        # Build a v8 database from scratch: open + close, then manually downgrade
+        # the schema_version row so the next open triggers the migration.
+        with UnifiedDatabase(db_file) as db:
+            db._conn.execute("UPDATE schema_version SET version = 8")
+            db._conn.execute("DROP TABLE IF EXISTS preflight_pr_stats_cache")
+            db._conn.execute("DROP TABLE IF EXISTS preflight_repo_meta_cache")
+            db._conn.execute("DROP TABLE IF EXISTS preflight_ai_scan_cache")
+            db._conn.commit()
+
+        # Re-open: should run v8 -> v9 migration
+        with UnifiedDatabase(db_file) as db:
+            row = db._conn.execute("SELECT version FROM schema_version").fetchone()
+            assert row["version"] == SCHEMA_VERSION
+            tables = {r[0] for r in db._conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+            assert "preflight_pr_stats_cache" in tables
+            assert "preflight_repo_meta_cache" in tables
+            assert "preflight_ai_scan_cache" in tables
+
+    def test_migrate_is_idempotent_on_re_open(self, tmp_path):
+        db_file = str(tmp_path / "v8.db")
+        # First open creates everything at current SCHEMA_VERSION
+        with UnifiedDatabase(db_file):
+            pass
+        # Second open should be a no-op (no migration runs)
+        with UnifiedDatabase(db_file) as db:
+            row = db._conn.execute("SELECT version FROM schema_version").fetchone()
+            assert row["version"] == SCHEMA_VERSION

--- a/tests/unit/tools/test_preflight_check.py
+++ b/tests/unit/tools/test_preflight_check.py
@@ -1,0 +1,142 @@
+"""Tests for tools/preflight_check.py (#283 scaffold)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gh_link_auditor.preflight.report import PreflightReport, PreflightVerdict
+from tools.preflight_check import (
+    DEFAULT_REPORT_DIR,
+    DEFAULT_THRESHOLD,
+    _build_parser,
+    _make_run_id,
+    main,
+    run_preflight,
+)
+
+
+class TestBuildParser:
+    def test_required_repo(self):
+        # parser exits when --repo missing
+        import pytest
+
+        with pytest.raises(SystemExit):
+            _build_parser().parse_args([])
+
+    def test_all_flag_defaults(self):
+        args = _build_parser().parse_args(["--repo", "owner/r"])
+        assert args.repo == "owner/r"
+        assert args.candidate_id is None
+        assert args.report is False
+        assert args.score_only is False
+        assert args.strict is False
+        assert args.threshold == DEFAULT_THRESHOLD
+        assert args.preflight_log_dir == DEFAULT_REPORT_DIR
+
+    def test_explicit_flags(self, tmp_path):
+        args = _build_parser().parse_args(
+            [
+                "--repo",
+                "o/r",
+                "--candidate-id",
+                "abc123",
+                "--report",
+                "--score-only",
+                "--strict",
+                "--threshold",
+                "85",
+                "--preflight-log-dir",
+                str(tmp_path),
+            ]
+        )
+        assert args.repo == "o/r"
+        assert args.candidate_id == "abc123"
+        assert args.report is True
+        assert args.score_only is True
+        assert args.strict is True
+        assert args.threshold == 85
+        assert args.preflight_log_dir == tmp_path
+
+
+class TestMakeRunId:
+    def test_format(self):
+        run_id = _make_run_id()
+        assert run_id.startswith("preflight-")
+        # Should have a timestamp segment and a short hex suffix
+        parts = run_id.split("-")
+        assert len(parts) >= 3
+        assert "T" in parts[1] and parts[1].endswith("Z")
+        assert len(parts[-1]) == 6
+
+
+class TestRunPreflightScaffold:
+    """The scaffold's ``run_preflight`` returns PASS with no evaluations.
+
+    Real gate / score dispatch lands in subsequent PRs under #281.
+    """
+
+    def test_returns_preflight_report(self):
+        report = run_preflight("owner/r", {"dead_url": "https://a", "candidate_url": "https://b"})
+        assert isinstance(report, PreflightReport)
+        assert report.repo_full_name == "owner/r"
+        assert report.verdict == PreflightVerdict.PASS
+        assert report.score == 0
+        assert report.threshold == DEFAULT_THRESHOLD
+        assert report.gate_results == []
+        assert report.score_breakdown == []
+        assert report.run_id.startswith("preflight-")
+
+    def test_custom_threshold_passed_through(self):
+        report = run_preflight("owner/r", {"dead_url": "https://a", "candidate_url": "https://b"}, threshold=85)
+        assert report.threshold == 85
+
+    def test_explicit_run_id_used(self):
+        report = run_preflight(
+            "owner/r",
+            {"dead_url": "https://a", "candidate_url": "https://b"},
+            run_id="caller-supplied-id",
+        )
+        assert report.run_id == "caller-supplied-id"
+
+    def test_candidate_is_copied_not_shared(self):
+        candidate = {"dead_url": "https://a", "candidate_url": "https://b"}
+        report = run_preflight("owner/r", candidate)
+        candidate["dead_url"] = "MUTATED"
+        # report.candidate should not have been mutated through the dict identity
+        assert report.candidate["dead_url"] == "https://a"
+
+
+class TestMain:
+    def test_exit_zero_on_pass(self, capsys):
+        rc = main(["--repo", "owner/r"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "verdict=pass" in out
+
+    def test_strict_returns_zero_when_pass(self, capsys):
+        rc = main(["--repo", "owner/r", "--strict"])
+        assert rc == 0
+
+    def test_score_only_prints_int(self, capsys):
+        rc = main(["--repo", "owner/r", "--score-only"])
+        out = capsys.readouterr().out.strip()
+        assert rc == 0
+        assert out == "0"
+
+    def test_report_writes_files(self, tmp_path, capsys):
+        rc = main(["--repo", "owner/r", "--report", "--preflight-log-dir", str(tmp_path)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "markdown:" in out
+        assert "json:" in out
+        files = list(tmp_path.iterdir())
+        suffixes = sorted(f.suffix for f in files)
+        assert suffixes == [".json", ".md"]
+
+    def test_default_report_dir_constant_is_data_preflight_reports(self):
+        # Sanity check: the default ends with data/preflight-reports
+        assert DEFAULT_REPORT_DIR.parts[-2:] == ("data", "preflight-reports")
+
+    def test_default_report_dir_under_project(self):
+        # Make sure DEFAULT_REPORT_DIR points at the repo, not the cwd
+        assert isinstance(DEFAULT_REPORT_DIR, Path)

--- a/tools/preflight_check.py
+++ b/tools/preflight_check.py
@@ -1,0 +1,159 @@
+"""Phase B preflight tool (#283 scaffold; full gates / scores land in
+subsequent PRs under #281).
+
+Runs the preflight evaluation for a single candidate (or all candidates
+for a repo) and writes a markdown + JSON report. Used as a gate by
+``tools/derive_replacement_prs.py`` PRIOR to ``n6_submit_pr`` so no fork
+or push happens until preflight passes.
+
+Usage::
+
+    poetry run python tools/preflight_check.py --repo owner/name --report
+    poetry run python tools/preflight_check.py --repo owner/name --score-only
+    poetry run python tools/preflight_check.py --repo owner/name --strict
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+
+from gh_link_auditor.preflight import (  # noqa: E402
+    PreflightReport,
+    PreflightVerdict,
+    save_report,
+)
+
+DEFAULT_REPORT_DIR = _PROJECT_ROOT / "data" / "preflight-reports"
+DEFAULT_THRESHOLD = 90
+
+
+def run_preflight(
+    repo_full_name: str,
+    candidate: dict[str, Any],
+    db: Any = None,  # UnifiedDatabase; typed loosely until gate/score PRs wire deps
+    threshold: int = DEFAULT_THRESHOLD,
+    run_id: str | None = None,
+    skip_preflight_banner: bool = False,
+) -> PreflightReport:
+    """Run preflight evaluation for a single candidate.
+
+    This is the scaffolded entry point: returns ``PASS`` with no gates /
+    scores evaluated. Per-gate (#288-#297) and per-score (#298-#309)
+    issues plug into this dispatch in subsequent PRs.
+
+    Args:
+        repo_full_name: ``owner/repo``.
+        candidate: dict with at least ``dead_url`` and ``candidate_url``;
+            may also carry ``source_file``, ``line_number``, ``method``,
+            ``confidence``, etc.
+        db: unified database (gates use cache tables from #285).
+        threshold: minimum score required to PASS (default 90).
+        run_id: optional caller-supplied run id; auto-generated if None.
+        skip_preflight_banner: when True, the report markdown includes
+            the BAD-ESCAPE banner (set by ``--skip-preflight`` on tool A).
+
+    Returns:
+        A ``PreflightReport`` with the verdict + score + per-gate /
+        per-score evidence.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    return PreflightReport(
+        repo_full_name=repo_full_name,
+        candidate=dict(candidate),
+        verdict=PreflightVerdict.PASS,
+        score=0,
+        threshold=threshold,
+        gate_results=[],
+        score_breakdown=[],
+        gate_failure_name=None,
+        started_at=now,
+        completed_at=now,
+        run_id=run_id or _make_run_id(),
+        skip_preflight_banner=skip_preflight_banner,
+    )
+
+
+def _make_run_id() -> str:
+    """Generate a sortable, unique-enough run id for a preflight invocation."""
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    short = uuid.uuid4().hex[:6]
+    return f"preflight-{ts}-{short}"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Phase B preflight evaluator (#281 umbrella)",
+    )
+    p.add_argument("--repo", required=True, help="target repo (owner/name)")
+    p.add_argument("--candidate-id", default=None, help="optional candidate id filter")
+    p.add_argument(
+        "--report",
+        action="store_true",
+        help="write a markdown + JSON report to --preflight-log-dir",
+    )
+    p.add_argument(
+        "--score-only",
+        action="store_true",
+        help="print only the integer score; useful for CI scripts",
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit non-zero on any HARD_GATE_FAILED / SCORE_TOO_LOW / NEEDS_OPERATOR_REVIEW",
+    )
+    p.add_argument(
+        "--threshold",
+        type=int,
+        default=DEFAULT_THRESHOLD,
+        help="minimum total score required to PASS (default: 90)",
+    )
+    p.add_argument(
+        "--preflight-log-dir",
+        type=Path,
+        default=DEFAULT_REPORT_DIR,
+        help=f"directory for markdown + JSON reports (default: {DEFAULT_REPORT_DIR})",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    candidate = {
+        "dead_url": "",
+        "candidate_url": "",
+        "source_file": "",
+        "line_number": None,
+        "method": "",
+    }
+    report = run_preflight(
+        repo_full_name=args.repo,
+        candidate=candidate,
+        threshold=args.threshold,
+    )
+
+    if args.report:
+        md_path, json_path = save_report(report, args.preflight_log_dir)
+        print(f"markdown: {md_path}")
+        print(f"json: {json_path}")
+
+    if args.score_only:
+        print(report.score)
+    else:
+        print(f"verdict={report.verdict.value} score={report.score} threshold={report.threshold}")
+
+    if args.strict and report.verdict != PreflightVerdict.PASS:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR-β of the Phase B preflight execution plan (#281 umbrella). Bundles four interdependent infra pieces so subsequent gate / score PRs have a complete plug-in surface:

1. **`tools/preflight_check.py` scaffold (#283)** — CLI + `run_preflight()` stub that returns `PASS` with no evaluations
2. **3 new preflight cache tables in `unified_db` (#285)** — `preflight_pr_stats_cache` (7d TTL), `preflight_repo_meta_cache` (24h), `preflight_ai_scan_cache` (per file SHA). Schema **v8 → v9** migration is narrow (only new tables); avoids the Windows tempdir/sqlite lock race that the longer migration chain otherwise tripped
3. **Markdown + JSON report renderers (#286)** plus `save_report()` helper. Operator-clickable links, hard-gate / score tables, OPERATOR REVIEW NEEDED banner, SKIP-PREFLIGHT banner
4. **Subagent infrastructure (#287)** — `RealSubagent` shells out to `claude --print` with `CLAUDECODE=""` per universal CLAUDE.md mandate (NOT `@anthropic-ai/sdk`; NOT the Claude Code session-only `Agent` tool). 60s timeout → `UNCERTAIN`. `FakeSubagent` fake (no MagicMock). Fallback to `hostile_classifier.ANTI_AI_PHRASES` when `claude` is unavailable. 3 prompt files under `prompts/preflight/`

No gates or scores fire yet. `run_preflight` returns `PASS` for every candidate; per-gate (#288–#297) and per-score (#298–#309) issues plug into the dispatch in subsequent PRs.

## Why bundle 4 issues?

Each piece is small infra; mutual dependencies resolve cleanly within the bundle. Splitting would mean 4 PRs each with placeholder imports of the next, with little real review benefit.

## Test plan

- [x] `poetry run pytest -q` → **2315 passed**, 1 skipped (was 2247 after PR-α; +68 tests)
- [x] `poetry run ruff format --check .` → 242 files already formatted
- [x] `poetry run ruff check .` → all checks passed
- [x] `git grep -i -E '(A\+\+|PRs filed|contribution graph|green square|naked ambition)'` → 0 hits
- [x] `poetry run python tools/preflight_check.py --repo owner/r` → exits 0, prints `verdict=pass score=0 threshold=90`
- [x] `poetry run python tools/preflight_check.py --repo owner/r --report --preflight-log-dir /tmp/x` → writes markdown + JSON
- [x] `TestMigrationV8ToV9` covers manual schema_version downgrade + re-open path
- [x] No MagicMock added (FakeSubagent is a typed dataclass; `RealSubagent` tests patch `subprocess.run`/`shutil.which` — external boundaries, consistent with existing `tests/unit/test_network.py` patterns)

Closes #283
Closes #285
Closes #286
Closes #287
