### PR TITLE
fix(preflight): set encoding="utf-8" on subprocess.run for Windows cp1252 safety

### DIFF
--- a/src/gh_link_auditor/preflight/gates.py
+++ b/src/gh_link_auditor/preflight/gates.py
@@ -289,6 +289,8 @@ def gate_no_duplicate_pr(
                     ["gh", "api", api_path],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=30,
                     check=False,
                 )

--- a/src/gh_link_auditor/preflight/scores.py
+++ b/src/gh_link_auditor/preflight/scores.py
@@ -509,6 +509,8 @@ def score_r3_outsider_merge_rate(
                     ["gh", "api", path],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=30,
                     check=False,
                 )
@@ -574,6 +576,8 @@ def score_r4_maintainer_structure(
                     ["gh", "api", path],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=30,
                     check=False,
                 )

--- a/src/gh_link_auditor/preflight/subagent.py
+++ b/src/gh_link_auditor/preflight/subagent.py
@@ -149,6 +149,8 @@ class RealSubagent:
                 env=env,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=self._timeout_s,
                 check=False,
             )


### PR DESCRIPTION
## Summary

Four `subprocess.run` call sites under `src/gh_link_auditor/preflight/` used `text=True` without an explicit `encoding=`. On Windows, Python defaults to cp1252 in that case, which can't represent UTF-8 bytes commonly returned by GitHub API JSON (emoji, accented maintainer names, foreign-language PR titles).

The #314 dry-run hit this on its first candidate and crashed the subprocess reader thread:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 2298
```

Then propagated as `AttributeError: 'NoneType' object has no attribute 'strip'` because `r.stdout` was never decoded.

## Fix

Add `encoding="utf-8", errors="replace"` to each subprocess.run call:

| File | Function |
|---|---|
| `gates.py` | `gate_duplicate_pr_open` |
| `scores.py` | R3 outsider-merge-rate |
| `scores.py` | R4 maintainer-structure |
| `subagent.py` | `RealSubagent.run` (latent — happened to work on AndreaVidali because that response was ASCII-clean) |

`errors="replace"` is belt-and-suspenders — substitution char on any residual edge case, never a crash.

## Test plan

- [x] `pytest tests/unit/preflight/ -q` — 123 passed, 0 failed
- [x] `ruff check` + `ruff format --check` clean on edited files
- [ ] CI green (Lint + Test)
- [ ] Cerberus-AZ approves
- [ ] (Post-merge) re-run `tools/derive_replacement_prs.py --preflight-report-only --campaign-allowed` and confirm it completes through all 149 candidates

Follow-up potential (out of scope): consolidate the duplicated subprocess wrapper into a shared `_gh_get` helper in `src/gh_link_auditor/preflight/_subproc.py` so future call sites can't drift again. Skipping here to keep the fix narrow.

Closes #337