### PR TITLE
fix(scan): record HEAD and GET statuses separately + log HEAD->GET fallback

### DIFF
--- a/src/gh_link_auditor/bulk_scan/runner.py
+++ b/src/gh_link_auditor/bulk_scan/runner.py
@@ -236,6 +236,8 @@ def run_liveness(db: UnifiedDatabase, run_id: str) -> dict[str, dict]:
             final_url=result.get("final_url"),
             is_bot_blocked=bool(result.get("is_bot_blocked")),
             ttl_hours=LIVENESS_CACHE_TTL_HOURS,
+            head_status=result.get("head_status_code"),
+            get_status=result.get("get_status_code"),
         )
 
     fresh = liveness.check_urls_bulk(to_probe, on_result=_persist)

--- a/src/gh_link_auditor/network.py
+++ b/src/gh_link_auditor/network.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import http.client
 import ipaddress
+import logging
 import random
 import socket
 import ssl
@@ -20,6 +21,8 @@ import urllib.request
 from email.utils import parsedate_to_datetime
 from typing import NotRequired, TypedDict
 from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Configuration data structures (LLD §2.3)
@@ -49,7 +52,7 @@ class RequestResult(TypedDict):
     url: str  # The requested URL
     status: str  # ok, error, timeout, failed, disconnected, invalid
     status_code: int | None  # HTTP status code or None
-    method: str  # HEAD or GET
+    method: str  # HEAD or GET (whichever yielded the final status)
     response_time_ms: int | None  # Response time in milliseconds
     retries: int  # Number of retries attempted
     error: str | None  # Error description if not ok
@@ -57,6 +60,14 @@ class RequestResult(TypedDict):
     # Optional via NotRequired so pre-#315 call sites that build RequestResult dicts
     # without this key remain valid TypedDict constructions.
     final_url: NotRequired[str | None]
+    # HEAD-specific status code (#343). Always populated when an HTTP request was
+    # actually attempted; None when no HEAD request happened (e.g., invalid-URL
+    # short-circuits). Lets downstream code see "URL is HEAD-strict" patterns
+    # (HEAD 4xx + GET 2xx) without re-probing.
+    head_status_code: NotRequired[int | None]
+    # GET-specific status code (#343). None when HEAD-only succeeded and no
+    # GET fallback was attempted. Populated when HEAD→GET fallback fired.
+    get_status_code: NotRequired[int | None]
 
 
 # ---------------------------------------------------------------------------
@@ -560,6 +571,10 @@ def check_url(
     retries = 0
     get_fallback_attempted = False
     browser_ua_attempted = False
+    # Track the status from each method separately so callers can detect
+    # HEAD-strict URLs (HEAD 4xx + GET 2xx) without re-probing (#343).
+    head_status_recorded: int | None = None
+    get_status_recorded: int | None = None
 
     # Use a while loop (per reviewer suggestion) for cleaner retry/fallback logic.
     while True:
@@ -568,6 +583,10 @@ def check_url(
             method,
             request_config,
         )
+        if method == "HEAD":
+            head_status_recorded = status_code
+        else:
+            get_status_recorded = status_code
 
         # Success — 2xx/3xx
         if status_code is not None and 200 <= status_code < 400:
@@ -580,12 +599,19 @@ def check_url(
                 retries=retries,
                 error=None,
                 final_url=final_url,
+                head_status_code=head_status_recorded,
+                get_status_code=get_status_recorded,
             )
 
         retry_ok, try_get = should_retry(status_code, error_type)
 
         # HEAD→GET fallback (403/405) — not counted as a retry
         if try_get and not get_fallback_attempted:
+            logger.info(
+                "url_check head_to_get_fallback url=%s head_status=%s",
+                url,
+                head_status_recorded,
+            )
             method = "GET"
             get_fallback_attempted = True
             continue
@@ -636,6 +662,8 @@ def check_url(
                 retries=retries,
                 error=_build_error_message(status_code, error_type),
                 final_url=final_url,
+                head_status_code=head_status_recorded,
+                get_status_code=get_status_recorded,
             )
 
         # Retryable — check if we have retries left
@@ -656,4 +684,6 @@ def check_url(
             retries=retries,
             error=_build_error_message(status_code, error_type),
             final_url=final_url,
+            head_status_code=head_status_recorded,
+            get_status_code=get_status_recorded,
         )

--- a/src/gh_link_auditor/unified_db.py
+++ b/src/gh_link_auditor/unified_db.py
@@ -21,7 +21,7 @@ from gh_link_auditor.models import BlacklistEntry, InteractionRecord, Interactio
 logger = logging.getLogger(__name__)
 
 DEFAULT_DB_PATH = Path.home() / ".ghla" / "ghla.db"
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 
 class UnifiedDatabase:
@@ -247,6 +247,8 @@ class UnifiedDatabase:
         """)
 
         # --- url_check_cache: URL check results (#122) ---
+        # head_status / get_status added in v10 (#343) so callers can detect
+        # HEAD-strict URLs (HEAD 4xx + GET 2xx) without re-probing.
         c.execute("""
             CREATE TABLE IF NOT EXISTS url_check_cache (
                 url TEXT PRIMARY KEY,
@@ -254,6 +256,8 @@ class UnifiedDatabase:
                 final_url TEXT,
                 is_bot_blocked INTEGER DEFAULT 0,
                 retry_count INTEGER DEFAULT 0,
+                head_status INTEGER,
+                get_status INTEGER,
                 last_checked_at TEXT NOT NULL,
                 expires_at TEXT NOT NULL
             )
@@ -437,6 +441,8 @@ class UnifiedDatabase:
             self._migrate_v7_to_v8()
         if from_version <= 8:
             self._migrate_v8_to_v9()
+        if from_version <= 9:
+            self._migrate_v9_to_v10()
 
     def _migrate_v1_to_v2(self) -> None:
         logger.info("Migrating schema v1 → v2")
@@ -681,6 +687,27 @@ class UnifiedDatabase:
         c.execute("UPDATE schema_version SET version = ?", (SCHEMA_VERSION,))
         c.commit()
         logger.info("Migration to v9 complete")
+
+    # ------------------------------------------------------------------
+    # Migration v9 -> v10: head_status + get_status on url_check_cache (#343)
+    # ------------------------------------------------------------------
+
+    def _migrate_v9_to_v10(self) -> None:
+        logger.info("Migrating schema v9 → v10")
+        c = self._conn
+        # If url_check_cache exists, add the new columns. If it doesn't,
+        # the table will be created with the new columns by the next
+        # _create_all_tables call (which CREATE TABLE IF NOT EXISTS) so
+        # nothing to do here.
+        cols = {row[1] for row in c.execute("PRAGMA table_info(url_check_cache)").fetchall()}
+        if cols:
+            if "head_status" not in cols:
+                c.execute("ALTER TABLE url_check_cache ADD COLUMN head_status INTEGER")
+            if "get_status" not in cols:
+                c.execute("ALTER TABLE url_check_cache ADD COLUMN get_status INTEGER")
+        c.execute("UPDATE schema_version SET version = ?", (SCHEMA_VERSION,))
+        c.commit()
+        logger.info("Migration to v10 complete")
 
     # ------------------------------------------------------------------
     # External migration: import from metrics.db
@@ -1115,19 +1142,29 @@ class UnifiedDatabase:
         is_bot_blocked: bool = False,
         retry_count: int = 0,
         ttl_hours: int = 24,
+        head_status: int | None = None,
+        get_status: int | None = None,
     ) -> None:
         now = datetime.now(timezone.utc)
-        expires = now.replace(hour=now.hour + ttl_hours) if ttl_hours < 24 else now.replace(day=now.day + 1)
-        # Simpler: just add hours
         from datetime import timedelta
 
         expires = now + timedelta(hours=ttl_hours)
         self._conn.execute(
             """INSERT OR REPLACE INTO url_check_cache
             (url, http_status, final_url, is_bot_blocked, retry_count,
-             last_checked_at, expires_at)
-            VALUES (?,?,?,?,?,?,?)""",
-            (url, http_status, final_url, int(is_bot_blocked), retry_count, now.isoformat(), expires.isoformat()),
+             head_status, get_status, last_checked_at, expires_at)
+            VALUES (?,?,?,?,?,?,?,?,?)""",
+            (
+                url,
+                http_status,
+                final_url,
+                int(is_bot_blocked),
+                retry_count,
+                head_status,
+                get_status,
+                now.isoformat(),
+                expires.isoformat(),
+            ),
         )
         self._conn.commit()
 
@@ -1139,7 +1176,7 @@ class UnifiedDatabase:
         ).fetchone()
         if row is None:
             return None
-        return {
+        result = {
             "url": row["url"],
             "http_status": row["http_status"],
             "final_url": row["final_url"],
@@ -1147,6 +1184,15 @@ class UnifiedDatabase:
             "retry_count": row["retry_count"],
             "last_checked_at": row["last_checked_at"],
         }
+        # head_status / get_status are v10+ columns (#343). Older rows may not
+        # have them; older code paths shouldn't break if they're absent.
+        try:
+            result["head_status"] = row["head_status"]
+            result["get_status"] = row["get_status"]
+        except (IndexError, KeyError):
+            result["head_status"] = None
+            result["get_status"] = None
+        return result
 
     # ------------------------------------------------------------------
     # Preflight caches (#285)

--- a/tests/unit/bulk_scan/test_storage.py
+++ b/tests/unit/bulk_scan/test_storage.py
@@ -8,8 +8,9 @@ from gh_link_auditor.unified_db import SCHEMA_VERSION, UnifiedDatabase
 
 class TestSchemaV7:
     def test_schema_version(self) -> None:
-        # Phase B preflight (#285) bumped to v9.
-        assert SCHEMA_VERSION == 9
+        # Phase B preflight (#285) bumped to v9; #343 bumped to v10 for
+        # head_status / get_status columns on url_check_cache.
+        assert SCHEMA_VERSION == 10
 
     def test_fresh_db_has_bulk_scan_tables(self, tmp_path) -> None:
         with UnifiedDatabase(str(tmp_path / "x.db")) as db:

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -81,6 +81,69 @@ class TestCheckUrlSuccessHead:
         assert result["error"] is None
         assert result["url"] == "https://example.com"
         assert isinstance(result["response_time_ms"], int)
+        # #343: head_status_code populated on direct HEAD success; get_status_code None
+        assert result["head_status_code"] == 200
+        assert result["get_status_code"] is None
+
+
+class TestCheckUrlHeadStrictTracking:
+    """#343: When HEAD→GET fallback fires, both statuses are recorded on
+    the RequestResult so downstream code can detect HEAD-strict URLs
+    without re-probing."""
+
+    def test_head_403_get_200_records_both(self, no_retry_backoff_config):
+        """HEAD returns 403, GET fallback returns 200 — both recorded."""
+        call_count = [0]
+
+        def _urlopen_factory(req, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First call is HEAD → 403
+                raise urllib.error.HTTPError(
+                    url="https://example.com",
+                    code=403,
+                    msg="Forbidden",
+                    hdrs=None,  # type: ignore[arg-type]
+                    fp=None,
+                )
+            # Second call is GET → 200
+            return _mock_urlopen_response(status=200)
+
+        with mock.patch("gh_link_auditor.network.urllib.request.urlopen", side_effect=_urlopen_factory):
+            result = check_url(
+                "https://example.com",
+                backoff_config=no_retry_backoff_config,
+            )
+
+        assert result["status"] == "ok"
+        assert result["status_code"] == 200
+        assert result["method"] == "GET"
+        assert result["head_status_code"] == 403
+        assert result["get_status_code"] == 200
+
+    def test_both_404_records_both(self, no_retry_backoff_config):
+        """HEAD and GET both 404 (fallback attempted, both dead) — both
+        statuses recorded so downstream can see 'truly dead, not HEAD-strict'."""
+
+        def _urlopen_factory(req, **kwargs):
+            raise urllib.error.HTTPError(
+                url="https://example.com",
+                code=404,
+                msg="Not Found",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=None,
+            )
+
+        with mock.patch("gh_link_auditor.network.urllib.request.urlopen", side_effect=_urlopen_factory):
+            result = check_url(
+                "https://example.com/nope",
+                backoff_config=no_retry_backoff_config,
+            )
+
+        assert result["status"] != "ok"
+        assert result["status_code"] == 404
+        assert result["head_status_code"] == 404
+        assert result["get_status_code"] == 404
 
 
 # ---------------------------------------------------------------------------
@@ -1337,6 +1400,7 @@ class TestCheckUrlFullFlow:
         assert result["status"] == "ok"
         assert isinstance(result, dict)
         # Verify all required keys are present, including final_url (#315)
+        # and head_status_code/get_status_code (#343)
         expected_keys = {
             "url",
             "status",
@@ -1346,6 +1410,8 @@ class TestCheckUrlFullFlow:
             "retries",
             "error",
             "final_url",
+            "head_status_code",
+            "get_status_code",
         }
         assert set(result.keys()) == expected_keys
 

--- a/tests/unit/test_unified_db.py
+++ b/tests/unit/test_unified_db.py
@@ -1064,3 +1064,66 @@ class TestMigrationV8ToV9:
         with UnifiedDatabase(db_file) as db:
             row = db._conn.execute("SELECT version FROM schema_version").fetchone()
             assert row["version"] == SCHEMA_VERSION
+
+
+class TestMigrationV9ToV10:
+    """#343: head_status + get_status columns added to url_check_cache."""
+
+    def test_migrate_adds_head_status_and_get_status_columns(self, tmp_path):
+        db_file = str(tmp_path / "v9.db")
+        # Build a v9 database: open + close, then downgrade the version and
+        # drop the new columns so the next open triggers v9 -> v10.
+        with UnifiedDatabase(db_file) as db:
+            db._conn.execute("UPDATE schema_version SET version = 9")
+            # Rebuild url_check_cache without the new columns (simulating v9)
+            db._conn.execute("DROP TABLE IF EXISTS url_check_cache")
+            db._conn.execute(
+                """CREATE TABLE url_check_cache (
+                    url TEXT PRIMARY KEY,
+                    http_status INTEGER,
+                    final_url TEXT,
+                    is_bot_blocked INTEGER DEFAULT 0,
+                    retry_count INTEGER DEFAULT 0,
+                    last_checked_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL
+                )"""
+            )
+            db._conn.commit()
+
+        # Re-open: should run v9 -> v10 migration
+        with UnifiedDatabase(db_file) as db:
+            row = db._conn.execute("SELECT version FROM schema_version").fetchone()
+            assert row["version"] == SCHEMA_VERSION
+            cols = {r[1] for r in db._conn.execute("PRAGMA table_info(url_check_cache)").fetchall()}
+            assert "head_status" in cols
+            assert "get_status" in cols
+
+    def test_cache_url_check_persists_both_statuses(self, tmp_path):
+        db_file = str(tmp_path / "v10.db")
+        with UnifiedDatabase(db_file) as db:
+            db.cache_url_check(
+                url="https://x.example/page",
+                http_status=200,
+                final_url="https://x.example/page",
+                head_status=403,
+                get_status=200,
+            )
+            row = db.get_cached_url_check("https://x.example/page")
+            assert row is not None
+            assert row["http_status"] == 200
+            assert row["head_status"] == 403
+            assert row["get_status"] == 200
+
+    def test_cache_url_check_defaults_keep_old_callers_working(self, tmp_path):
+        db_file = str(tmp_path / "v10.db")
+        with UnifiedDatabase(db_file) as db:
+            # Old call shape (no head_status / get_status) must still work.
+            db.cache_url_check(
+                url="https://y.example/page",
+                http_status=200,
+                final_url=None,
+            )
+            row = db.get_cached_url_check("https://y.example/page")
+            assert row is not None
+            assert row["head_status"] is None
+            assert row["get_status"] is None


### PR DESCRIPTION
## Summary

#314 audit found URLs marked dead in `bulk_scan_findings` that are actually 2xx now. Investigation showed `network.check_url` already implements the HEAD→GET fallback chain, modern-UA retry, and headless-Playwright stealth — the existing fallback logic is comprehensive. But `check_url` only returned ONE status code, losing the "URL is HEAD-strict" signal (HEAD 4xx but GET 2xx). That hides a class of upstream-quirky servers from downstream consumers and from operator triage.

This PR addresses #343's remaining acceptance items:
- Track HEAD and GET statuses separately on the `RequestResult`
- Log when HEAD→GET fallback fires (debugging trace)
- Persist both statuses on `url_check_cache` so cached results retain the signal

## Changes

| File | Change |
|---|---|
| `network.py` | `RequestResult` gains `head_status_code` + `get_status_code` (NotRequired). `check_url` tracks both in the retry/fallback loop. INFO log when HEAD→GET fires |
| `unified_db.py` | Schema v9→v10 migration adds `head_status` + `get_status` columns to `url_check_cache`. `cache_url_check` / `get_cached_url_check` updated. Migration tolerates missing table (deep older-version paths) |
| `bulk_scan/runner.py` | `_persist` plumbs both new fields into `cache_url_check` |

Backward compatibility:
- Old `cache_url_check` call shape (no new kwargs) still works; new columns default to `NULL`
- `RequestResult` consumers reading only existing keys are unaffected (TypedDict NotRequired)

## Test plan

- [x] 2 new check_url tests covering HEAD-strict tracking (HEAD 403 + GET 200; both 404)
- [x] 3 new migration tests: column addition; persistence of both statuses; backward-compat call shape
- [x] Existing `test_check_url_default_configs` updated to assert the new keys
- [x] `test_storage.py::test_schema_version` updated 9 → 10
- [x] Full unit suite: 2435 passed, 1 skipped
- [x] `ruff check` + `ruff format` clean
- [ ] CI green
- [ ] Cerberus-AZ approves

## What this does NOT include

`network.check_url`'s fallback chain itself — already comprehensive. The smoke test (`tools/probe_check_url_audit_urls.py`, not committed) confirmed all 5 audit URLs that bulk-scan classified dead are correctly classified live by the existing logic. The audit's findings reflect data staleness, not detection error.

Closes #343