### PR TITLE
fix(preflight-gate): dead_url_still_dead accepts redirect-to-renamed-location as PASS

### DIFF
--- a/src/gh_link_auditor/preflight/gates.py
+++ b/src/gh_link_auditor/preflight/gates.py
@@ -175,6 +175,43 @@ def gate_dead_url_still_present(
 # ---------------------------------------------------------------------------
 
 
+def _is_redirect_to_renamed_location(dead_url: str, final_url: str | None) -> bool:
+    """True when ``final_url`` is a meaningfully different location from
+    ``dead_url`` — indicating the dead URL only "works" via redirect to a
+    renamed canonical address.
+
+    Currently handles:
+    - github.com URLs where owner or repo path segments differ
+    - any URL where the host differs entirely
+
+    Stays conservative: same-host docs-reorganization redirects don't count
+    here (too many false positives — many sites silently redirect everything,
+    e.g. http -> https or www-prefix normalization that doesn't represent a
+    real rename).
+    """
+    if not final_url or final_url == dead_url:
+        return False
+
+    from urllib.parse import urlparse
+
+    d = urlparse(dead_url)
+    f = urlparse(final_url)
+
+    # Different host: counts as a rename (org or domain moved)
+    if d.netloc.lower() != f.netloc.lower():
+        return True
+
+    # Same host. For github.com URLs, look for an owner/repo rename
+    if d.netloc.lower() == "github.com":
+        d_parts = d.path.strip("/").split("/")
+        f_parts = f.path.strip("/").split("/")
+        if len(d_parts) >= 2 and len(f_parts) >= 2:
+            if d_parts[0] != f_parts[0] or d_parts[1] != f_parts[1]:
+                return True
+
+    return False
+
+
 def gate_dead_url_still_dead(
     repo_full_name: str,
     candidate: dict[str, Any],
@@ -182,10 +219,14 @@ def gate_dead_url_still_dead(
     *,
     http_check: HttpCheck | None = None,
 ) -> GateResult:
-    """Fail when the dead URL returns 2xx — it's been resurrected.
+    """Fail when the dead URL serves direct 2xx content (it's been resurrected).
 
-    Filing a PR to "fix" a URL that works now would be a no-op at best,
-    embarrassing at worst.
+    PASS in two situations:
+    1. dead URL is still non-2xx (the original "dead" condition)
+    2. dead URL returns 2xx but only via a redirect to a renamed canonical
+       location (different host, or different github.com owner/repo) —
+       in that case the PR to update to the canonical target is a real fix
+       (the redirect is fragile; the new URL is the durable address)
     """
     dead_url = candidate.get("dead_url") or ""
     if not dead_url:
@@ -199,12 +240,33 @@ def gate_dead_url_still_dead(
     check = http_check or _default_http_check
     result = check(dead_url)
     status_code = result.get("status_code")
+    final_url = result.get("final_url")
+
     if status_code is not None and 200 <= status_code < 300:
+        if _is_redirect_to_renamed_location(dead_url, final_url):
+            return GateResult(
+                name="dead_url_still_dead",
+                passed=True,
+                reason=(
+                    f"dead URL returned {status_code} via redirect to renamed location; PR updates to canonical target"
+                ),
+                evidence={
+                    "dead_url": dead_url,
+                    "status_code": status_code,
+                    "final_url": final_url,
+                    "redirect_to_renamed": True,
+                },
+            )
         return GateResult(
             name="dead_url_still_dead",
             passed=False,
-            reason=f"dead URL returned {status_code}; it has been resurrected",
-            evidence={"dead_url": dead_url, "status_code": status_code},
+            reason=f"dead URL returned {status_code}; it has been resurrected (serves direct content)",
+            evidence={
+                "dead_url": dead_url,
+                "status_code": status_code,
+                "final_url": final_url,
+                "redirect_to_renamed": False,
+            },
         )
     return GateResult(
         name="dead_url_still_dead",

--- a/tests/unit/preflight/test_gates.py
+++ b/tests/unit/preflight/test_gates.py
@@ -167,6 +167,80 @@ class TestGateDeadUrlStillDead:
         )
         assert result.passed is False
         assert "resurrected" in result.reason
+        assert result.evidence["redirect_to_renamed"] is False
+
+    def test_passes_when_dead_url_redirects_to_renamed_github_owner(self, db):
+        """github.com owner rename: old-org -> new-org. PR is a real fix."""
+        result = gate_dead_url_still_dead(
+            "owner/r",
+            _candidate(dead_url="https://github.com/deepmind/lab/blob/master/python/README.md"),
+            db,
+            http_check=lambda url: {
+                "status_code": 200,
+                "status": "ok",
+                "final_url": "https://github.com/google-deepmind/lab/blob/master/python/README.md",
+            },
+        )
+        assert result.passed is True
+        assert result.evidence["redirect_to_renamed"] is True
+        assert "canonical target" in result.reason
+
+    def test_passes_when_dead_url_redirects_to_renamed_github_repo(self, db):
+        """github.com repo rename: same owner, old-name -> new-name. PR is a real fix."""
+        result = gate_dead_url_still_dead(
+            "owner/r",
+            _candidate(dead_url="https://github.com/open-mmlab/mmclassification/blob/master/configs/x.py"),
+            db,
+            http_check=lambda url: {
+                "status_code": 200,
+                "status": "ok",
+                "final_url": "https://github.com/open-mmlab/mmpretrain/blob/master/configs/x.py",
+            },
+        )
+        assert result.passed is True
+        assert result.evidence["redirect_to_renamed"] is True
+
+    def test_passes_when_dead_url_redirects_to_different_host(self, db):
+        """Different host entirely: docs moved off blogspot, etc."""
+        result = gate_dead_url_still_dead(
+            "owner/r",
+            _candidate(dead_url="https://oldproject.blogspot.com/docs"),
+            db,
+            http_check=lambda url: {
+                "status_code": 200,
+                "status": "ok",
+                "final_url": "https://oldproject.com/docs",
+            },
+        )
+        assert result.passed is True
+        assert result.evidence["redirect_to_renamed"] is True
+
+    def test_fails_when_dead_url_redirects_within_same_repo_path(self, db):
+        """Same github owner/repo, different path: docs reorganization,
+        NOT a rename — the URL really is live, just rearranged."""
+        result = gate_dead_url_still_dead(
+            "owner/r",
+            _candidate(dead_url="https://github.com/owner/repo/blob/main/old/file.md"),
+            db,
+            http_check=lambda url: {
+                "status_code": 200,
+                "status": "ok",
+                "final_url": "https://github.com/owner/repo/blob/main/new/file.md",
+            },
+        )
+        assert result.passed is False
+        assert result.evidence["redirect_to_renamed"] is False
+
+    def test_fails_when_dead_url_2xx_with_no_final_url(self, db):
+        """Lazy http_check that doesn't return final_url: defaults to no-rename."""
+        result = gate_dead_url_still_dead(
+            "owner/r",
+            _candidate(),
+            db,
+            http_check=lambda url: {"status_code": 200, "status": "ok"},
+        )
+        assert result.passed is False
+        assert result.evidence["redirect_to_renamed"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The #314 audit found ~5 of 38 `dead_url_still_dead` failures were legitimate fixes — github repo-rename redirects where the old URL still returns 200 via GitHub's redirect to the new owner/repo, but the new URL is the durable canonical address. The existing gate failed these as "URL not dead." This PR updates the gate to distinguish "URL serves direct content" from "URL serves redirect to renamed location."

## Cases recovered

From the audit:

| Old URL (still 200 via redirect) | Canonical post-rename URL |
|---|---|
| `github.com/deepmind/lab/...` | `github.com/google-deepmind/lab/...` |
| `github.com/vector-im/element-web/...` | `github.com/element-hq/element-web/...` |
| `github.com/open-mmlab/mmclassification/...` | `github.com/open-mmlab/mmpretrain/...` |
| `github.com/volcengine/verl/...` | `github.com/verl-project/verl/...` |
| `github.com/zudi-lin/pytorch_connectomics/...` | `github.com/PytorchConnectomics/pytorch_connectomics/...` |

A PR updating the markdown to the post-rename canonical URL is a real durability improvement — relying on a redirect is fragile (GitHub can drop it, the org can break it).

## Scope of "meaningfully different"

Stays conservative — only fires when there's strong rename signal:

- **github.com URLs**: different owner OR different repo path segment
- **any host**: completely different host (org moved off blogspot, etc.)
- **NOT counted**: same-host docs reorganization (too many false positives from generic http→https / www-prefix redirects)

The evidence dict now records `redirect_to_renamed: True/False` so downstream report rendering can surface the distinction.

## Test plan

- [x] 5 new unit tests covering each rename scenario + the "path move within same repo" non-rename case
- [x] Existing `test_fails_when_dead_url_returns_2xx` updated to assert the new evidence field
- [x] Total preflight unit tests: 130 → 135
- [x] `ruff check` + `ruff format` clean
- [ ] CI green
- [ ] Cerberus-AZ approves
- [ ] (Post-merge, after the cleanup checkpoint) Re-run preflight on existing 86 repos; expect ~5 of the previous `dead_url_still_dead` to now PASS

## What this does NOT change

- The other gates (anti_ai, repo_active, blacklist, dead_url_still_present, candidate_url_alive, redirect_target_related, no_duplicate_pr, no_markdown_corruption, stars_floor) — untouched
- Scoring components — untouched
- Default `http_check` — it already returned `final_url`; this PR just consumes it

Closes #341