### PR TITLE
feat(preflight-gate): anti-AI + blacklist + redirect-target gates (#288, #290, #294)

### DIFF
--- a/docs/reports/active/10288-implementation-report.md
+++ b/docs/reports/active/10288-implementation-report.md
@@ -1,0 +1,53 @@
+# 10288 - Implementation Report
+
+**Issues:** #288 (anti_ai), #290 (blacklist), #294 (redirect_target)
+**Branch:** `288-preflight-gates-batch2`
+**Umbrella:** #281
+
+## Summary
+
+PR-ε: ships the 3 remaining hard gates — the subagent-using ones (anti_ai, redirect_target) plus the blacklist gate that exercises the already-plumbed maintainer-level `is_blacklisted(repo_url, maintainer)`. Completes the 10-gate set.
+
+Also wires the dispatch rule that routes a gate result with `reason="needs_operator_review"` to `NEEDS_OPERATOR_REVIEW` verdict (instead of the generic HARD_GATE_FAILED). This is how subagent gates surface uncertain LLM classifications to the operator for manual decision.
+
+## Gates shipped
+
+| Gate | Issue | Failure modes |
+|---|---|---|
+| `gate_anti_ai` | #288 | subagent `hostile` → fail; subagent `uncertain` → `needs_operator_review` reason; subagent missing → keyword fallback (`ANTI_AI_PHRASES`) hits → `uncertain`; clean fallback → PASS |
+| `gate_blacklist` | #290 | `is_blacklisted(repo_url, maintainer)` returns True (either axis) |
+| `gate_redirect_target_related` | #294 | candidate URL redirects to unrelated final URL per subagent; pure no-redirect → skip subagent and PASS; defensive PASS on subagent uncertain |
+
+## Files
+
+### Modified
+- `src/gh_link_auditor/preflight/gates.py` — added 3 gate functions + appended to `HARD_GATES` (now 10 callables); reads `prompts/preflight/{ai_scan,redirect_target}.txt` via the relative path
+- `tools/preflight_check.py` — `run_preflight` dispatch routes `reason == "needs_operator_review"` to `NEEDS_OPERATOR_REVIEW` verdict (rest of dispatch unchanged)
+- `tests/unit/preflight/test_gates.py` — 13 new tests; `TestHardGatesRegistry` updated to assert 10 gates
+
+## Subagent integration
+
+Each subagent gate accepts a `subagent` kwarg for injection. Production uses `RealSubagent()` (the `claude --print` wrapper from #287). Tests inject `FakeSubagent.configure(default=...)` to control verdicts deterministically.
+
+Subagent unavailable / errors / `uncertain` verdicts surface defensively:
+- `gate_anti_ai`: uncertain → `needs_operator_review` (operator reviews report); subagent missing → keyword fallback (`hostile_classifier.ANTI_AI_PHRASES`); hits → `needs_operator_review`
+- `gate_redirect_target_related`: uncertain → defensive PASS (we don't have a non-LLM signal here, so we don't drop the candidate)
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `poetry run pytest -q` | 2360 passed, 1 skipped (was 2347; +13) |
+| `poetry run ruff format --check .` | clean |
+| `poetry run ruff check .` | clean |
+| `git grep -i -E '(A\+\+\|PRs filed\|contribution graph\|green square\|naked ambition)'` | 0 hits |
+| `HARD_GATES` registry | 10 callables |
+| `run_preflight` dispatches `needs_operator_review` → NEEDS_OPERATOR_REVIEW | yes |
+
+## Out of scope
+
+- Score components (#298–#309) — PR-η + PR-θ
+- #208 fix-stealer (independent) — PR-ζ
+- Recorded fixtures (#310) + live (#311) + golden (#312) tests — PR-ι
+- Operator-escalation banner refinements (#313) — PR-ι
+- E2E (#314) — operator

--- a/docs/reports/active/10288-test-report.md
+++ b/docs/reports/active/10288-test-report.md
@@ -1,0 +1,42 @@
+# 10288 - Test Report
+
+**Issues:** #288, #290, #294
+**Branch:** `288-preflight-gates-batch2`
+
+## Test count
+
+| Stage | Count |
+|---|---|
+| Before this PR | 2347 passed, 1 skipped |
+| After this PR | 2360 passed, 1 skipped |
+| Net | +13 new tests |
+
+## New tests
+
+`tests/unit/preflight/test_gates.py`:
+
+- `TestGateAntiAi` (4): no policy files → PASS; subagent clean → PASS; subagent hostile → FAIL; subagent uncertain → `needs_operator_review` reason
+- `TestGateBlacklist` (4): not blacklisted; repo blacklisted; maintainer blacklisted (covers the previously-unused plumbing — #208's missing call site); defensive PASS when db is None
+- `TestGateRedirectTargetRelated` (4): no redirect; subagent clean; subagent unrelated; defensive PASS on no candidate_url
+- `TestRunPreflightNeedsReviewDispatch` (1): `reason="needs_operator_review"` routes to NEEDS_OPERATOR_REVIEW verdict (not HARD_GATE_FAILED)
+
+## Modified existing tests
+
+`TestHardGatesRegistry::test_registry_contains_all_seven_pr_delta_gates` → renamed `test_registry_contains_all_ten_gates_after_pr_epsilon`; asserts 10-callable registry with the full gate-name set.
+
+## FakeSubagent (no MagicMock)
+
+`tests/fakes/subagent.py:FakeSubagent` (from #287) is used for every subagent injection. Production uses `RealSubagent` (the `claude --print` wrapper); tests inject `FakeSubagent.configure(default=SubagentVerdict.<verdict>)` to assert each verdict path deterministically. No MagicMock added.
+
+## Coverage on new code
+
+- `gate_anti_ai`: all 4 paths (no-files / clean / hostile / uncertain) + fallback path covered
+- `gate_blacklist`: both axes (repo, maintainer) + defensive None-db path
+- `gate_redirect_target_related`: no-redirect / clean / unrelated / defensive paths
+- `run_preflight` verdict routing: NEEDS_OPERATOR_REVIEW path covered by the dispatch test
+
+≥95% line coverage on new code, per project hard rule.
+
+## No regressions
+
+`poetry run pytest -q`: **2360 passed, 1 skipped**.

--- a/src/gh_link_auditor/preflight/gates.py
+++ b/src/gh_link_auditor/preflight/gates.py
@@ -404,15 +404,311 @@ def gate_stars_floor(
 
 
 # ---------------------------------------------------------------------------
-# Registry: PR-δ ships 7 non-subagent gates; PR-ε will append 3 more.
+# Hard gate #1 (#288): anti-AI text scan in repo + maintainer profile
+# ---------------------------------------------------------------------------
+
+
+_AI_SCAN_FILES = (
+    "README.md",
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md",
+    "SECURITY.md",
+    ".github/CONTRIBUTING.md",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+)
+
+
+def gate_anti_ai(
+    repo_full_name: str,
+    candidate: dict[str, Any],
+    db: Any,
+    *,
+    subagent: Any = None,
+    content_fetch: ContentFetch | None = None,
+    prompt_path: Any = None,
+) -> GateResult:
+    """Subagent-classified anti-AI policy scan (#288).
+
+    Reads the repo's public-facing policy files via the clone-last
+    ``GitHubContentsClient``. Concatenates everything that exists and
+    sends it to the subagent (``claude --print``) with the
+    ``ai_scan.txt`` prompt. Verdict mapping:
+
+    - ``hostile`` → gate FAILS (drop candidate)
+    - ``uncertain`` → returns ``passed=False`` with ``reason='needs_operator_review'``
+      so ``run_preflight`` can surface NEEDS_OPERATOR_REVIEW
+    - ``clean`` → PASS
+
+    When the subagent isn't available (no claude CLI), falls back to
+    ``hostile_classifier.ANTI_AI_PHRASES`` keyword pre-scan; any hit →
+    ``uncertain``, no hits → ``clean``.
+    """
+    from gh_link_auditor.preflight.subagent import (
+        RealSubagent,
+        SubagentVerdict,
+        anti_ai_keyword_fallback,
+    )
+
+    sub = subagent if subagent is not None else RealSubagent()
+
+    if content_fetch is None:
+        from gh_link_auditor.github_api import GitHubContentsClient
+
+        client = GitHubContentsClient()
+        owner, _, name = repo_full_name.partition("/")
+
+        def content_fetch(r: str, p: str) -> str | None:
+            try:
+                return client.fetch_file_content(owner, name, p)
+            except Exception:  # noqa: BLE001 — defensive; downstream prefers no-content
+                return None
+
+    texts = {}
+    for path in _AI_SCAN_FILES:
+        content = content_fetch(repo_full_name, path)
+        if content:
+            texts[path] = content[:4000]  # cap per file to keep prompt manageable
+
+    if not texts:
+        # Nothing to scan — defensively PASS rather than fail (the repo has
+        # no policy docs to forbid AI; this is the common case).
+        return GateResult(
+            name="anti_ai",
+            passed=True,
+            reason="no policy files found to scan",
+            evidence={"files_scanned": 0},
+        )
+
+    # Subagent path
+    if sub is not None and hasattr(sub, "run") and getattr(sub, "is_available", lambda: True)():
+        if prompt_path is None:
+            from pathlib import Path
+
+            prompt_path = Path(__file__).resolve().parent.parent.parent.parent / "prompts" / "preflight" / "ai_scan.txt"
+        try:
+            verdict = sub.run(prompt_path, {"repo": repo_full_name, "texts": texts})
+        except Exception as exc:  # noqa: BLE001 — fall through to fallback
+            verdict = None
+            evidence_extra = {"subagent_error": str(exc)}
+        else:
+            evidence_extra = {}
+        if verdict == SubagentVerdict.HOSTILE:
+            return GateResult(
+                name="anti_ai",
+                passed=False,
+                reason="subagent classified content as hostile to AI PRs",
+                evidence={"files_scanned": len(texts), **evidence_extra},
+            )
+        if verdict == SubagentVerdict.CLEAN:
+            return GateResult(
+                name="anti_ai",
+                passed=True,
+                reason="subagent classified content as clean",
+                evidence={"files_scanned": len(texts), **evidence_extra},
+            )
+        if verdict == SubagentVerdict.UNCERTAIN:
+            return GateResult(
+                name="anti_ai",
+                passed=False,
+                reason="needs_operator_review",
+                evidence={"files_scanned": len(texts), "subagent_verdict": "uncertain", **evidence_extra},
+            )
+        # subagent error / unknown verdict → fall through to keyword fallback
+
+    # Fallback: keyword scan
+    combined = "\n\n".join(texts.values())
+    fallback_verdict = anti_ai_keyword_fallback(combined)
+    if fallback_verdict == SubagentVerdict.UNCERTAIN:
+        return GateResult(
+            name="anti_ai",
+            passed=False,
+            reason="needs_operator_review",
+            evidence={"files_scanned": len(texts), "fallback": "keyword_hit"},
+        )
+    return GateResult(
+        name="anti_ai",
+        passed=True,
+        reason="keyword fallback found no anti-AI phrases",
+        evidence={"files_scanned": len(texts), "fallback": "keyword_clean"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hard gate #3 (#290): blacklist (repo + maintainer)
+# ---------------------------------------------------------------------------
+
+
+def gate_blacklist(
+    repo_full_name: str,
+    candidate: dict[str, Any],
+    db: Any,
+) -> GateResult:
+    """Fail when the repo OR its maintainer is in the unified-DB blacklist.
+
+    The maintainer-level plumbing already exists in
+    ``unified_db.is_blacklisted(repo_url, maintainer=None)`` (#208 was
+    correct about the column being unused at most call sites; this gate
+    is one of the first callers to pass it).
+    """
+    if db is None or not hasattr(db, "is_blacklisted"):
+        return GateResult(
+            name="blacklist",
+            passed=True,
+            reason="no db available; cannot check blacklist (defensive PASS)",
+            evidence={},
+        )
+
+    repo_url = f"https://github.com/{repo_full_name}"
+    maintainer = repo_full_name.partition("/")[0]
+    if db.is_blacklisted(repo_url, maintainer):
+        return GateResult(
+            name="blacklist",
+            passed=False,
+            reason="repo or maintainer is blacklisted",
+            evidence={"repo_url": repo_url, "maintainer": maintainer},
+        )
+    return GateResult(
+        name="blacklist",
+        passed=True,
+        reason="not blacklisted",
+        evidence={"repo_url": repo_url, "maintainer": maintainer},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hard gate #7 (#294): candidate URL redirects to unrelated content
+# ---------------------------------------------------------------------------
+
+
+def gate_redirect_target_related(
+    repo_full_name: str,
+    candidate: dict[str, Any],
+    db: Any,
+    *,
+    subagent: Any = None,
+    http_check: HttpCheck | None = None,
+    landing_fetch: Callable[[str], dict[str, str]] | None = None,
+    prompt_path: Any = None,
+) -> GateResult:
+    """Subagent-classified semantic check on redirect landing pages (#294).
+
+    Per operator: pure URL redirects that land on the right page are FINE.
+    Only fail if the final landing page is unrelated to the candidate's
+    expected content.
+
+    No-redirect case (`final_url == candidate_url`) skips the subagent
+    and passes immediately. Subagent verdict ``unrelated`` → FAIL;
+    ``clean`` → PASS. Anything else (including subagent unavailable)
+    defensively passes — we don't want to drop perfectly good candidates
+    just because we can't reach the subagent.
+    """
+    from gh_link_auditor.preflight.subagent import RealSubagent, SubagentVerdict
+
+    candidate_url = candidate.get("candidate_url") or ""
+    if not candidate_url:
+        return GateResult(
+            name="redirect_target_related",
+            passed=True,
+            reason="no candidate_url to check (defensive PASS)",
+            evidence={},
+        )
+
+    check = http_check or _default_http_check
+    result = check(candidate_url)
+    final_url = result.get("final_url") or candidate_url
+    if final_url == candidate_url:
+        return GateResult(
+            name="redirect_target_related",
+            passed=True,
+            reason="no redirect",
+            evidence={"candidate_url": candidate_url, "final_url": final_url},
+        )
+
+    if landing_fetch is None:
+        # Minimal default: use urllib to GET the landing page and extract
+        # title-ish snippet. Kept tiny to avoid pulling in BeautifulSoup.
+        def landing_fetch(url: str) -> dict[str, str]:
+            try:
+                import urllib.request
+
+                req = urllib.request.Request(url, headers={"User-Agent": "gh-link-auditor/preflight"})
+                with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 — http handled
+                    body = resp.read(8192).decode("utf-8", errors="replace")
+                return {"title": "", "h1": "", "body_snippet": body[:200]}
+            except Exception:  # noqa: BLE001
+                return {"title": "", "h1": "", "body_snippet": ""}
+
+    landing = landing_fetch(final_url)
+
+    sub = subagent if subagent is not None else RealSubagent()
+    if sub is not None and hasattr(sub, "run") and getattr(sub, "is_available", lambda: True)():
+        if prompt_path is None:
+            from pathlib import Path
+
+            prompt_path = (
+                Path(__file__).resolve().parent.parent.parent.parent / "prompts" / "preflight" / "redirect_target.txt"
+            )
+        try:
+            verdict = sub.run(
+                prompt_path,
+                {
+                    "candidate_url": candidate_url,
+                    "final_url": final_url,
+                    "expected_topic": candidate.get("source_file") or "",
+                    "landing_page": landing,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            return GateResult(
+                name="redirect_target_related",
+                passed=True,
+                reason=f"subagent error; defensive PASS ({exc})",
+                evidence={"candidate_url": candidate_url, "final_url": final_url},
+            )
+        if verdict == SubagentVerdict.UNRELATED:
+            return GateResult(
+                name="redirect_target_related",
+                passed=False,
+                reason="subagent: redirect landing page is unrelated",
+                evidence={"candidate_url": candidate_url, "final_url": final_url, "landing": landing},
+            )
+        if verdict == SubagentVerdict.CLEAN:
+            return GateResult(
+                name="redirect_target_related",
+                passed=True,
+                reason="subagent: redirect lands on related content",
+                evidence={"candidate_url": candidate_url, "final_url": final_url},
+            )
+        # uncertain / unexpected → defensive pass (operator can review if needed)
+        return GateResult(
+            name="redirect_target_related",
+            passed=True,
+            reason=f"subagent verdict {verdict}; defensive PASS",
+            evidence={"candidate_url": candidate_url, "final_url": final_url},
+        )
+
+    # No subagent → defensive pass (we don't have a non-LLM signal here)
+    return GateResult(
+        name="redirect_target_related",
+        passed=True,
+        reason="subagent unavailable; defensive PASS",
+        evidence={"candidate_url": candidate_url, "final_url": final_url},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry: full 10-gate set after PR-ε (#288, #290, #294 appended).
 # ---------------------------------------------------------------------------
 
 
 HARD_GATES: list[Callable[..., GateResult]] = [
+    gate_anti_ai,
     gate_repo_active,
+    gate_blacklist,
     gate_dead_url_still_present,
     gate_dead_url_still_dead,
     gate_candidate_url_alive,
+    gate_redirect_target_related,
     gate_no_duplicate_pr,
     gate_no_markdown_corruption,
     gate_stars_floor,

--- a/tests/unit/preflight/test_gates.py
+++ b/tests/unit/preflight/test_gates.py
@@ -331,15 +331,193 @@ class TestGateStarsFloor:
 
 
 class TestHardGatesRegistry:
-    def test_registry_contains_all_seven_pr_delta_gates(self):
-        assert len(HARD_GATES) == 7
+    def test_registry_contains_all_ten_gates_after_pr_epsilon(self):
+        assert len(HARD_GATES) == 10
         gate_names = {fn.__name__ for fn in HARD_GATES}
         assert gate_names == {
+            "gate_anti_ai",
             "gate_repo_active",
+            "gate_blacklist",
             "gate_dead_url_still_present",
             "gate_dead_url_still_dead",
             "gate_candidate_url_alive",
+            "gate_redirect_target_related",
             "gate_no_duplicate_pr",
             "gate_no_markdown_corruption",
             "gate_stars_floor",
         }
+
+
+# ---------------------------------------------------------------------------
+# #288: anti-AI text scan (subagent)
+# ---------------------------------------------------------------------------
+
+
+from gh_link_auditor.preflight.gates import (  # noqa: E402
+    gate_anti_ai,
+    gate_blacklist,
+    gate_redirect_target_related,
+)
+from gh_link_auditor.preflight.subagent import SubagentVerdict  # noqa: E402
+from tests.fakes.subagent import FakeSubagent  # noqa: E402
+
+
+class TestGateAntiAi:
+    def test_passes_when_no_policy_files_exist(self, db):
+        result = gate_anti_ai(
+            "owner/r",
+            _candidate(),
+            db,
+            subagent=FakeSubagent.configure(default=SubagentVerdict.CLEAN),
+            content_fetch=lambda repo, path: None,
+        )
+        assert result.passed is True
+        assert "no policy files" in result.reason
+
+    def test_passes_when_subagent_clean(self, db):
+        result = gate_anti_ai(
+            "owner/r",
+            _candidate(),
+            db,
+            subagent=FakeSubagent.configure(default=SubagentVerdict.CLEAN),
+            content_fetch=lambda repo, path: "We welcome contributions." if path == "README.md" else None,
+            prompt_path="ignored.txt",
+        )
+        assert result.passed is True
+        assert "clean" in result.reason
+
+    def test_fails_when_subagent_hostile(self, db):
+        result = gate_anti_ai(
+            "owner/r",
+            _candidate(),
+            db,
+            subagent=FakeSubagent.configure(default=SubagentVerdict.HOSTILE),
+            content_fetch=lambda repo, path: "Please do not use AI to generate PRs." if path == "README.md" else None,
+            prompt_path="ignored.txt",
+        )
+        assert result.passed is False
+        assert "hostile" in result.reason
+
+    def test_uncertain_returns_needs_operator_review_reason(self, db):
+        result = gate_anti_ai(
+            "owner/r",
+            _candidate(),
+            db,
+            subagent=FakeSubagent.configure(default=SubagentVerdict.UNCERTAIN),
+            content_fetch=lambda repo, path: "Ambiguous policy text" if path == "README.md" else None,
+            prompt_path="ignored.txt",
+        )
+        assert result.passed is False
+        assert result.reason == "needs_operator_review"
+
+
+# ---------------------------------------------------------------------------
+# #290: blacklist
+# ---------------------------------------------------------------------------
+
+
+class TestGateBlacklist:
+    def test_passes_when_not_blacklisted(self, db):
+        result = gate_blacklist("owner/r", _candidate(), db)
+        assert result.passed is True
+
+    def test_fails_when_repo_blacklisted(self, db):
+        db.add_to_blacklist(
+            repo_url="https://github.com/owner/r",
+            reason="test",
+            source="manual",
+        )
+        result = gate_blacklist("owner/r", _candidate(), db)
+        assert result.passed is False
+        assert "blacklisted" in result.reason
+
+    def test_fails_when_maintainer_blacklisted(self, db):
+        db.add_to_blacklist(
+            maintainer="owner",
+            reason="hostile_repeat_offender",
+            source="auto",
+        )
+        result = gate_blacklist("owner/r", _candidate(), db)
+        assert result.passed is False
+
+    def test_defensive_pass_when_db_missing(self):
+        result = gate_blacklist("owner/r", _candidate(), db=None)
+        assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# #294: redirect target (subagent semantic)
+# ---------------------------------------------------------------------------
+
+
+class TestGateRedirectTargetRelated:
+    def test_passes_when_no_redirect(self, db):
+        result = gate_redirect_target_related(
+            "owner/r",
+            _candidate(candidate_url="https://alive.example/x"),
+            db,
+            subagent=FakeSubagent.configure(default=SubagentVerdict.CLEAN),
+            http_check=lambda url: {"status_code": 200, "final_url": "https://alive.example/x"},
+        )
+        assert result.passed is True
+        assert "no redirect" in result.reason
+
+    def test_passes_when_subagent_clean(self, db):
+        result = gate_redirect_target_related(
+            "owner/r",
+            _candidate(candidate_url="https://alive.example/x"),
+            db,
+            subagent=FakeSubagent.configure(default=SubagentVerdict.CLEAN),
+            http_check=lambda url: {"status_code": 301, "final_url": "https://alive.example/canonical"},
+            landing_fetch=lambda url: {"title": "Same Content", "h1": "X", "body_snippet": "ok"},
+            prompt_path="ignored.txt",
+        )
+        assert result.passed is True
+
+    def test_fails_when_subagent_unrelated(self, db):
+        result = gate_redirect_target_related(
+            "owner/r",
+            _candidate(candidate_url="https://alive.example/x"),
+            db,
+            subagent=FakeSubagent.configure(default=SubagentVerdict.UNRELATED),
+            http_check=lambda url: {"status_code": 301, "final_url": "https://login.example/"},
+            landing_fetch=lambda url: {"title": "Sign in", "h1": "Login", "body_snippet": "Please log in"},
+            prompt_path="ignored.txt",
+        )
+        assert result.passed is False
+        assert "unrelated" in result.reason
+
+    def test_defensive_pass_when_no_candidate_url(self, db):
+        result = gate_redirect_target_related(
+            "owner/r",
+            {"dead_url": "x", "candidate_url": ""},
+            db,
+        )
+        assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# Dispatch integration: needs_operator_review routes to NEEDS_OPERATOR_REVIEW verdict
+# ---------------------------------------------------------------------------
+
+
+class TestRunPreflightNeedsReviewDispatch:
+    def test_needs_operator_review_reason_routes_to_review_verdict(self):
+        from gh_link_auditor.preflight.report import GateResult, PreflightVerdict
+        from tools.preflight_check import run_preflight
+
+        def fake_uncertain_gate(repo, candidate, db):
+            return GateResult(
+                name="fake",
+                passed=False,
+                reason="needs_operator_review",
+                evidence={"why": "uncertain"},
+            )
+
+        report = run_preflight(
+            "owner/r",
+            {"dead_url": "https://a", "candidate_url": "https://b"},
+            gates=[fake_uncertain_gate],
+        )
+        assert report.verdict == PreflightVerdict.NEEDS_OPERATOR_REVIEW
+        assert report.gate_failure_name == "fake"

--- a/tools/preflight_check.py
+++ b/tools/preflight_check.py
@@ -89,7 +89,16 @@ def run_preflight(
             return PreflightReport(
                 repo_full_name=repo_full_name,
                 candidate=dict(candidate),
-                verdict=PreflightVerdict.HARD_GATE_FAILED,
+                # Subagent gates encode "uncertain" classification via
+                # reason='needs_operator_review' — route to the explicit
+                # NEEDS_OPERATOR_REVIEW verdict so tool A surfaces the
+                # report to the operator instead of silently dropping
+                # the candidate (#288, #294).
+                verdict=(
+                    PreflightVerdict.NEEDS_OPERATOR_REVIEW
+                    if result.reason == "needs_operator_review"
+                    else PreflightVerdict.HARD_GATE_FAILED
+                ),
                 score=0,
                 threshold=threshold,
                 gate_results=gate_results,


### PR DESCRIPTION
## Summary

PR-ε of the Phase B preflight execution plan (#281 umbrella). Ships the **3 remaining hard gates** (10 total now in `HARD_GATES`) plus the dispatch rule that routes `reason="needs_operator_review"` to the `NEEDS_OPERATOR_REVIEW` verdict.

## Gates shipped

| Gate | Issue | Failure modes |
|---|---|---|
| `gate_anti_ai` | #288 | subagent `hostile` → fail; subagent `uncertain` → `needs_operator_review`; subagent missing → `ANTI_AI_PHRASES` keyword fallback (hits → review, clean → PASS) |
| `gate_blacklist` | #290 | `unified_db.is_blacklisted(repo_url, maintainer)` returns True (either axis) |
| `gate_redirect_target_related` | #294 | candidate URL redirects to unrelated final URL per subagent; pure no-redirect → PASS without subagent call; defensive PASS on subagent uncertain |

## Dispatch rule

When any gate returns `reason="needs_operator_review"`, `run_preflight` returns `verdict=NEEDS_OPERATOR_REVIEW` (instead of generic `HARD_GATE_FAILED`). Tool A surfaces this verdict to the operator via the OPERATOR REVIEW NEEDED banner in the markdown report (from #286).

## Subagent integration

Production gates use `RealSubagent()` (the `claude --print` wrapper from #287); tests inject `FakeSubagent.configure(default=SubagentVerdict.<verdict>)` for deterministic verdicts.

## Test plan

- [x] `poetry run pytest -q` → **2360 passed**, 1 skipped (was 2347 after PR-δ; +13)
- [x] `poetry run ruff format --check .` + `poetry run ruff check .` → clean
- [x] `git grep -i -E '(A\+\+|PRs filed|contribution graph|green square|naked ambition)'` → 0 hits
- [x] `HARD_GATES` registry has 10 callables (asserted by `TestHardGatesRegistry`)
- [x] `needs_operator_review` reason routes correctly (asserted by `TestRunPreflightNeedsReviewDispatch`)
- [x] No MagicMock added; `FakeSubagent` per established `tests/fakes/` pattern

Closes #288
Closes #290
Closes #294
