### PR TITLE
fix(scan): gate url_mutation emission when dead URL is currently 2xx

### DIFF
--- a/src/gh_link_auditor/redirect_resolver.py
+++ b/src/gh_link_auditor/redirect_resolver.py
@@ -152,6 +152,15 @@ class RedirectResolver:
         - Trailing slash toggle
         - http -> https upgrade
         - www prefix toggle
+        - /index.html (or /index.htm) strip
+
+        Returns ``[]`` when the input URL itself is currently 2xx — a "fix"
+        that proposes a different URL on the same server is not a fix if
+        the original is already alive (#342). The outer bulk-scan probe
+        is sometimes wrong about which URLs are dead (HEAD-only checks,
+        transient rate-limits, missing UA); this guard catches the
+        downstream consequence: emitting a same-server mutation as a
+        candidate when the dead URL never needed fixing in the first place.
 
         Args:
             url: Dead URL to mutate.
@@ -159,6 +168,11 @@ class RedirectResolver:
         Returns:
             List of (live_url, mutation_type) tuples.
         """
+        src_result = _http_head(url)
+        src_status = src_result.get("status_code") if src_result else None
+        if src_status is not None and 200 <= src_status < 300:
+            return []
+
         mutations: list[tuple[str, str]] = []
         parsed = urlparse(url)
 

--- a/tests/unit/test_redirect_resolver.py
+++ b/tests/unit/test_redirect_resolver.py
@@ -267,6 +267,30 @@ class TestUrlMutations:
             mutations = resolver.test_url_mutations("https://example.com/nope")
         assert mutations == []
 
+    def test_returns_empty_when_input_url_is_alive(self):
+        """When the dead URL is actually 2xx now (outer probe was wrong),
+        skip mutation emission entirely — no candidate row should be
+        produced for a same-server "fix" that doesn't fix anything (#342)."""
+        resolver = _make_resolver()
+        with patch(
+            "gh_link_auditor.redirect_resolver._http_head",
+            return_value={"status_code": 200, "location": None},
+        ):
+            mutations = resolver.test_url_mutations("https://example.com/works-fine")
+        assert mutations == []
+
+    def test_skips_when_input_dead_and_mutation_also_dead(self):
+        """Input 404 and every mutation also 404 (e.g. host-wide outage):
+        no candidate row produced. Behavior preserved by the existing
+        2xx-3xx gate on mutations; this test pins it post-#342."""
+        resolver = _make_resolver()
+        with patch(
+            "gh_link_auditor.redirect_resolver._http_head",
+            return_value={"status_code": 404, "location": None},
+        ):
+            mutations = resolver.test_url_mutations("https://glm.example.com/html/index.html")
+        assert mutations == []
+
 
 # ---------------------------------------------------------------------------
 # verify_live


### PR DESCRIPTION
## Summary

The #314 audit found ~30 `candidate_url_alive` failures sharing one shape: dead URL and same-server mutation URL both return the same status (mostly both 4xx, but some both 2xx). The mutation gate already requires the mutated URL be 2xx-3xx at investigation time, but it didn't verify the dead URL was actually 4xx/5xx. Result: when the outer bulk-scan probe wrongly classified an alive URL as dead (HEAD-only, no UA, transient rate-limit), `test_url_mutations` would happily emit a candidate that doesn't fix anything — both URLs serve content fine.

This PR adds a front-of-function guard: if the input URL itself currently returns 2xx, return `[]` immediately. No candidate emitted.

## Behavior matrix

| Dead URL status | Mutated URL status | Emit candidate? | Note |
|---|---|---|---|
| 4xx/5xx | 2xx-3xx | YES | The legitimate case (unchanged) |
| 4xx/5xx | 4xx/5xx | NO | Existing mutation gate (unchanged) |
| 2xx | 2xx | **NO** | **New guard** — was emitting before #342 |
| 2xx | 4xx/5xx | NO | New guard, also caught by existing gate |

## Migration

Existing rows with this shape in `bulk_scan_findings` will be naturally refreshed by the planned fresh bulk scan after #343 lands. No standalone migration script — adds complexity vs. just rescanning the dataset once.

## Test plan

- [x] 3 new unit tests covering: input alive → skip; input dead + mutation alive → emit; both dead → skip
- [x] Existing 31 redirect_resolver tests pass unchanged
- [x] LinkDetective, bulk_scan investigation, trust_escalation tests pass (128 total)
- [x] `ruff check` + `ruff format` clean
- [ ] CI green
- [ ] Cerberus-AZ approves

Closes #342