### PR TITLE
fix(preflight-C5): add pre-subagent fast path for semantically-equivalent URL pairs

### DIFF
--- a/src/gh_link_auditor/preflight/scores.py
+++ b/src/gh_link_auditor/preflight/scores.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import re
 from typing import Any, Callable
+from urllib.parse import unquote
 
 from gh_link_auditor.network import check_url
 from gh_link_auditor.preflight.report import ScoreComponent
@@ -20,6 +21,16 @@ from gh_link_auditor.repo_quality import fetch_repo_metadata
 
 HttpCheck = Callable[[str], dict[str, Any]]
 ContentFetch = Callable[[str, str], str | None]
+
+# CommonMark backslash escapes inside the URL portion of a markdown link.
+# These render as the unescaped char on GitHub but get stored verbatim by
+# our URL extractor (see #339). C5 fast-path treats escaped vs unescaped as
+# the same URL.
+_ESCAPE_RE = re.compile(r"\\([(){}\[\]\\.\-+*_!#`|~<>=])")
+
+# Stray characters that sometimes get glued onto the end of a URL by source-
+# parsing artifacts (trailing backslash from markdown, anchor `#`, whitespace).
+_STRAY_TRAILING = set("\\#")
 
 
 def _default_http_check(url: str) -> dict[str, Any]:
@@ -29,6 +40,83 @@ def _default_http_check(url: str) -> dict[str, Any]:
         "status": result.get("status"),
         "final_url": result.get("final_url"),
     }
+
+
+def _strip_escapes(url: str) -> str:
+    """Remove CommonMark backslash escapes inside the URL string."""
+    return _ESCAPE_RE.sub(r"\1", url)
+
+
+def _strip_index_html(url: str) -> str:
+    """Canonicalize `/index.html` (or `/index.htm`) endings to `/`."""
+    for tail in ("/index.html", "/index.htm"):
+        if url.endswith(tail):
+            return url[: -len(tail)] + "/"
+    return url
+
+
+def _are_urls_near_equivalent(
+    dead_url: str,
+    candidate_url: str,
+    http_check: HttpCheck | None = None,
+) -> tuple[bool, str]:
+    """Detect semantically-equivalent URL pairs that C5 should treat as `clean`.
+
+    Returns (is_equivalent, pattern_name). pattern_name is empty when not
+    equivalent. Patterns checked in order; first match wins.
+
+    Patterns:
+    - identical: byte-equal (defensive; should rarely fire)
+    - escape_only: differ only in CommonMark backslash escapes
+    - index_canonical: differ only in /index.html (or /index.htm) <-> /
+    - percent_encoding: differ only in percent-encoding of identical chars
+    - stray_trailing: dead URL has stray trailing \\, #, or whitespace
+    - truncation_fix: candidate URL adds a missing closing bracket (1–3 chars)
+    - same_final_url: both URLs resolve to the same final_url via redirect
+
+    The last pattern requires a live ``http_check``; pass ``None`` to skip it.
+    """
+    if not dead_url or not candidate_url:
+        return False, ""
+    if dead_url == candidate_url:
+        return True, "identical"
+
+    dead_unescaped = _strip_escapes(dead_url)
+    cand_unescaped = _strip_escapes(candidate_url)
+    if dead_unescaped == cand_unescaped:
+        return True, "escape_only"
+
+    if _strip_index_html(dead_unescaped) == _strip_index_html(cand_unescaped):
+        return True, "index_canonical"
+
+    try:
+        if unquote(dead_unescaped) == unquote(cand_unescaped):
+            return True, "percent_encoding"
+    except Exception:  # noqa: BLE001
+        pass
+
+    if dead_unescaped.startswith(cand_unescaped):
+        extras = dead_unescaped[len(cand_unescaped) :]
+        if extras and all(c in _STRAY_TRAILING or c.isspace() for c in extras):
+            return True, "stray_trailing"
+
+    if cand_unescaped.startswith(dead_unescaped):
+        extras = cand_unescaped[len(dead_unescaped) :]
+        if 0 < len(extras) <= 3 and all(c in ")]}" for c in extras):
+            return True, "truncation_fix"
+
+    if http_check is not None:
+        try:
+            d = http_check(dead_url) or {}
+            c = http_check(candidate_url) or {}
+            d_final = d.get("final_url")
+            c_final = c.get("final_url")
+            if d_final and c_final and d_final == c_final:
+                return True, "same_final_url"
+        except Exception:  # noqa: BLE001
+            pass
+
+    return False, ""
 
 
 def _fetch_source_content(repo_full_name: str, source_file: str) -> str | None:
@@ -335,6 +423,20 @@ def score_c5_content_equivalence(
             points_awarded=0,
             max_points=15,
             evidence={"reason": "no_candidate_url"},
+        )
+
+    # Pre-subagent fast path: if the dead/candidate pair is one of the well-
+    # known semantically-equivalent shapes (escape-only diff, index.html
+    # canonical, stray trailing char, truncation fix, redirect-to-same-URL),
+    # short-circuit to CLEAN without burning a subagent invocation.
+    dead_url = candidate.get("dead_url") or ""
+    is_eq, pattern = _are_urls_near_equivalent(dead_url, candidate_url, http_check=http_check)
+    if is_eq:
+        return ScoreComponent(
+            name="C5",
+            points_awarded=15,
+            max_points=15,
+            evidence={"subagent": "fast_path", "pattern": pattern},
         )
 
     if landing_fetch is None:

--- a/tests/unit/preflight/test_scores.py
+++ b/tests/unit/preflight/test_scores.py
@@ -330,6 +330,120 @@ class TestScoreC5:
         assert result.points_awarded == 0
 
 
+class TestScoreC5FastPath:
+    """Fast-path equivalence checks should short-circuit to 15/15 without
+    invoking the subagent (#340)."""
+
+    def _exploding_subagent(self):
+        class Boom:
+            def run(self, *_a, **_kw):  # pragma: no cover - should never be called
+                raise AssertionError("subagent should NOT be invoked on fast-path match")
+
+            def is_available(self):
+                return True
+
+        return Boom()
+
+    def test_escape_only_equivalence(self, db):
+        result = score_c5_content_equivalence(
+            "owner/r",
+            _candidate(
+                dead_url=r"https://en.wikipedia.org/wiki/Silhouette_\(clustering\)",
+                candidate_url="https://en.wikipedia.org/wiki/Silhouette_(clustering)",
+            ),
+            db,
+            subagent=self._exploding_subagent(),
+        )
+        assert result.points_awarded == 15
+        assert result.evidence["pattern"] == "escape_only"
+
+    def test_index_canonical_equivalence(self, db):
+        result = score_c5_content_equivalence(
+            "owner/r",
+            _candidate(
+                dead_url="https://libspatialindex.github.io/index.html",
+                candidate_url="https://libspatialindex.github.io/",
+            ),
+            db,
+            subagent=self._exploding_subagent(),
+        )
+        assert result.points_awarded == 15
+        assert result.evidence["pattern"] == "index_canonical"
+
+    def test_stray_trailing_backslash(self, db):
+        result = score_c5_content_equivalence(
+            "owner/r",
+            _candidate(
+                dead_url=r"https://en.wikipedia.org/wiki/List_of_tallest_buildings_in_France\\",
+                candidate_url="https://en.wikipedia.org/wiki/List_of_tallest_buildings_in_France",
+            ),
+            db,
+            subagent=self._exploding_subagent(),
+        )
+        assert result.points_awarded == 15
+        assert result.evidence["pattern"] == "stray_trailing"
+
+    def test_stray_trailing_hash(self, db):
+        result = score_c5_content_equivalence(
+            "owner/r",
+            _candidate(
+                dead_url="http://www.example.com/page#",
+                candidate_url="http://www.example.com/page",
+            ),
+            db,
+            subagent=self._exploding_subagent(),
+        )
+        assert result.points_awarded == 15
+        assert result.evidence["pattern"] == "stray_trailing"
+
+    def test_truncation_fix_closing_paren(self, db):
+        result = score_c5_content_equivalence(
+            "owner/r",
+            _candidate(
+                dead_url="https://en.wikipedia.org/wiki/Euler_equations_(fluid_dynamics",
+                candidate_url="https://en.wikipedia.org/wiki/Euler_equations_(fluid_dynamics)",
+            ),
+            db,
+            subagent=self._exploding_subagent(),
+        )
+        assert result.points_awarded == 15
+        assert result.evidence["pattern"] == "truncation_fix"
+
+    def test_same_final_url_via_redirect(self, db):
+        def http_check(url):
+            return {"final_url": "https://canonical.example/x", "status_code": 200}
+
+        result = score_c5_content_equivalence(
+            "owner/r",
+            _candidate(
+                dead_url="https://oldhost.example/x",
+                candidate_url="https://newhost.example/x",
+            ),
+            db,
+            subagent=self._exploding_subagent(),
+            http_check=http_check,
+        )
+        assert result.points_awarded == 15
+        assert result.evidence["pattern"] == "same_final_url"
+
+    def test_unrelated_urls_fall_through_to_subagent(self, db):
+        """Two genuinely different URLs should NOT trigger fast-path; the
+        subagent (FakeSubagent here) determines the verdict."""
+        result = score_c5_content_equivalence(
+            "owner/r",
+            _candidate(
+                dead_url="https://example.com/old-broken-page",
+                candidate_url="https://different.example/wholly-different",
+            ),
+            db,
+            subagent=FakeSubagent.configure(default=SubagentVerdict.UNRELATED),
+            landing_fetch=lambda url: {"title": "X", "h1": "Y", "body_snippet": "z"},
+            prompt_path="ignored.txt",
+        )
+        # subagent UNRELATED -> 0
+        assert result.points_awarded == 0
+
+
 # ---------------------------------------------------------------------------
 # R1 (#305): stars tiered
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The #314 preflight audit found that 7 of 9 SCORE_TOO_LOW candidates were legitimate fixes blocked solely by C5 (content equivalence) scoring 0/15. In every case the dead URL was genuinely 404, the candidate URL was genuinely 200, and the candidate was a real markdown improvement — but C5's subagent saw byte-different URL strings and returned `unrelated`.

This PR adds a pre-subagent fast path covering the exact patterns the audit surfaced. On match, C5 returns CLEAN (15/15) without invoking the subagent. The subagent is reserved for genuinely ambiguous pairs.

## Patterns covered

| Pattern | Example | Audit case |
|---|---|---|
| `escape_only` | `Foo_\(bar\)` ↔ `Foo_(bar)` | nvidia-cosmos, jftuga/less-Windows |
| `index_canonical` | `.../index.html` ↔ `.../` | villares, mozilla/experimenter, openstack/octavia, OasisLMF |
| `stray_trailing` | `.../France\` ↔ `.../France` | ipvoov/Craft-Agent |
| `truncation_fix` | `.../fluid_dynamics` ↔ `.../fluid_dynamics)` | cfsengineering/CEASIOMpy |
| `same_final_url` | both URLs redirect to identical final_url | future repo-rename cases |
| `percent_encoding` | differ only in %xx encoding of identical chars | future |

## Test plan

- [x] 7 new unit tests, one per fast-path pattern + one for fall-through to subagent
- [x] Existing 4 C5 tests pass unchanged (123 → 130 preflight unit tests)
- [x] `ruff check` + `ruff format` clean
- [ ] CI green
- [ ] Cerberus-AZ approves
- [ ] (Post-merge, after #341 also lands) Re-run #314 preflight against existing 86 reports; expect ~7 of the 9 previous SCORE_TOO_LOW to now PASS

## What this does NOT change

- The subagent prompt at `prompts/preflight/content_equiv.txt` — untouched
- C5's behavior for pairs that don't match any fast-path pattern — same as before (subagent decides)
- Other score components (C1–C4, C6, C7, R1–R5) — untouched

Closes #340