### PR TITLE
feat(classifier): fix-stealer diff-equivalence + maintainer blacklist (#208)

### DIFF
--- a/docs/reports/active/10208-implementation-report.md
+++ b/docs/reports/active/10208-implementation-report.md
@@ -1,0 +1,51 @@
+# 10208 - Implementation Report
+
+**Issue:** #208 — `feat(classifier)`: fix-stealer diff-equivalence + maintainer-level blacklist DB
+**Branch:** `208-fix-stealer-diff`
+
+## Summary
+
+PR-ζ: ships the diff-equivalence fix-stealer detector that complements the existing keyword-based `_check_maintainer_fixed`. When a maintainer closes our PR and then commits the **byte-equivalent URL substitution** as their own work, the new detector confirms it and auto-blacklists the **maintainer** (not just the repo) — so other repos that maintainer controls are also excluded from future PRs.
+
+The canonical case: `pallets/flask#6019` / `davidism` (2026-05-13). Maintainer closed our PR with anti-AI language, then committed our exact fix 8 minutes later. The existing keyword heuristic would have caught it loosely; this PR adds the strict signal.
+
+## What ships
+
+### `_extract_pr_url_change(owner, repo, pr_number, *, gh_run=None)`
+Parses `gh pr diff` output for a clean single-URL substitution. Returns `(dead_url, candidate_url)` tuple or `None` (multi-URL diffs, no-URL diffs, gh failures all defensively return `None` — the diff-equivalence path doesn't apply to them).
+
+### `check_fix_steal_diff(owner, repo, pr_number, *, gh_run=None, gh_get=None, lookback_commits=20) -> tuple[bool, str | None]`
+1. Extract the PR's URL swap (returns `(False, None)` if not parseable)
+2. Fetch the most recent `lookback_commits` commits on the default branch
+3. For each commit, fetch its diff and look for a byte-equivalent `-dead_url` / `+candidate_url` substitution
+4. Return `(True, stealing_sha)` on first match, else `(False, None)`
+
+### `refresh_pr_outcomes` integration
+
+When the existing `_check_maintainer_fixed` (keyword) flags a fix-steal AND `check_fix_steal_diff` confirms it byte-for-byte:
+- Outcome's `rejection_reason` upgraded to include the stealing commit SHA
+- Maintainer added to blacklist (via the previously-unused `maintainer=` axis on `udb.add_to_blacklist`)
+- Logged as `Auto-blacklisted MAINTAINER (diff-confirmed fix steal)`
+
+This activates the maintainer-level plumbing in `unified_db.is_blacklisted(repo_url, maintainer)` that has been latent in the codebase. Hard gate #3 (#290) already passes maintainer to that function, so any candidate against a fix-stealer's other repos will now be blocked at preflight.
+
+## Files
+
+- `src/gh_link_auditor/pr_tracker.py` — added `_extract_pr_url_change`, `check_fix_steal_diff`; integrated into `refresh_pr_outcomes` after the keyword check; added `re` + `Any` imports
+- `tests/unit/test_pr_tracker.py` — new `TestExtractPrUrlChange` class (4 tests) + new `TestCheckFixStealDiff` class (3 tests)
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `poetry run pytest -q` | 2431 passed, 1 skipped (was 2424; +7 tests) |
+| `poetry run ruff format --check .` + `ruff check .` | clean |
+| `git grep banned regex` | 0 hits |
+| Maintainer-blacklist plumbing actively populated | yes (via `udb.add_to_blacklist(maintainer=...)`) |
+| Existing keyword-heuristic preserved | yes (used as the cheap pre-filter before the more expensive diff fetch) |
+
+## Out of scope
+
+- Replacing the keyword heuristic entirely (kept as the pre-filter to avoid burning API quota on the diff-fetch path for every closed PR)
+- Persistent record of confirmed fix-steals beyond the blacklist entry — could be a follow-up issue if the operator wants per-maintainer trail analytics
+- Reverse path (un-blacklisting a maintainer after time-decay) — not in this PR's scope

--- a/docs/reports/active/10208-test-report.md
+++ b/docs/reports/active/10208-test-report.md
@@ -1,0 +1,50 @@
+# 10208 - Test Report
+
+**Issue:** #208
+**Branch:** `208-fix-stealer-diff`
+
+## Test count
+
+| Stage | Count |
+|---|---|
+| Before this PR | 2424 passed, 1 skipped |
+| After this PR | 2431 passed, 1 skipped |
+| Net | +7 new tests |
+
+## New tests
+
+`tests/unit/test_pr_tracker.py`:
+
+### `TestExtractPrUrlChange` (4 tests)
+
+- `test_extracts_clean_single_url_swap` — `-` line + `+` line each containing a URL → returns the tuple
+- `test_returns_none_on_multi_url_diff` — 2 removals + 2 additions → returns None (out of scope)
+- `test_returns_none_on_no_urls` — text-only diff → returns None
+- `test_returns_none_on_gh_failure` — `gh pr diff` exits non-zero → returns None
+
+### `TestCheckFixStealDiff` (3 tests)
+
+- `test_detects_byte_equivalent_steal` — PR has clean URL swap; subsequent commit contains the same swap → `(True, sha)` with the stealing commit SHA
+- `test_returns_false_when_no_pr_diff` — gh pr diff fails → `(False, None)` early-exit
+- `test_returns_false_when_no_matching_commit` — PR has clean URL swap but no commit on default branch contains it → `(False, None)`
+
+## Dependency injection (no MagicMock)
+
+Both new functions accept `gh_run` and `gh_get` callable kwargs for offline testing. Production defaults call `subprocess.run("gh ...")` and parse JSON. Tests inject lambdas returning `_mock_completed(...)` (the same helper the existing `TestCheckMaintainerFixed` tests use). No MagicMock added.
+
+## Lint
+
+| Check | Result |
+|---|---|
+| `poetry run ruff format --check .` | clean (1 file auto-reformatted) |
+| `poetry run ruff check .` | clean |
+
+## Coverage
+
+`_extract_pr_url_change`: 4 paths (clean / multi-URL / no-URLs / gh failure) covered.
+`check_fix_steal_diff`: 3 paths (positive / no-diff / no-matching-commit) covered.
+Auto-blacklist wiring in `refresh_pr_outcomes`: not directly tested in this PR (integration test would require setting up the full outcome refresh path with N6 stubs). The function-level confidence is sufficient; the integration is straightforward.
+
+## No regressions
+
+`poetry run pytest -q`: **2431 passed, 1 skipped**.

--- a/src/gh_link_auditor/pr_tracker.py
+++ b/src/gh_link_auditor/pr_tracker.py
@@ -9,10 +9,11 @@ See Issue #86 for specification.
 from __future__ import annotations
 
 import logging
+import re
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from gh_link_auditor.metrics.models import PROutcome
@@ -225,6 +226,133 @@ def _check_maintainer_fixed(
         return False
 
 
+def _extract_pr_url_change(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    *,
+    gh_run: Any = None,
+) -> tuple[str, str] | None:
+    """Extract the (dead_url, candidate_url) tuple from a PR's diff (#208).
+
+    Parses the unified diff for a single URL substitution. Returns None
+    when the PR is empty / multi-URL / not a clean URL swap (defensive —
+    fix-steal detection only applies to our single-URL PR format).
+    """
+    if gh_run is None:
+        gh_run = subprocess.run
+
+    try:
+        result = gh_run(
+            ["gh", "pr", "diff", str(pr_number), "--repo", f"{owner}/{repo}"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+
+    removed: list[str] = []
+    added: list[str] = []
+    for line in result.stdout.splitlines():
+        if line.startswith("---") or line.startswith("+++"):
+            continue
+        if line.startswith("-") and len(line) > 1:
+            removed.append(line[1:])
+        elif line.startswith("+") and len(line) > 1:
+            added.append(line[1:])
+
+    if len(removed) != 1 or len(added) != 1:
+        return None
+
+    # Extract URL from each line (use simple http(s) regex)
+    url_re = re.compile(r"https?://[^\s\"'<>)]+")
+    rm_match = url_re.search(removed[0])
+    add_match = url_re.search(added[0])
+    if not rm_match or not add_match:
+        return None
+    return rm_match.group(0), add_match.group(0)
+
+
+def check_fix_steal_diff(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    *,
+    gh_run: Any = None,
+    gh_get: Any = None,
+    lookback_commits: int = 20,
+) -> tuple[bool, str | None]:
+    """Detect whether the maintainer committed our exact URL fix after
+    closing our PR (#208).
+
+    Returns ``(stolen, commit_sha)``. ``stolen=True`` only when:
+
+    1. The closed PR contains a single, parseable URL swap.
+    2. A subsequent commit on the default branch contains the SAME swap
+       (byte-equivalent dead_url → candidate_url substitution).
+
+    The keyword-based ``_check_maintainer_fixed`` (older heuristic) is
+    kept for the no-diff fallback; this diff-based path is the strict
+    signal that auto-blacklists the maintainer (not just the repo).
+    """
+    if gh_run is None:
+        gh_run = subprocess.run
+
+    pair = _extract_pr_url_change(owner, repo, pr_number, gh_run=gh_run)
+    if pair is None:
+        return False, None
+    dead_url, candidate_url = pair
+
+    if gh_get is None:
+
+        def gh_get(path: str) -> Any:
+            try:
+                r = gh_run(
+                    ["gh", "api", path],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    check=False,
+                )
+                if r.returncode != 0 or not r.stdout.strip():
+                    return None
+                import json as _json
+
+                return _json.loads(r.stdout)
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                return None
+
+    commits = gh_get(f"repos/{owner}/{repo}/commits?per_page={lookback_commits}")
+    if not isinstance(commits, list):
+        return False, None
+
+    for c in commits:
+        sha = c.get("sha") if isinstance(c, dict) else None
+        if not sha:
+            continue
+        # Fetch the commit's diff via gh api repos/.../commits/<sha>
+        commit_detail = gh_get(f"repos/{owner}/{repo}/commits/{sha}")
+        if not isinstance(commit_detail, dict):
+            continue
+        files = commit_detail.get("files") or []
+        for f in files:
+            patch = f.get("patch") if isinstance(f, dict) else None
+            if not patch:
+                continue
+            # A byte-equivalent fix swap shows the SAME removed + added lines
+            if dead_url in patch and candidate_url in patch:
+                # Confirm same removal-then-addition pattern
+                rm_line = next((ln for ln in patch.splitlines() if ln.startswith("-") and dead_url in ln), None)
+                add_line = next((ln for ln in patch.splitlines() if ln.startswith("+") and candidate_url in ln), None)
+                if rm_line and add_line:
+                    return True, sha
+    return False, None
+
+
 _UNRESPONSIVE_DAYS = 30
 _UNRESPONSIVE_EXPIRY_DAYS = 90
 
@@ -334,6 +462,31 @@ def refresh_pr_outcomes(db_path: Path) -> list[PROutcome]:
                         source="fix_stolen",
                     )
                     logger.info("Auto-blacklisted (fix stolen): %s", repo_url)
+
+                    # Strict confirmation: diff-equivalence check (#208).
+                    # When confirmed, also blacklist the MAINTAINER (not
+                    # just the repo) so other repos they maintain are
+                    # excluded too.
+                    stolen, stealing_sha = check_fix_steal_diff(owner, repo, pr_number)
+                    if stolen:
+                        outcome.rejection_reason = (
+                            f"maintainer committed our exact fix in {stealing_sha[:8]}"
+                            if stealing_sha
+                            else "maintainer committed our exact fix"
+                        )
+                        udb.add_to_blacklist(
+                            maintainer=owner,
+                            reason=(
+                                f"Diff-equivalent fix-steal confirmed for {repo_url} "
+                                f"(commit {stealing_sha[:8] if stealing_sha else 'unknown'})"
+                            ),
+                            source="fix_stolen_diff",
+                        )
+                        logger.info(
+                            "Auto-blacklisted MAINTAINER (diff-confirmed fix steal): %s (%s)",
+                            owner,
+                            stealing_sha[:8] if stealing_sha else "n/a",
+                        )
 
             udb.record_pr_outcome(outcome)
             updated.append(outcome)

--- a/tests/unit/test_pr_tracker.py
+++ b/tests/unit/test_pr_tracker.py
@@ -165,6 +165,125 @@ class TestCheckMaintainerFixed:
             assert _check_maintainer_fixed("org", "repo", 42) is False
 
 
+class TestExtractPrUrlChange:
+    """Tests for _extract_pr_url_change() (#208)."""
+
+    def test_extracts_clean_single_url_swap(self) -> None:
+        from gh_link_auditor.pr_tracker import _extract_pr_url_change
+
+        diff = (
+            "--- a/README.md\n"
+            "+++ b/README.md\n"
+            "@@ -1,1 +1,1 @@\n"
+            "-See the docs at https://old.example/x for details.\n"
+            "+See the docs at https://new.example/x for details.\n"
+        )
+
+        def fake_run(*args, **kwargs):
+            return _mock_completed(diff)
+
+        pair = _extract_pr_url_change("o", "r", 42, gh_run=fake_run)
+        assert pair == ("https://old.example/x", "https://new.example/x")
+
+    def test_returns_none_on_multi_url_diff(self) -> None:
+        from gh_link_auditor.pr_tracker import _extract_pr_url_change
+
+        diff = (
+            "--- a/README.md\n"
+            "+++ b/README.md\n"
+            "-line one https://a.example\n"
+            "-line two https://b.example\n"
+            "+line one https://x.example\n"
+            "+line two https://y.example\n"
+        )
+
+        def fake_run(*args, **kwargs):
+            return _mock_completed(diff)
+
+        assert _extract_pr_url_change("o", "r", 42, gh_run=fake_run) is None
+
+    def test_returns_none_on_no_urls(self) -> None:
+        from gh_link_auditor.pr_tracker import _extract_pr_url_change
+
+        diff = "--- a/x\n+++ b/x\n-old text\n+new text\n"
+
+        def fake_run(*args, **kwargs):
+            return _mock_completed(diff)
+
+        assert _extract_pr_url_change("o", "r", 42, gh_run=fake_run) is None
+
+    def test_returns_none_on_gh_failure(self) -> None:
+        from gh_link_auditor.pr_tracker import _extract_pr_url_change
+
+        def fake_run(*args, **kwargs):
+            return _mock_completed("", returncode=1)
+
+        assert _extract_pr_url_change("o", "r", 42, gh_run=fake_run) is None
+
+
+class TestCheckFixStealDiff:
+    """Tests for check_fix_steal_diff() — the davidism / pallets case (#208)."""
+
+    def test_detects_byte_equivalent_steal(self) -> None:
+        from gh_link_auditor.pr_tracker import check_fix_steal_diff
+
+        # Step 1: PR diff is a clean URL swap
+        pr_diff = "--- a/README.md\n+++ b/README.md\n-See https://old.example/x\n+See https://new.example/x\n"
+
+        def fake_run(*args, **kwargs):
+            return _mock_completed(pr_diff)
+
+        # Step 2: maintainer's commit contains the SAME URL swap
+        commits_listing = [{"sha": "deadbeef12345678"}]
+        commit_detail = {
+            "files": [{"patch": ("@@ -1,1 +1,1 @@\n-See https://old.example/x\n+See https://new.example/x\n")}]
+        }
+
+        def fake_gh_get(path):
+            if "/commits/" in path:
+                return commit_detail
+            if "commits" in path:
+                return commits_listing
+            return None
+
+        stolen, sha = check_fix_steal_diff("o", "r", 42, gh_run=fake_run, gh_get=fake_gh_get)
+        assert stolen is True
+        assert sha == "deadbeef12345678"
+
+    def test_returns_false_when_no_pr_diff(self) -> None:
+        from gh_link_auditor.pr_tracker import check_fix_steal_diff
+
+        def fake_run(*args, **kwargs):
+            return _mock_completed("", returncode=1)
+
+        stolen, sha = check_fix_steal_diff("o", "r", 42, gh_run=fake_run, gh_get=lambda p: None)
+        assert stolen is False
+        assert sha is None
+
+    def test_returns_false_when_no_matching_commit(self) -> None:
+        from gh_link_auditor.pr_tracker import check_fix_steal_diff
+
+        pr_diff = "-See https://old.example/x\n+See https://new.example/x\n"
+
+        def fake_run(*args, **kwargs):
+            return _mock_completed(pr_diff)
+
+        # Commits exist but none contain the URL swap
+        commits_listing = [{"sha": "abc123"}]
+        commit_detail = {"files": [{"patch": "-totally unrelated\n+also unrelated\n"}]}
+
+        def fake_gh_get(path):
+            if "/commits/" in path:
+                return commit_detail
+            if "commits" in path:
+                return commits_listing
+            return None
+
+        stolen, sha = check_fix_steal_diff("o", "r", 42, gh_run=fake_run, gh_get=fake_gh_get)
+        assert stolen is False
+        assert sha is None
+
+
 class TestFetchPrComments:
     """Tests for _fetch_pr_comments() — issue #178."""
 


### PR DESCRIPTION
## Summary

PR-ζ — completes the Phase B safety story by activating the previously-latent maintainer-blacklist plumbing in `unified_db.is_blacklisted(repo_url, maintainer)`.

When a maintainer closes our PR and commits the byte-equivalent URL substitution as their own work (the **davidism / pallets#6019** pattern from 2026-05-13):

1. Existing `_check_maintainer_fixed` keyword heuristic flags it (cheap pre-filter)
2. **NEW:** `check_fix_steal_diff` confirms strict via diff comparison
3. **NEW:** when confirmed, the **maintainer** is added to the blacklist (not just the repo)

Hard gate #3 (#290, shipped in PR-ε) already passes the maintainer axis to `is_blacklisted`, so a confirmed fix-stealer's other repos are excluded from future PRs at preflight time.

## Functions added

- `_extract_pr_url_change(owner, repo, pr_number, *, gh_run=None)` — parses `gh pr diff` for a clean single-URL swap; returns `(dead_url, candidate_url)` or `None`
- `check_fix_steal_diff(owner, repo, pr_number, *, gh_run=None, gh_get=None, lookback_commits=20) -> (bool, sha)` — scans the most recent N commits on the default branch for the byte-equivalent substitution

## Integration

`refresh_pr_outcomes` chains the two signals:

```python
maintainer_fixed = _check_maintainer_fixed(owner, repo, pr_number)
if maintainer_fixed:
    # ... existing repo-level blacklist ...
    stolen, stealing_sha = check_fix_steal_diff(owner, repo, pr_number)
    if stolen:
        udb.add_to_blacklist(maintainer=owner, source="fix_stolen_diff", ...)
```

## Test plan

- [x] `poetry run pytest -q` → **2431 passed**, 1 skipped (was 2424 after PR-κ; +7)
- [x] `poetry run ruff format --check .` + `ruff check .` → clean
- [x] No MagicMock; `gh_run` + `gh_get` callable injection (same pattern as the rest of Phase B gates / scores)
- [x] `TestExtractPrUrlChange` (4 tests: clean / multi-URL / no-URLs / gh failure)
- [x] `TestCheckFixStealDiff` (3 tests: positive / no-diff / no-matching-commit)

Closes #208
