### PR TITLE
fix(cli): route INFO logs to stderr; add watch_bulk_scan.py poller

### DIFF
--- a/src/gh_link_auditor/cli/main.py
+++ b/src/gh_link_auditor/cli/main.py
@@ -6,6 +6,7 @@ Provides the `ghla` command with subcommands.
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 import warnings
 
@@ -22,6 +23,32 @@ from gh_link_auditor.cli.rewrite_queue_cmd import build_rewrite_queue_parser  # 
 from gh_link_auditor.cli.run import build_run_parser  # noqa: E402
 
 
+def _configure_logging(level: int) -> None:
+    """Route library loggers to stderr so long-running commands stream
+    progress to the operator's console instead of going silent for hours.
+
+    Previously the CLI did not call logging.basicConfig at all, which
+    meant every logger.info(...) across bulk-scan, preflight, liveness,
+    investigation, etc. went to the default null handler. Multi-hour
+    runs appeared frozen even though work was happening.
+
+    force=True replaces any handler imported libraries may have
+    configured first (e.g. langchain). Without it, basicConfig would
+    be a no-op when handlers already exist.
+    """
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)-5s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+        stream=sys.stderr,
+        force=True,
+    )
+    # Knock down third-party noise so the gh_link_auditor signal stays
+    # readable. -vv re-enables DEBUG on these.
+    for noisy in ("httpx", "httpcore", "urllib3"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the main argument parser.
 
@@ -31,6 +58,19 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="ghla",
         description="gh-link-auditor: Dead link resolution pipeline",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity: -v = DEBUG from gh_link_auditor; -vv = DEBUG everywhere including httpx",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress INFO-level progress; only WARNING/ERROR are shown",
     )
     subparsers = parser.add_subparsers(dest="command")
 
@@ -60,6 +100,17 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    if args.quiet:
+        _configure_logging(logging.WARNING)
+    elif args.verbose >= 2:
+        _configure_logging(logging.DEBUG)
+        for noisy in ("httpx", "httpcore", "urllib3"):
+            logging.getLogger(noisy).setLevel(logging.DEBUG)
+    elif args.verbose == 1:
+        _configure_logging(logging.DEBUG)
+    else:
+        _configure_logging(logging.INFO)
 
     if not args.command:
         parser.print_help()

--- a/tools/watch_bulk_scan.py
+++ b/tools/watch_bulk_scan.py
@@ -1,0 +1,131 @@
+"""Poll a running bulk-scan and print progress to the console.
+
+Workaround for the CLI's missing logging output (fix landing as a PR).
+Until that ships, run this in a second terminal alongside the scan and
+you'll see the repo-count incrementing, findings count incrementing, and
+a rough rate + ETA.
+
+Usage::
+
+    poetry run python tools/watch_bulk_scan.py [RUN_ID]
+    poetry run python tools/watch_bulk_scan.py --interval 15
+
+If RUN_ID is omitted, watches the most-recent run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from gh_link_auditor.bulk_scan import scoring, storage  # noqa: E402
+from gh_link_auditor.unified_db import DEFAULT_DB_PATH, UnifiedDatabase  # noqa: E402
+
+
+def _resolve_run_id(db: UnifiedDatabase, requested: str | None) -> str | None:
+    if requested:
+        return requested
+    runs = storage.list_runs(db, limit=1)
+    return runs[0]["run_id"] if runs else None
+
+
+def _snapshot(db: UnifiedDatabase, run_id: str) -> dict:
+    run = storage.get_run(db, run_id)
+    if run is None:
+        return {}
+    counts = storage.get_repo_count_by_status(db, run_id)
+    total = storage.count_findings(db, run_id)
+    surfaced = storage.count_findings(db, run_id, surfaced=True)
+    median = scoring.quality_sample_median(db, run_id)
+    return {
+        "status": run["status"],
+        "counts": counts,
+        "total": total,
+        "surfaced": surfaced,
+        "median": median,
+        "target": run.get("target_repo_count") or 0,
+    }
+
+
+def _format_delta(curr: int, prev: int | None) -> str:
+    if prev is None:
+        return ""
+    d = curr - prev
+    return f" (+{d})" if d > 0 else " (=)" if d == 0 else f" ({d})"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_id", nargs="?", default=None)
+    parser.add_argument("--interval", type=int, default=30, help="poll interval seconds (default 30)")
+    parser.add_argument("--db-path", default=str(DEFAULT_DB_PATH))
+    args = parser.parse_args()
+
+    started_wall: float | None = None
+    first_inv: int | None = None
+    prev_inv: int | None = None
+    prev_total: int | None = None
+
+    while True:
+        try:
+            with UnifiedDatabase(args.db_path) as db:
+                run_id = _resolve_run_id(db, args.run_id)
+                if not run_id:
+                    print("no runs found", flush=True)
+                    return 1
+                snap = _snapshot(db, run_id)
+        except Exception as exc:  # noqa: BLE001
+            print(f"poll error: {exc}", flush=True)
+            time.sleep(args.interval)
+            continue
+
+        if not snap:
+            print(f"run {run_id} not found", flush=True)
+            return 1
+
+        now = datetime.now(timezone.utc).strftime("%H:%M:%S")
+        counts = snap["counts"]
+        inv = counts.get("inventoried", 0)
+        pend = counts.get("pending", 0)
+        err = counts.get("error", 0)
+        if started_wall is None:
+            started_wall = time.time()
+            first_inv = inv
+        elapsed_min = (time.time() - started_wall) / 60
+        gained = inv - (first_inv or 0)
+        rate = (gained / elapsed_min) if elapsed_min > 0.1 else 0.0
+        remaining = max(snap["target"] - inv, 0)
+        eta_min = (remaining / rate) if rate > 0 else None
+        eta_str = f"ETA ~{eta_min:.0f}m" if eta_min is not None else "ETA n/a"
+
+        print(
+            f"[{now}] {run_id} status={snap['status']:13s} "
+            f"inventoried={inv}/{snap['target']}{_format_delta(inv, prev_inv)} "
+            f"pending={pend} err={err} "
+            f"findings={snap['total']}{_format_delta(snap['total'], prev_total)} "
+            f"rate={rate:.1f}/min {eta_str}",
+            flush=True,
+        )
+
+        prev_inv = inv
+        prev_total = snap["total"]
+
+        if snap["status"] in ("done", "quality_aborted", "aborted"):
+            print(f"\nrun finished with status: {snap['status']}", flush=True)
+            return 0
+
+        try:
+            time.sleep(args.interval)
+        except KeyboardInterrupt:
+            print("\ninterrupted (the scan keeps running; just stopping the watcher)", flush=True)
+            return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`gh_link_auditor.cli.main` never called `logging.basicConfig`. Every `logger.info(...)` across the codebase (bulk-scan, preflight, liveness, investigation, gh_client, ...) went to the root logger's NullHandler and disappeared. This is the underlying cause of the long-running visibility complaint operators have been raising — multi-hour runs look frozen even when work is happening.

## What changes

`src/gh_link_auditor/cli/main.py`:
- `_configure_logging(level)` calls `logging.basicConfig(..., stream=sys.stderr, force=True)` with `HH:MM:SS LEVEL name: message` format
- Top-level `-v/--verbose` (count) and `-q/--quiet` flags
- Default INFO; `-v` adds DEBUG from `gh_link_auditor`; `-vv` adds DEBUG everywhere
- httpx/httpcore/urllib3 throttled to WARNING by default so the signal stays readable

`tools/watch_bulk_scan.py`:
- Out-of-process poller; prints status + repo-count + findings-count + delta + rate + ETA every N seconds
- Workaround for the running scan that started before this fix landed

## Test plan

- [x] 73 CLI unit tests pass
- [x] `ruff check` + `ruff format` clean
- [x] Smoke test: `ghla bulk-scan list-runs` works (and stays terse — no surprise log output for read-only subcommands)
- [ ] CI green
- [ ] Cerberus-AZ approves
- [ ] Post-merge: kick off a small bulk-scan and confirm progress lines stream to console

## Why this is urgent

Sibling visibility issues (#234, #240, #277) all sit on top of this. Even after those land, if the CLI doesn't route logs to stderr, their `logger.info` updates would still be invisible. This fix is the load-bearing prerequisite.

Closes #353