### PR TITLE
feat(preflight): integrate preflight gate into derive_replacement_prs.py (#284)

### DIFF
--- a/docs/reports/active/10284-implementation-report.md
+++ b/docs/reports/active/10284-implementation-report.md
@@ -1,0 +1,61 @@
+# 10284 - Implementation Report
+
+**Issue:** #284 — `feat(preflight)`: integrate preflight gate into tools/derive_replacement_prs.py
+**Branch:** `284-preflight-toola-integration`
+**Umbrella:** #281
+
+## Summary
+
+PR-γ: wires `run_preflight()` into `tools/derive_replacement_prs.derive_and_submit` PRIOR to `n6_submit_pr`. No fork, no push, no PR until preflight passes. Adds the 4 promised CLI flags.
+
+The preflight is run per repo (first safe row as the representative candidate). Gate / score implementations (per-issue under #281) refine evaluation later — for now the scaffold returns `PASS` with `score=threshold` so the integration permits submission by default. The gating semantics are real: when actual gates fail, the dispatch routes to the right `skipped` reason.
+
+## Files
+
+### Modified
+
+- `tools/derive_replacement_prs.py`
+  - New imports: `PreflightVerdict`, `save_report`, `DEFAULT_REPORT_DIR`, `DEFAULT_THRESHOLD`, `run_preflight`
+  - `derive_and_submit` runs `run_preflight()` after the `safe_rows` filter and before `_build_state` + `n6_submit_pr`. Verdict dispatch:
+    - `HARD_GATE_FAILED` → skip with `preflight_gate_{report.gate_failure_name}`
+    - `NEEDS_OPERATOR_REVIEW` → skip with `preflight_needs_review`
+    - `score < threshold` → skip with `preflight_score_{N}`
+    - `--preflight-report-only` → skip every repo with `preflight_report_only` (reports still written)
+    - `--skip-preflight` → bypass the verdict check; write report with BAD ESCAPE banner; allow N6
+  - 4 new flags on `_build_parser`: `--preflight-threshold` (default 90), `--preflight-log-dir` (default `data/preflight-reports/`), `--preflight-report-only`, `--skip-preflight`
+- `tools/preflight_check.py`
+  - Scaffold `run_preflight` now returns `score=threshold` (was 0) so the integration's threshold check passes by default. Per-gate / per-score issues will set real scores from `score_breakdown` sum
+- `tests/unit/tools/test_preflight_check.py`
+  - 3 tests updated: `test_returns_preflight_report`, `test_custom_threshold_passed_through`, `test_score_only_prints_int` — assert score == DEFAULT_THRESHOLD (was 0)
+- `tests/unit/tools/test_derive_replacement_prs.py`
+  - `_make_args` helper extended with `preflight_threshold`, `preflight_log_dir` (tempdir), `preflight_report_only=False`, `skip_preflight=False`
+  - `TestBuildParser::test_defaults` + `test_explicit_flags` updated with 4 new flag assertions
+  - NEW `TestPreflightIntegration` class — 5 tests:
+    - `test_hard_gate_failed_skips_with_gate_name`
+    - `test_needs_operator_review_skips`
+    - `test_score_too_low_skips_with_score`
+    - `test_preflight_report_only_skips_all_without_filing`
+    - `test_skip_preflight_bypasses_gate`
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `poetry run pytest -q` | 2320 passed, 1 skipped (was 2315 after PR-β; +5 from PR-γ integration tests) |
+| `poetry run ruff format --check .` | 242 files already formatted |
+| `poetry run ruff check .` | All checks passed |
+| `poetry run python tools/derive_replacement_prs.py --help` | Lists the 4 new flags + the existing `--campaign-allowed` |
+
+## Design notes
+
+- **Per-repo vs per-candidate.** The scaffold's `run_preflight` signature takes a single candidate, so the integration runs preflight ONCE per repo using `safe_rows[0]` as the representative. When per-gate issues land, they may refine to per-candidate evaluation within a PR. This PR doesn't pre-empt that decision.
+- **`--skip-preflight` always writes the report.** The BAD ESCAPE banner in the markdown ensures the operator can see the bypass after the fact, even though the verdict didn't gate.
+- **`--preflight-report-only` writes reports + skips submission.** Useful for the #314 end-to-end verification step where the operator wants to read 87 reports without filing 87 PRs.
+
+## Out of scope
+
+- Per-candidate (vs per-repo) preflight evaluation — gate / score issues will decide
+- Actual hard gate logic — PR-δ + PR-ε
+- Actual score components — PR-η + PR-θ
+- Subagent runtime fixture / live tests — PR-ι
+- E2E verification (#314) — operator

--- a/docs/reports/active/10284-test-report.md
+++ b/docs/reports/active/10284-test-report.md
@@ -1,0 +1,51 @@
+# 10284 - Test Report
+
+**Issue:** #284
+**Branch:** `284-preflight-toola-integration`
+
+## Test count
+
+| Stage | Count |
+|---|---|
+| Before this PR | 2315 passed, 1 skipped |
+| After this PR | 2320 passed, 1 skipped |
+| Net | +5 new tests |
+
+## New tests
+
+### `tests/unit/tools/test_derive_replacement_prs.py::TestPreflightIntegration` (5 tests)
+
+Each test patches `tools.derive_replacement_prs.run_preflight` to inject a controlled verdict / score, then asserts the integration's skip reason / submission behavior.
+
+1. `test_hard_gate_failed_skips_with_gate_name` — `HARD_GATE_FAILED` verdict with `gate_failure_name="anti_ai"` → `skipped` contains `("o/r", "preflight_gate_anti_ai")`; no submission
+2. `test_needs_operator_review_skips` — `NEEDS_OPERATOR_REVIEW` → `skipped` contains `("o/r", "preflight_needs_review")`
+3. `test_score_too_low_skips_with_score` — `PASS` verdict with `score=42` (< threshold 90) → `skipped` contains `("o/r", "preflight_score_42")`
+4. `test_preflight_report_only_skips_all_without_filing` — even with `PASS` + high score, `--preflight-report-only` skips all with `preflight_report_only`; reports ARE written
+5. `test_skip_preflight_bypasses_gate` — `HARD_GATE_FAILED` would normally skip, but `--skip-preflight=True` lets the PR through
+
+## Modified existing tests
+
+`tests/unit/tools/test_derive_replacement_prs.py`:
+- `_make_args` helper — added `campaign_allowed=True`, `preflight_threshold=90`, `preflight_log_dir=<tempdir>`, `preflight_report_only=False`, `skip_preflight=False` defaults so existing TestDeriveAndSubmit tests continue to call `derive_and_submit` with a complete args namespace
+- `TestBuildParser::test_defaults` — asserts the 4 new flag defaults (`preflight_threshold == 90`, `preflight_report_only is False`, `skip_preflight is False`, `preflight_log_dir is not None`)
+- `TestBuildParser::test_explicit_flags` — added `--preflight-threshold 85 --preflight-log-dir /tmp/reports --preflight-report-only --skip-preflight` and asserts each (`Path` comparison normalizes per platform)
+
+`tests/unit/tools/test_preflight_check.py`:
+- `test_returns_preflight_report` — `assert report.score == DEFAULT_THRESHOLD` (was 0)
+- `test_custom_threshold_passed_through` — also asserts `report.score == 85`
+- `test_score_only_prints_int` — `assert out == str(DEFAULT_THRESHOLD)` (was `"0"`)
+
+## Mocking
+
+`unittest.mock.patch` is used to inject `run_preflight` stubs at the integration's import site (`tools.derive_replacement_prs.run_preflight`). This matches the existing test pattern in this file (e.g. `mock.patch("gh_link_auditor.pipeline.nodes.n1_scan.network_check_url", ...)`) and is acceptable per the codebase convention for patching internal-API call sites in tool tests. No MagicMock added to the codebase; `FakeSubagent` (from #287) is the typed-fake pattern preferred for new collaborators.
+
+## Lint
+
+| Check | Result |
+|---|---|
+| `poetry run ruff format --check .` | 242 files already formatted |
+| `poetry run ruff check .` | All checks passed |
+
+## No regressions
+
+Full suite (`poetry run pytest -q`): **2320 passed, 1 skipped**. The earlier-flaky `TestMigrationV2ToV3::test_migration_adds_columns_to_v2_table` (fixed in PR-β) remains stable.

--- a/tests/unit/tools/test_derive_replacement_prs.py
+++ b/tests/unit/tools/test_derive_replacement_prs.py
@@ -72,6 +72,12 @@ def _insert_finding(udb: UnifiedDatabase, **overrides) -> int:
 
 
 def _make_args(**overrides) -> argparse.Namespace:
+    # Mirrors _build_parser defaults plus the Phase B preflight flags (#284).
+    # Tests get a tempdir for preflight reports so save_report doesn't write
+    # into the operator's real data/preflight-reports/ at test time.
+    import tempfile
+    from pathlib import Path
+
     defaults = {
         "db": "/tmp/x",
         "run_id": None,
@@ -81,6 +87,11 @@ def _make_args(**overrides) -> argparse.Namespace:
         "max_prs": 10,
         "auto_approve": True,
         "dry_run": False,
+        "campaign_allowed": True,  # tests of derive_and_submit don't gate on this
+        "preflight_threshold": 90,
+        "preflight_log_dir": Path(tempfile.gettempdir()) / "preflight-test-reports",
+        "preflight_report_only": False,
+        "skip_preflight": False,
     }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -617,6 +628,132 @@ class TestDeriveAndSubmit:
 
 
 # ---------------------------------------------------------------------------
+# Phase B preflight integration (#284)
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightIntegration:
+    """Verify each preflight verdict path is routed to the correct skip reason."""
+
+    def _make_fake_run_preflight(self, verdict, score=90, gate_failure_name=None):
+        """Build a stub run_preflight that returns the given verdict / score."""
+        from gh_link_auditor.preflight.report import PreflightReport, PreflightVerdict
+
+        verdict_enum = PreflightVerdict[verdict] if isinstance(verdict, str) else verdict
+
+        def _fake(repo_full_name, candidate, db=None, threshold=90, skip_preflight_banner=False, run_id=None):
+            return PreflightReport(
+                repo_full_name=repo_full_name,
+                candidate=dict(candidate),
+                verdict=verdict_enum,
+                score=score,
+                threshold=threshold,
+                gate_results=[],
+                score_breakdown=[],
+                gate_failure_name=gate_failure_name,
+                started_at="2026-05-24T15:00:00+00:00",
+                completed_at="2026-05-24T15:00:01+00:00",
+                run_id="preflight-test",
+                skip_preflight_banner=skip_preflight_banner,
+            )
+
+        return _fake
+
+    def test_hard_gate_failed_skips_with_gate_name(self, db_path, tmp_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert_finding(udb, repo_full_name="o/r")
+
+        from unittest.mock import patch
+
+        fake = self._make_fake_run_preflight("HARD_GATE_FAILED", score=0, gate_failure_name="anti_ai")
+
+        with patch("tools.derive_replacement_prs.run_preflight", side_effect=fake):
+            result = mod.derive_and_submit(
+                _make_args(db=db_path, preflight_log_dir=tmp_path),
+                n6_fn=lambda s: {**s, "pr_url": "should-not-fire"},
+            )
+
+        assert result["submitted"] == []
+        assert any(reason == "preflight_gate_anti_ai" for _, reason in result["skipped"])
+
+    def test_needs_operator_review_skips(self, db_path, tmp_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert_finding(udb, repo_full_name="o/r")
+
+        from unittest.mock import patch
+
+        fake = self._make_fake_run_preflight("NEEDS_OPERATOR_REVIEW")
+
+        with patch("tools.derive_replacement_prs.run_preflight", side_effect=fake):
+            result = mod.derive_and_submit(
+                _make_args(db=db_path, preflight_log_dir=tmp_path),
+                n6_fn=lambda s: {**s, "pr_url": "should-not-fire"},
+            )
+
+        assert result["submitted"] == []
+        assert any(reason == "preflight_needs_review" for _, reason in result["skipped"])
+
+    def test_score_too_low_skips_with_score(self, db_path, tmp_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert_finding(udb, repo_full_name="o/r")
+
+        from unittest.mock import patch
+
+        # PASS verdict but score below threshold
+        fake = self._make_fake_run_preflight("PASS", score=42)
+
+        with patch("tools.derive_replacement_prs.run_preflight", side_effect=fake):
+            result = mod.derive_and_submit(
+                _make_args(db=db_path, preflight_log_dir=tmp_path),
+                n6_fn=lambda s: {**s, "pr_url": "should-not-fire"},
+            )
+
+        assert result["submitted"] == []
+        assert any(reason == "preflight_score_42" for _, reason in result["skipped"])
+
+    def test_preflight_report_only_skips_all_without_filing(self, db_path, tmp_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert_finding(udb, repo_full_name="o/r")
+
+        from unittest.mock import patch
+
+        # Even with a PASS verdict, --preflight-report-only must skip filing
+        fake = self._make_fake_run_preflight("PASS", score=95)
+
+        with patch("tools.derive_replacement_prs.run_preflight", side_effect=fake):
+            result = mod.derive_and_submit(
+                _make_args(db=db_path, preflight_log_dir=tmp_path, preflight_report_only=True),
+                n6_fn=lambda s: {**s, "pr_url": "should-not-fire"},
+            )
+
+        assert result["submitted"] == []
+        assert any(reason == "preflight_report_only" for _, reason in result["skipped"])
+        # Report files should still have been written
+        assert any(tmp_path.iterdir())
+
+    def test_skip_preflight_bypasses_gate(self, db_path, tmp_path):
+        with UnifiedDatabase(db_path) as udb:
+            _insert_finding(udb, repo_full_name="o/r")
+
+        from unittest.mock import patch
+
+        # Hard-gate failure that would normally skip — but --skip-preflight bypasses it
+        fake = self._make_fake_run_preflight("HARD_GATE_FAILED", score=0, gate_failure_name="anti_ai")
+
+        def fake_n6(state):
+            return {**state, "pr_url": "https://github.com/o/r/pull/1"}
+
+        with patch("tools.derive_replacement_prs.run_preflight", side_effect=fake):
+            result = mod.derive_and_submit(
+                _make_args(db=db_path, preflight_log_dir=tmp_path, skip_preflight=True),
+                n6_fn=fake_n6,
+            )
+
+        # Despite the failed gate, the PR was submitted because --skip-preflight bypassed the check
+        assert len(result["submitted"]) == 1
+
+
+# ---------------------------------------------------------------------------
 # Output rendering + CLI surface
 # ---------------------------------------------------------------------------
 
@@ -687,6 +824,11 @@ class TestBuildParser:
         assert args.auto_approve is False
         assert args.dry_run is False
         assert args.campaign_allowed is False
+        # Phase B preflight flags (#284)
+        assert args.preflight_threshold == 90
+        assert args.preflight_report_only is False
+        assert args.skip_preflight is False
+        assert args.preflight_log_dir is not None  # defaults to data/preflight-reports
 
     def test_explicit_flags(self):
         args = mod._build_parser().parse_args(
@@ -706,6 +848,12 @@ class TestBuildParser:
                 "--auto-approve",
                 "--dry-run",
                 "--campaign-allowed",
+                "--preflight-threshold",
+                "85",
+                "--preflight-log-dir",
+                "/tmp/reports",
+                "--preflight-report-only",
+                "--skip-preflight",
             ]
         )
         assert args.db == "/tmp/x.db"
@@ -717,6 +865,13 @@ class TestBuildParser:
         assert args.auto_approve is True
         assert args.dry_run is True
         assert args.campaign_allowed is True
+        # Phase B preflight flags (#284) — Path constructor normalizes separators per platform
+        from pathlib import Path
+
+        assert args.preflight_threshold == 85
+        assert args.preflight_log_dir == Path("/tmp/reports")
+        assert args.preflight_report_only is True
+        assert args.skip_preflight is True
 
 
 class TestMain:

--- a/tests/unit/tools/test_preflight_check.py
+++ b/tests/unit/tools/test_preflight_check.py
@@ -80,7 +80,8 @@ class TestRunPreflightScaffold:
         assert isinstance(report, PreflightReport)
         assert report.repo_full_name == "owner/r"
         assert report.verdict == PreflightVerdict.PASS
-        assert report.score == 0
+        # Scaffold returns score == threshold so tool A's gate logic passes (#284).
+        assert report.score == DEFAULT_THRESHOLD
         assert report.threshold == DEFAULT_THRESHOLD
         assert report.gate_results == []
         assert report.score_breakdown == []
@@ -89,6 +90,8 @@ class TestRunPreflightScaffold:
     def test_custom_threshold_passed_through(self):
         report = run_preflight("owner/r", {"dead_url": "https://a", "candidate_url": "https://b"}, threshold=85)
         assert report.threshold == 85
+        # Scaffold mirrors score to threshold so tool A's gate logic passes (#284).
+        assert report.score == 85
 
     def test_explicit_run_id_used(self):
         report = run_preflight(
@@ -121,7 +124,8 @@ class TestMain:
         rc = main(["--repo", "owner/r", "--score-only"])
         out = capsys.readouterr().out.strip()
         assert rc == 0
-        assert out == "0"
+        # Scaffold score mirrors threshold so the integration's gate passes (#284).
+        assert out == str(DEFAULT_THRESHOLD)
 
     def test_report_writes_files(self, tmp_path, capsys):
         rc = main(["--repo", "owner/r", "--report", "--preflight-log-dir", str(tmp_path)])

--- a/tools/derive_replacement_prs.py
+++ b/tools/derive_replacement_prs.py
@@ -40,7 +40,9 @@ from gh_link_auditor import (  # noqa: E402
 )
 from gh_link_auditor.metrics.models import PROutcome  # noqa: E402
 from gh_link_auditor.pipeline.nodes.n6_submit_pr import n6_submit_pr  # noqa: E402
+from gh_link_auditor.preflight import PreflightVerdict, save_report  # noqa: E402
 from gh_link_auditor.unified_db import DEFAULT_DB_PATH, UnifiedDatabase  # noqa: E402
+from tools.preflight_check import DEFAULT_REPORT_DIR, DEFAULT_THRESHOLD, run_preflight  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Pure-compute helpers (unit-testable, no I/O)
@@ -331,6 +333,41 @@ def derive_and_submit(
                 continue
             repo_rows = safe_rows
 
+            # Phase B preflight (#284): run per-repo PRIOR TO FORK. No fork,
+            # no push, no PR until preflight passes. The representative
+            # candidate is the first safe row; gate / score implementations
+            # under #281 may refine to per-candidate evaluation later.
+            representative = {
+                "dead_url": safe_rows[0]["dead_url"],
+                "candidate_url": safe_rows[0]["candidate_url"],
+                "source_file": safe_rows[0].get("source_file", ""),
+                "line_number": safe_rows[0].get("line_number"),
+                "method": safe_rows[0].get("method", ""),
+            }
+            report = run_preflight(
+                repo_full_name=repo_full_name,
+                candidate=representative,
+                db=udb,
+                threshold=args.preflight_threshold,
+                skip_preflight_banner=args.skip_preflight,
+            )
+            save_report(report, args.preflight_log_dir)
+
+            if args.preflight_report_only:
+                skipped.append((repo_full_name, "preflight_report_only"))
+                continue
+
+            if not args.skip_preflight:
+                if report.verdict == PreflightVerdict.HARD_GATE_FAILED:
+                    skipped.append((repo_full_name, f"preflight_gate_{report.gate_failure_name}"))
+                    continue
+                if report.verdict == PreflightVerdict.NEEDS_OPERATOR_REVIEW:
+                    skipped.append((repo_full_name, "preflight_needs_review"))
+                    continue
+                if report.score < args.preflight_threshold:
+                    skipped.append((repo_full_name, f"preflight_score_{report.score}"))
+                    continue
+
             fixes = _rows_to_fixes(repo_rows)
             verdicts = _rows_to_verdicts(repo_rows)
 
@@ -410,6 +447,34 @@ def _build_parser() -> argparse.ArgumentParser:
             "acknowledge that the public-surface scrub (issue #278) is merged "
             "and the operator has manually reviewed the surface. Required to "
             "submit any PRs; omit to keep the pipeline paused."
+        ),
+    )
+    # Phase B preflight integration (#284). When --skip-preflight is set,
+    # a report is still written but the gate / score verdict does not
+    # block submission; the report carries a BAD ESCAPE banner.
+    p.add_argument(
+        "--preflight-threshold",
+        type=int,
+        default=DEFAULT_THRESHOLD,
+        help=f"minimum preflight score to submit (default: {DEFAULT_THRESHOLD})",
+    )
+    p.add_argument(
+        "--preflight-log-dir",
+        type=Path,
+        default=DEFAULT_REPORT_DIR,
+        help=f"directory for preflight reports (default: {DEFAULT_REPORT_DIR})",
+    )
+    p.add_argument(
+        "--preflight-report-only",
+        action="store_true",
+        help="run preflight on every candidate, write reports, exit without filing PRs",
+    )
+    p.add_argument(
+        "--skip-preflight",
+        action="store_true",
+        help=(
+            "BAD ESCAPE — write the preflight report with a warning banner but "
+            "do not gate submission on it. Default off. Use only for debugging."
         ),
     )
     return p

--- a/tools/preflight_check.py
+++ b/tools/preflight_check.py
@@ -66,11 +66,15 @@ def run_preflight(
         per-score evidence.
     """
     now = datetime.now(timezone.utc).isoformat()
+    # Scaffold returns ``score=threshold`` so a PASS verdict actually passes
+    # the integration's ``report.score < args.preflight_threshold`` check
+    # (#284). When per-gate / per-score issues land they'll set the real
+    # score from the score_breakdown sum.
     return PreflightReport(
         repo_full_name=repo_full_name,
         candidate=dict(candidate),
         verdict=PreflightVerdict.PASS,
-        score=0,
+        score=threshold,
         threshold=threshold,
         gate_results=[],
         score_breakdown=[],


### PR DESCRIPTION
## Summary

PR-γ of the Phase B preflight execution plan (#281 umbrella). Wires `run_preflight()` into `tools/derive_replacement_prs.derive_and_submit` PRIOR to `n6_submit_pr`. No fork, no push, no PR until preflight passes.

## Flags added to `tools/derive_replacement_prs.py`

- `--preflight-threshold N` (default `90`)
- `--preflight-log-dir PATH` (default `data/preflight-reports/`)
- `--preflight-report-only` — run preflight on every candidate, write reports, exit without filing
- `--skip-preflight` — BAD ESCAPE; report written with banner warning; verdict does NOT gate

## Verdict dispatch

| Verdict / condition | Action |
|---|---|
| `HARD_GATE_FAILED` | skip with reason `preflight_gate_<gate_failure_name>` |
| `NEEDS_OPERATOR_REVIEW` | skip with reason `preflight_needs_review` |
| `report.score < threshold` | skip with reason `preflight_score_<N>` |
| `--preflight-report-only` | skip every repo with reason `preflight_report_only` (reports still written) |
| `--skip-preflight` | bypass verdict checks; allow N6 to run; report carries BAD ESCAPE banner |
| Otherwise (PASS + score ≥ threshold) | proceed to N6 |

## Scaffold tweak

The PR-β scaffold's `run_preflight` returned `score=0`, which would have caused the integration's threshold check (`score < threshold`) to skip every PASS verdict. Bumped to `score=threshold` so PASS verdict actually passes by default. Per-gate / per-score issues will set real scores from the `score_breakdown` sum.

## Test plan

- [x] `poetry run pytest -q` → **2320 passed**, 1 skipped (was 2315 after PR-β; +5 from new `TestPreflightIntegration` class)
- [x] `poetry run ruff format --check .` + `poetry run ruff check .` → clean
- [x] `git grep -i -E '(A\+\+|PRs filed|contribution graph|green square|naked ambition)'` → 0 hits
- [x] `poetry run python tools/derive_replacement_prs.py --help` → lists 4 new flags
- [x] Hard gate, operator review, score-too-low, report-only, skip-preflight paths all covered

Closes #284
