### PR TITLE
fix(bulk-scan): wire host-blocklist into ALWAYS_ALIVE_DOMAINS + stage-3 skip

### DIFF
--- a/src/gh_link_auditor/bulk_scan/runner.py
+++ b/src/gh_link_auditor/bulk_scan/runner.py
@@ -37,6 +37,7 @@ from gh_link_auditor.bulk_scan.config import (
     REPORT_FILE,
     SAMPLE_FILE,
 )
+from gh_link_auditor.false_positives import is_always_alive_domain
 from gh_link_auditor.unified_db import UnifiedDatabase
 
 logger = logging.getLogger(__name__)
@@ -321,6 +322,17 @@ def run_investigation(
             skipped_non_english += 1
             continue
         url = finding["dead_url"]
+        # Host-level skip: known-anti-bot / JS-shell / paywalled hosts measured
+        # to yield zero useful candidates across hundreds of investigations
+        # (data/host-blocklist-candidates.md). Earlier we only filtered these
+        # at inventory time; rows already in bulk_scan_findings from a prior
+        # scan or a slow-to-update blocklist still arrive here. Skip them now
+        # instead of burning archive_client / CDX cycles.
+        if is_always_alive_domain(url):
+            with db._conn:
+                _mark_finding(db, finding["id"], "skipped_alive")
+            skipped_alive += 1
+            continue
         result = liveness_results.get(url, {})
         if not liveness.is_dead_result(result):
             # URL is alive — mark and move on (#244: no DELETE, preserves Stage 1 mapping)

--- a/src/gh_link_auditor/false_positives.py
+++ b/src/gh_link_auditor/false_positives.py
@@ -22,11 +22,21 @@ SKIP_DOMAINS: set[str] = {
     "0.0.0.0",
 }
 
-# Stack Exchange network — categorical skip. URLs here have semantics our
-# pipeline doesn't encode: /a/N and /q/N redirect to long form, content is
-# essentially never deleted, and "fixing" SO links is almost always wrong
-# (#211, 2026-05-13).
+# Categorical skip during inventory AND investigation. Two sub-categories
+# share the same set because the pipeline behavior is identical: don't
+# probe, don't investigate, don't burn candidate-generation cycles.
+#
+# 1. Stack Exchange family (#211) — URLs have semantics our pipeline
+#    can't encode: /a/N and /q/N redirect to long form, content is
+#    essentially never deleted, and "fixing" SO links is almost always wrong.
+#
+# 2. Known-anti-bot / JS-shell / paywalled (data/host-blocklist-candidates.md
+#    2026-05-23) — measured 0% candidate-yield across hundreds of real
+#    investigations, often 100% bot-blocked (None status). We have nothing
+#    useful to offer maintainers from these hosts. Add new entries here
+#    when the next host-blocklist audit surfaces another categorical waste.
 ALWAYS_ALIVE_DOMAINS: set[str] = {
+    # Stack Exchange family (#211)
     "stackoverflow.com",
     "stackexchange.com",  # plus every *.stackexchange.com subdomain
     "serverfault.com",
@@ -34,6 +44,34 @@ ALWAYS_ALIVE_DOMAINS: set[str] = {
     "askubuntu.com",
     "mathoverflow.net",
     "stackapps.com",
+    # Known-anti-bot / JS-shell / paywalled (from
+    # data/host-blocklist-candidates.md, generated 2026-05-23 across a
+    # 506k-finding scan — every host below had 0 candidates produced
+    # despite tens to hundreds of real investigation attempts).
+    "npmjs.com",
+    "kalshi.com",
+    "polymarket.com",
+    "medium.com",
+    "openai.com",
+    "linkedin.com",
+    "dl.acm.org",
+    "ieeexplore.ieee.org",
+    "sciencedirect.com",
+    "glyphwiki.org",
+    "opendap.4tu.nl",
+    "play.picoctf.org",
+    "docs.signalfx.com",
+    "forums.welltrainedmind.com",
+    "experimentalhistory.substack.com",
+    "gseth.com",
+    "ecode360.com",
+    "eigenphi.io",
+    "notes.andymatuschak.org",
+    "vision.princeton.edu",
+    "afcd.foodstandards.gov.au",
+    "bibliography.lingpy.org",
+    "pyspedas.readthedocs.io",
+    "mfa-models.readthedocs.io",
 }
 
 # Domains that return 403/429 to bots but work fine in browsers.

--- a/tests/unit/test_false_positives.py
+++ b/tests/unit/test_false_positives.py
@@ -287,10 +287,16 @@ class TestIsFalsePositive:
         # status. (Previously this returned False — required a 403/429 to fire.)
         assert is_false_positive("https://stackoverflow.com/q/1") is True
 
-    def test_non_se_bot_blocked_without_status_not_filtered(self) -> None:
-        # Non-SE bot-blocked domains (medium, wikipedia, etc.) still require a
-        # status code to be flagged — they aren't always-alive, just bot-blocked.
-        assert is_false_positive("https://medium.com/something") is False
+    def test_wikipedia_bot_blocked_without_status_not_filtered(self) -> None:
+        # wikipedia.org is BOT_BLOCKED_DOMAINS but NOT ALWAYS_ALIVE_DOMAINS, so
+        # it still requires a status code to flag as false positive.
+        assert is_false_positive("https://en.wikipedia.org/wiki/Foo") is False
+
+    def test_categorical_skip_blocklist_filtered_without_status(self) -> None:
+        # Host-blocklist domains added 2026-05-26 (npmjs, medium, openai, etc.)
+        # are categorical skips like Stack Exchange — filtered regardless of status.
+        assert is_false_positive("https://www.npmjs.com/package/foo") is True
+        assert is_false_positive("https://medium.com/something") is True
 
     # ------------------------------------------------------------------
     # #243: donation / sponsorship URL categorical skip

--- a/tools/skip_blocklisted_pending.py
+++ b/tools/skip_blocklisted_pending.py
@@ -1,0 +1,80 @@
+"""One-shot DB mutation: mark pending findings on known-anti-bot hosts as
+skipped_alive so the running scan stops touching them on its next
+iteration. Companion to the host-blocklist wire-in (false_positives.py
+ALWAYS_ALIVE_DOMAINS additions, 2026-05-26).
+
+Safe to run while a scan is active: updates only `pending` rows, doesn't
+touch derived_candidate or any in-flight state. SQLite serializes.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+DOMAINS = {
+    "npmjs.com",
+    "kalshi.com",
+    "polymarket.com",
+    "medium.com",
+    "openai.com",
+    "linkedin.com",
+    "dl.acm.org",
+    "ieeexplore.ieee.org",
+    "sciencedirect.com",
+    "glyphwiki.org",
+    "opendap.4tu.nl",
+    "play.picoctf.org",
+    "docs.signalfx.com",
+    "forums.welltrainedmind.com",
+    "experimentalhistory.substack.com",
+    "gseth.com",
+    "ecode360.com",
+    "eigenphi.io",
+    "notes.andymatuschak.org",
+    "vision.princeton.edu",
+    "afcd.foodstandards.gov.au",
+    "bibliography.lingpy.org",
+    "pyspedas.readthedocs.io",
+    "mfa-models.readthedocs.io",
+}
+
+
+def main() -> int:
+    run_id = sys.argv[1] if len(sys.argv) > 1 else "bulk-20260526T031148Z"
+    db_path = Path.home() / ".ghla" / "ghla.db"
+    d = sqlite3.connect(str(db_path))
+    rows = d.execute(
+        "SELECT id, dead_url FROM bulk_scan_findings WHERE run_id = ? AND investigation_state = 'pending'",
+        (run_id,),
+    ).fetchall()
+    sys.stdout.write(f"pending rows in {run_id}: {len(rows)}\n")
+
+    to_skip: list[int] = []
+    for rid, url in rows:
+        try:
+            host = (urlparse(url).hostname or "").lower()
+        except Exception:  # noqa: BLE001
+            continue
+        for dom in DOMAINS:
+            if host == dom or host.endswith("." + dom):
+                to_skip.append(rid)
+                break
+
+    sys.stdout.write(f"matching blocklist: {len(to_skip)}\n")
+    if to_skip:
+        placeholders = ",".join("?" * len(to_skip))
+        d.execute(
+            f"UPDATE bulk_scan_findings SET investigation_state='skipped_alive' WHERE id IN ({placeholders})",  # noqa: S608
+            to_skip,
+        )
+        d.commit()
+        sys.stdout.write(f"updated {len(to_skip)} rows to skipped_alive\n")
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`data/host-blocklist-candidates.md` (generated 2026-05-23 across a 506k-finding scan) listed 42 hosts with 0% candidate yield. The file existed; the hosts were never wired into the code. Result: every bulk-scan kept pulling these hosts through inventory + liveness + investigation, burning archive_client / CDX cycles to produce zero candidates. Operator caught `CDX API request failed for https://www.npmjs.com/` mid-scan.

## What changes

- `false_positives.py`: add 24 of 42 candidate hosts to `ALWAYS_ALIVE_DOMAINS` (the clear-anti-bot / JS-shell / paywalled subset; conservative — left `github.com`, `arxiv.org`, `doi.org`, `huggingface.co`, `web.archive.org`, `learn.microsoft.com` off since those have specific handlers or are useful)
- `bulk_scan/runner.py`: second-fence skip in `run_investigation` — check `is_always_alive_domain` before `investigate_one`. URLs already in DB from prior partial scans (or domains added mid-stage) now get marked `skipped_alive` instead of triggering archive client.
- `tools/skip_blocklisted_pending.py`: one-shot DB mutation operator can run against an active run to mark `pending` rows on these hosts as `skipped_alive`. Agent auto-mode classifier blocks the agent from running it during an active scan; operator runs it.
- Test updated: `medium.com` no longer "requires status code" — it's a categorical skip now. New test pins the categorical-skip behavior.

## Test plan

- [x] 133 `test_false_positives.py` tests pass
- [x] 174 `tests/unit/bulk_scan/` tests pass
- [x] `ruff check` + `ruff format` clean
- [ ] CI green
- [ ] Cerberus-AZ approves
- [ ] (Operator-driven, post-merge) run `tools/skip_blocklisted_pending.py bulk-20260526T031148Z` against the live scan

Closes #357