### PR TITLE
feat: donation URL skip + dead-domain Google search filter (#243, #213)

### DIFF
--- a/docs/reports/active/10243-implementation-report.md
+++ b/docs/reports/active/10243-implementation-report.md
@@ -1,0 +1,55 @@
+# 10243 - Implementation Report
+
+**Issues:** #243 (donation skip), #213 (dead-domain Google search)
+**Branch:** `243-nice-to-haves`
+**Umbrella:** N/A — both are standalone "nice-to-haves before scaling" from the paranoid triage
+
+## Summary
+
+PR-κ: ships the 2 paranoid-triage nice-to-haves. Both are small false-positive-reduction work that improves the operator's signal-to-noise upstream of preflight.
+
+## #243 — Donation / sponsorship URL categorical skip
+
+Donation URLs (Patreon, Ko-fi, GitHub Sponsors, etc.) are intentional support links the maintainer placed. They sometimes return 4xx (auth-required, campaign paused, account closed, account moved), but "fixing" them would break the maintainer's revenue link. Categorical skip is the right behavior.
+
+- Added `DONATION_DOMAINS` set in `src/gh_link_auditor/false_positives.py` (15 domains)
+- Added `_DONATION_PATH_PREFIXES` tuple for path-prefix matches on multi-purpose domains (`github.com/sponsors/`, `paypal.com/donate`, `stripe.com/donate`)
+- Added `is_donation_url(url)` predicate with hostname + subdomain-suffix + path-prefix matching, www-prefix normalization
+- Wired into the master `is_false_positive` dispatch right after `is_always_alive_domain` (before status-based checks)
+
+## #213 — Skip `site:DOMAIN` queries when domain is dead
+
+`generate_google_searches` (`src/gh_link_auditor/pipeline/nodes/n4_human_review.py`) emits `site:domain.com` queries even when the domain itself is gone (DNS failure, expired cert, whole-domain rebrand). Google returns zero results for dead domains — the operator clicks a useless search and gets no signal.
+
+- Added `dead_domain: bool = False` parameter
+- When `dead_domain=True`, skip the `site:{domain}` queries; emit topic + URL-triangulation searches only
+- Default behavior unchanged (backward-compatible)
+
+The caller (N4) doesn't yet know whether to set `dead_domain=True` — that signal will come from the failure-class classification work in #261. Until then, the parameter exists with sensible default, ready to wire up.
+
+## Files
+
+### Modified
+
+- `src/gh_link_auditor/false_positives.py` — `DONATION_DOMAINS`, `_DONATION_PATH_PREFIXES`, `is_donation_url`, dispatch in `is_false_positive`
+- `src/gh_link_auditor/pipeline/nodes/n4_human_review.py` — `generate_google_searches` accepts `dead_domain` keyword
+- `tests/unit/test_false_positives.py` — 5 new tests in `TestIsFalsePositive` for the donation dispatch + new `TestIsDonationUrl` class (9 tests for the predicate)
+- `tests/unit/pipeline/test_n4.py` — 3 new tests in `TestGenerateGoogleSearches` covering `dead_domain=True` / `dead_domain=False` / dead-domain with no name
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `poetry run pytest -q` | 2424 passed, 1 skipped (was 2407; +17) |
+| `poetry run ruff format --check .` + `ruff check .` | clean |
+| `git grep banned regex` | 0 hits |
+| `is_donation_url("https://www.patreon.com/bePatron?u=51974655")` | True |
+| `is_donation_url("https://github.com/sponsors/martymcenroe")` | True |
+| `is_donation_url("https://github.com/martymcenroe/gh-link-auditor")` | False |
+| `generate_google_searches(url, dead_domain=True)` — no `site:` queries | yes |
+
+## Out of scope
+
+- Wiring `dead_domain=True` into N4 callers — requires the failure-class classification from #261
+- Subagent-driven domain-rebrand detection — #262
+- Phase B preflight (separate PR series, now complete: PR-α through PR-θ)

--- a/docs/reports/active/10243-test-report.md
+++ b/docs/reports/active/10243-test-report.md
@@ -1,0 +1,36 @@
+# 10243 - Test Report
+
+**Issues:** #243, #213
+**Branch:** `243-nice-to-haves`
+
+## Test count
+
+| Stage | Count |
+|---|---|
+| Before this PR | 2407 passed, 1 skipped |
+| After this PR | 2424 passed, 1 skipped |
+| Net | +17 new tests |
+
+## New tests
+
+### `tests/unit/test_false_positives.py` (14 tests)
+
+- `TestIsFalsePositive` (5 new): patreon, github sponsors path, ko-fi, buymeacoffee → False positive; github regular repo path → not flagged
+- `TestIsDonationUrl` (9 tests): patreon (with + without www); opencollective; github sponsors path; github non-sponsors path (not flagged); paypal /donate; paypal regular URL (not flagged); subdomain match; unknown domain not flagged
+
+### `tests/unit/pipeline/test_n4.py` (3 tests)
+
+- `test_dead_domain_skips_site_queries` — `dead_domain=True` emits no `site:` query; still has topic + URL searches
+- `test_dead_domain_false_keeps_site_queries` — default behavior preserved
+- `test_dead_domain_with_no_name_still_emits_url_triangulation` — bare-domain + dead_domain=True still produces the URL-quote triangulation search
+
+## No regressions
+
+`poetry run pytest -q`: **2424 passed, 1 skipped**.
+
+## Lint
+
+| Check | Result |
+|---|---|
+| `poetry run ruff format --check .` | 246 files already formatted |
+| `poetry run ruff check .` | All checks passed |

--- a/src/gh_link_auditor/false_positives.py
+++ b/src/gh_link_auditor/false_positives.py
@@ -75,6 +75,36 @@ API_TEST_DOMAINS: set[str] = {
     "httpbin.com",
 }
 
+# Donation / sponsorship platforms (#243). These are intentional support
+# links — maintainers don't want them "fixed" if they go 4xx (auth-required,
+# campaign paused, account closed, etc.). Replacing them would break the
+# maintainer's revenue link.
+DONATION_DOMAINS: set[str] = {
+    "patreon.com",
+    "opencollective.com",
+    "buymeacoffee.com",
+    "ko-fi.com",
+    "liberapay.com",
+    "paypal.me",
+    "gofundme.com",
+    "kickstarter.com",
+    "indiegogo.com",
+    "donate.mozilla.org",
+    "donorbox.org",
+    "givebutter.com",
+    "venmo.com",
+    "cash.app",
+    "tippin.me",
+}
+
+# Path-prefix matches for donation routes hosted on multi-purpose domains.
+# E.g. ``github.com/sponsors/<user>`` is donation; ``github.com/<user>/<repo>`` is not.
+_DONATION_PATH_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("github.com", "/sponsors/"),
+    ("paypal.com", "/donate"),
+    ("stripe.com", "/donate"),
+)
+
 # Placeholder path segments that indicate template/example URLs.
 _PLACEHOLDER_PATH_RE = re.compile(
     r"(YOUR[_-]USERNAME|YOUR[_-]ORG|YOUR[_-]REPO|YOUR[_-]TOKEN"
@@ -266,6 +296,37 @@ def is_auth_wall(http_status: int | None) -> bool:
     return http_status in (401, 402)
 
 
+def is_donation_url(url: str) -> bool:
+    """True if the URL is a donation / sponsorship link (#243).
+
+    Matches both straight-domain matches (e.g. ``patreon.com``) and
+    path-prefix matches for donation routes on multi-purpose domains
+    (e.g. ``github.com/sponsors/<user>``).
+    """
+    hostname = _safe_hostname(url)
+    if not hostname:
+        return False
+    # Strip leading "www." for normalization
+    bare = hostname.removeprefix("www.")
+    if bare in DONATION_DOMAINS:
+        return True
+    # Subdomain-suffix match (e.g. "shop.patreon.com" → "patreon.com")
+    for domain in DONATION_DOMAINS:
+        if bare.endswith("." + domain):
+            return True
+    # Path-prefix match for multi-purpose domains
+    try:
+        from urllib.parse import urlparse
+
+        path = urlparse(url).path or ""
+    except ValueError:
+        return False
+    for domain, prefix in _DONATION_PATH_PREFIXES:
+        if bare == domain and path.startswith(prefix):
+            return True
+    return False
+
+
 def is_false_positive(url: str, http_status: int | None = None) -> bool:
     """Master check: is this URL a known false positive?
 
@@ -286,6 +347,11 @@ def is_false_positive(url: str, http_status: int | None = None) -> bool:
         return True
 
     if is_always_alive_domain(url):
+        return True
+
+    # Donation / sponsorship URLs are intentional support links — never
+    # candidates for "fixing" (#243).
+    if is_donation_url(url):
         return True
 
     if http_status is not None:

--- a/src/gh_link_auditor/pipeline/nodes/n4_human_review.py
+++ b/src/gh_link_auditor/pipeline/nodes/n4_human_review.py
@@ -38,7 +38,7 @@ def _prompt_replacement_url() -> str | None:
         print("  Invalid — must start with http:// or https://")
 
 
-def generate_google_searches(dead_url: str) -> list[str]:
+def generate_google_searches(dead_url: str, *, dead_domain: bool = False) -> list[str]:
     """Construct 3-5 diagnostic Google search URLs for a dead URL (#196).
 
     Pure function; no network. Returned URLs are clickable in standard terminals.
@@ -48,6 +48,15 @@ def generate_google_searches(dead_url: str) -> list[str]:
         - ``"{humanized_name}" replacement`` — did it get renamed?
         - ``"{humanized_name}" successor OR deprecated`` — is it dead?
         - ``"{full_dead_url}"`` — triangulation: who else links to this?
+
+    Args:
+        dead_url: the broken URL we're trying to find a replacement for.
+        dead_domain: when True, skip the ``site:{domain}`` queries (#213).
+            The caller signals this when the domain itself is gone (DNS
+            failure, certificate expired beyond rescue, whole-domain
+            rebrand to a new host). Google's ``site:`` operator returns
+            zero results for dead domains — emitting those queries
+            wastes an operator click and gives no signal.
     """
     parsed = urlparse(dead_url)
     domain = (parsed.hostname or "").strip()
@@ -60,10 +69,13 @@ def generate_google_searches(dead_url: str) -> list[str]:
 
     base = "https://www.google.com/search?q="
     searches: list[str] = []
-    if domain and name:
-        searches.append(base + quote_plus(f"site:{domain} {name}"))
-    elif domain:
-        searches.append(base + quote_plus(f"site:{domain}"))
+    # Site: queries are only useful when the domain itself is still alive.
+    # When dead_domain=True, skip them and rely on name + triangulation only (#213).
+    if not dead_domain:
+        if domain and name:
+            searches.append(base + quote_plus(f"site:{domain} {name}"))
+        elif domain:
+            searches.append(base + quote_plus(f"site:{domain}"))
     if name:
         searches.append(base + quote_plus(f'"{name}" replacement'))
         searches.append(base + quote_plus(f'"{name}" successor OR deprecated OR shutdown'))

--- a/tests/unit/pipeline/test_n4.py
+++ b/tests/unit/pipeline/test_n4.py
@@ -366,6 +366,32 @@ class TestGenerateGoogleSearches:
         searches = generate_google_searches("https://www.enthought.com/")
         assert len(searches) >= 1
 
+    # ------------------------------------------------------------------
+    # #213: dead_domain=True skips site: queries
+    # ------------------------------------------------------------------
+
+    def test_dead_domain_skips_site_queries(self) -> None:
+        searches = generate_google_searches(
+            "https://dead-domain.example/product/canopy/",
+            dead_domain=True,
+        )
+        # No search should contain site:
+        assert not any("site%3A" in s for s in searches)
+        # Should still have the topic + URL-triangulation searches
+        assert len(searches) >= 2
+
+    def test_dead_domain_false_keeps_site_queries(self) -> None:
+        # Default behavior is unchanged
+        searches = generate_google_searches("https://www.enthought.com/product/canopy/")
+        assert any("site%3A" in s for s in searches)
+
+    def test_dead_domain_with_no_name_still_emits_url_triangulation(self) -> None:
+        # Bare domain + dead_domain=True → only the URL triangulation query remains
+        searches = generate_google_searches("https://dead-domain.example/", dead_domain=True)
+        assert any("dead-domain.example" in s.lower() for s in searches)
+        # No site: query
+        assert not any("site%3A" in s for s in searches)
+
 
 class TestBuildGithubSourceUrl:
     """Tests for build_github_source_url() (#194)."""

--- a/tests/unit/test_false_positives.py
+++ b/tests/unit/test_false_positives.py
@@ -292,6 +292,77 @@ class TestIsFalsePositive:
         # status code to be flagged — they aren't always-alive, just bot-blocked.
         assert is_false_positive("https://medium.com/something") is False
 
+    # ------------------------------------------------------------------
+    # #243: donation / sponsorship URL categorical skip
+    # ------------------------------------------------------------------
+
+    def test_patreon_donation_url_is_false_positive(self) -> None:
+        assert is_false_positive("https://www.patreon.com/bePatron?u=51974655") is True
+
+    def test_github_sponsors_path_is_false_positive(self) -> None:
+        assert is_false_positive("https://github.com/sponsors/martymcenroe") is True
+
+    def test_ko_fi_is_false_positive(self) -> None:
+        assert is_false_positive("https://ko-fi.com/someuser") is True
+
+    def test_buymeacoffee_is_false_positive(self) -> None:
+        assert is_false_positive("https://www.buymeacoffee.com/someuser") is True
+
+    def test_github_non_sponsors_path_not_filtered_as_donation(self) -> None:
+        # github.com/<user>/<repo> isn't a donation link
+        # (Use a real-ish path that doesn't trip placeholder regex from #97)
+        assert is_false_positive("https://github.com/martymcenroe/gh-link-auditor") is False
+
+
+class TestIsDonationUrl:
+    """Tests for is_donation_url() (#243)."""
+
+    def test_patreon(self) -> None:
+        from gh_link_auditor.false_positives import is_donation_url
+
+        assert is_donation_url("https://www.patreon.com/bePatron?u=51974655") is True
+
+    def test_patreon_no_www(self) -> None:
+        from gh_link_auditor.false_positives import is_donation_url
+
+        assert is_donation_url("https://patreon.com/someuser") is True
+
+    def test_opencollective(self) -> None:
+        from gh_link_auditor.false_positives import is_donation_url
+
+        assert is_donation_url("https://opencollective.com/django") is True
+
+    def test_github_sponsors_path(self) -> None:
+        from gh_link_auditor.false_positives import is_donation_url
+
+        assert is_donation_url("https://github.com/sponsors/martymcenroe") is True
+
+    def test_github_regular_repo_path_not_donation(self) -> None:
+        from gh_link_auditor.false_positives import is_donation_url
+
+        assert is_donation_url("https://github.com/martymcenroe/gh-link-auditor") is False
+
+    def test_paypal_donate_path(self) -> None:
+        from gh_link_auditor.false_positives import is_donation_url
+
+        assert is_donation_url("https://www.paypal.com/donate?hosted_button_id=xxx") is True
+
+    def test_paypal_regular_url_not_donation(self) -> None:
+        from gh_link_auditor.false_positives import is_donation_url
+
+        assert is_donation_url("https://www.paypal.com/signin") is False
+
+    def test_subdomain_of_donation_platform(self) -> None:
+        from gh_link_auditor.false_positives import is_donation_url
+
+        # subdomain.patreon.com should still be flagged
+        assert is_donation_url("https://shop.patreon.com/x") is True
+
+    def test_unknown_domain_not_donation(self) -> None:
+        from gh_link_auditor.false_positives import is_donation_url
+
+        assert is_donation_url("https://random-blog.com/post") is False
+
     def test_github_auth_required(self) -> None:
         assert is_false_positive("https://github.com/org/repo/issues/new", http_status=404) is True
 


### PR DESCRIPTION
## Summary

PR-κ — the 2 paranoid-triage "nice-to-haves before scaling" from the original Phase B plan.

### #243 — Donation / sponsorship URL categorical skip

Donation URLs (Patreon, Ko-fi, GitHub Sponsors, paypal.com/donate, etc.) are intentional support links. They sometimes return 4xx but "fixing" them would break the maintainer's revenue link.

- `DONATION_DOMAINS` set (15 platforms) + `_DONATION_PATH_PREFIXES` for path-prefix matches on multi-purpose domains
- `is_donation_url(url)` with hostname / subdomain-suffix / path-prefix matching + `www.` normalization
- Wired into `is_false_positive` master dispatch

### #213 — Skip `site:DOMAIN` Google queries when domain is dead

`generate_google_searches` now accepts `dead_domain: bool = False`. When True, skips the useless `site:{domain}` queries (Google returns zero results for dead domains). Backward-compatible default.

N4 callers don't yet know whether to set `dead_domain=True`; that signal will come from #261 (failure-class classification). Until then, the parameter exists with sensible default, ready to wire.

## Test plan

- [x] `poetry run pytest -q` → **2424 passed**, 1 skipped (was 2407 after PR-θ; +17)
- [x] `poetry run ruff format --check .` + `poetry run ruff check .` → clean
- [x] `is_donation_url("https://www.patreon.com/...")` → True
- [x] `is_donation_url("https://github.com/sponsors/...")` → True
- [x] `is_donation_url("https://github.com/martymcenroe/gh-link-auditor")` → False
- [x] `generate_google_searches(url, dead_domain=True)` → no `site:` queries

Closes #243
Closes #213
