### PR TITLE
fix(bulk-scan): normalize CommonMark backslash escapes during URL extraction

### DIFF
--- a/src/gh_link_auditor/bulk_scan/inventory.py
+++ b/src/gh_link_auditor/bulk_scan/inventory.py
@@ -31,12 +31,22 @@ _FENCED_RE = re.compile(r"^(\s{0,3})(```+|~~~+)")
 _INDENTED_CODE_RE = re.compile(r"^(?: {4,}|\t)")
 _TRAIL_CHARS = set(".,;:!?'\"`")
 
+# CommonMark backslash escapes inside the URL portion of a markdown link
+# render as the unescaped char per the CommonMark spec (and on GitHub).
+# The raw URL extractor captures them verbatim, producing "dead" URLs
+# whose literal byte sequence (e.g. ``Foo_\(bar\)``) 404s on the host but
+# whose rendered href (``Foo_(bar)``) is alive — a false-positive dead-
+# link finding. Backslash is not a valid RFC 3986 URL character, so any
+# ``\`` we see in extracted text is a markdown artifact (#339).
+_ESCAPE_RE = re.compile(r"\\([(){}\[\]\\.\-+*_!#`|~<>=])")
+
 _GH_API = "https://api.github.com"
 _RAW_BASE = "https://raw.githubusercontent.com"
 
 
 def _clean_url_tail(raw: str) -> str:
-    """Strip trailing punctuation; cut at first unmatched closing paren.
+    """Unescape CommonMark backslashes; strip trailing punctuation; cut
+    at first unmatched closing paren.
 
     Markdown like ``[name](url)'s text`` makes the URL regex capture
     ``url)'s`` — the trailing ``s`` is a word-char so the trail-chars
@@ -44,7 +54,11 @@ def _clean_url_tail(raw: str) -> str:
     at the first unmatched ``)``; anything after is markdown spillover.
 
     Balanced parens are preserved (Wikipedia ``Foo_(bar)`` style).
+
+    Escape stripping happens FIRST so paren-matching downstream sees
+    the rendered form, not the raw markdown (#339).
     """
+    raw = _ESCAPE_RE.sub(r"\1", raw)
     while raw and raw[-1] in _TRAIL_CHARS:
         raw = raw[:-1]
 

--- a/tests/unit/bulk_scan/test_inventory.py
+++ b/tests/unit/bulk_scan/test_inventory.py
@@ -41,6 +41,25 @@ class TestCleanUrlTail:
             _clean_url_tail("https://en.wikipedia.org/wiki/Foo_(bar)is") == "https://en.wikipedia.org/wiki/Foo_(bar)is"
         )
 
+    def test_commonmark_escapes_unwrapped(self) -> None:
+        # Markdown ``[text](url_\(bar\))`` regex-captures the URL with the
+        # escapes in place; cleanup must un-escape (#339).
+        assert (
+            _clean_url_tail(r"https://en.wikipedia.org/wiki/Silhouette_\(clustering\)")
+            == "https://en.wikipedia.org/wiki/Silhouette_(clustering)"
+        )
+
+    def test_commonmark_escapes_unwrapped_then_balanced(self) -> None:
+        # After unescape, parens are balanced and preserved (Wikipedia style).
+        assert (
+            _clean_url_tail(r"https://en.wikipedia.org/wiki/Less_\(Unix\)")
+            == "https://en.wikipedia.org/wiki/Less_(Unix)"
+        )
+
+    def test_unescaped_url_unchanged(self) -> None:
+        # No backslash means no change.
+        assert _clean_url_tail("https://numpy.org/doc/stable/") == "https://numpy.org/doc/stable/"
+
 
 class TestExtractUrls:
     def test_simple(self) -> None:


### PR DESCRIPTION
## Summary

The URL-extraction pipeline in `bulk_scan/inventory.py` records URLs verbatim from markdown source. CommonMark backslash escapes inside the URL portion of a `[text](url)` link (e.g. `Foo_\(bar\)`) render as the unescaped form in browsers but get persisted as the raw escaped form in `bulk_scan_findings.dead_url`. HEAD-checks on the literal byte sequence return 404, producing false-positive dead-link findings.

Apply the unescape at the top of `_clean_url_tail` so all downstream processing (paren-matching, trail-strip, persistence) sees the rendered form. Backslash is not a valid RFC 3986 URL character; any `\` we see in extracted text is a markdown artifact.

## Affected pattern

Examples surfaced by the #314 audit:

| Source markdown URL | Stored verbatim → after fix |
|---|---|
| `[silhouette](https://en.wikipedia.org/wiki/Silhouette_\(clustering\))` | `Silhouette_\(clustering\)` → `Silhouette_(clustering)` |
| `[less](https://en.wikipedia.org/wiki/Less_\(Unix\))` | `Less_\(Unix\)` → `Less_(Unix)` |

## Migration

Two existing rows in `bulk_scan_findings` carry the escape pattern (the nvidia-cosmos and jftuga/less-Windows cases above). They'll get refreshed naturally by the fresh bulk scan planned after #342 and #343 land. No standalone migration script — adds complexity for 2 rows.

## Test plan

- [x] 3 new unit tests covering escape-only diff, escape + balanced-paren preserve, unaffected URLs unchanged
- [x] Existing 17 inventory tests pass unchanged (174 bulk_scan unit tests green total)
- [x] `ruff check` + `ruff format` clean
- [ ] CI green
- [ ] Cerberus-AZ approves

Closes #339