### PR TITLE
feat(bulk-scan): in-process status emitter -- one console, visible progress

### DIFF
--- a/src/gh_link_auditor/bulk_scan/progress.py
+++ b/src/gh_link_auditor/bulk_scan/progress.py
@@ -1,0 +1,233 @@
+"""Stage-aware progress rendering for the bulk-scan pipeline.
+
+A single source of truth for the status line emitted by:
+- runner.run_full() -- in-process daemon thread, one line per 30s, INFO logger
+- tools/watch_bulk_scan.py -- out-of-process poller, prints to stdout
+
+Status line shape matches tools/finish_stage{1,2,3}.py (PR #271):
+
+    [HH:MM:SS] stage<N> processed/total (pct%) ... rate=R/min (5m: r/min) ETA=T
+
+Per-stage detail:
+- stage1 (selecting/inventorying): inventoried/target with findings count
+- stage2 (checking): findings probed
+- stage3 (investigating): GROUP BY investigation_state buckets,
+  yield%, candidates inserted
+- stage4/5 (scoring/done): scoring snapshot
+
+All queries are read-only against bulk_scan_findings / bulk_scan_runs /
+bulk_scan_repos -- safe to run alongside an active scan.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import deque
+from datetime import datetime
+from typing import Any
+
+from gh_link_auditor.bulk_scan import scoring, storage
+from gh_link_auditor.unified_db import UnifiedDatabase
+
+logger = logging.getLogger(__name__)
+
+# Map bulk_scan_runs.status -> stage number for the prefix
+STAGE_MAP = {
+    "selecting": 1,
+    "inventorying": 1,
+    "checking": 2,
+    "investigating": 3,
+    "scoring": 4,
+    "done": 5,
+    "quality_aborted": 5,
+    "aborted": 5,
+}
+
+DEFAULT_INTERVAL_S = 30.0
+
+
+def investigation_buckets(db: UnifiedDatabase, run_id: str) -> dict[str, int]:
+    """Group bulk_scan_findings by investigation_state for the run."""
+    rows = db._conn.execute(
+        "SELECT investigation_state, COUNT(*) AS n FROM bulk_scan_findings "
+        "WHERE run_id = ? GROUP BY investigation_state",
+        (run_id,),
+    ).fetchall()
+    return {r["investigation_state"]: r["n"] for r in rows}
+
+
+def snapshot(db: UnifiedDatabase, run_id: str) -> dict[str, Any]:
+    """Read-only DB snapshot used by both in-process and out-of-process emitters."""
+    run = storage.get_run(db, run_id)
+    if run is None:
+        return {}
+    counts = storage.get_repo_count_by_status(db, run_id)
+    total = storage.count_findings(db, run_id)
+    surfaced = storage.count_findings(db, run_id, surfaced=True)
+    median = scoring.quality_sample_median(db, run_id)
+    inv_buckets = investigation_buckets(db, run_id)
+    return {
+        "status": run["status"],
+        "counts": counts,
+        "total_findings": total,
+        "surfaced": surfaced,
+        "median": median,
+        "target": run.get("target_repo_count") or 0,
+        "inv_buckets": inv_buckets,
+    }
+
+
+def _eta_str(remaining: int, rate_per_min: float) -> str:
+    if rate_per_min <= 0:
+        return "?"
+    m = remaining / rate_per_min
+    return f"{m:.0f}m" if m < 60 else f"{m / 60:.1f}h"
+
+
+def _rate(window: deque) -> float:
+    """Per-minute rate over the rolling window."""
+    if len(window) < 2:
+        return 0.0
+    ts0, v0 = window[0]
+    ts1, v1 = window[-1]
+    dt = ts1 - ts0
+    if dt <= 0:
+        return 0.0
+    return (v1 - v0) / (dt / 60.0)
+
+
+def render(
+    snap: dict[str, Any],
+    stage1_window: deque,
+    findings_window: deque,
+    stage3_window: deque,
+    started_mono: float,
+) -> str:
+    """Return a single-line status string for the current stage."""
+    now = datetime.now().strftime("%H:%M:%S")
+    status = snap["status"]
+    stage = STAGE_MAP.get(status, 0)
+    counts = snap["counts"]
+    target = snap["target"]
+    inv_repos = counts.get("inventoried", 0)
+    pend_repos = counts.get("pending", 0)
+    err_repos = counts.get("error", 0)
+    findings = snap["total_findings"]
+    surfaced = snap["surfaced"]
+    buckets = snap.get("inv_buckets", {})
+
+    if stage == 1:
+        processed = inv_repos + err_repos
+        pct = (100.0 * processed / target) if target else 0.0
+        elapsed_min = (time.monotonic() - started_mono) / 60.0
+        overall = (processed / elapsed_min) if elapsed_min > 0.1 else 0.0
+        recent = _rate(stage1_window)
+        findings_recent = _rate(findings_window)
+        remaining = max(target - processed, 0)
+        eta = _eta_str(remaining, recent if recent > 0 else overall)
+        return (
+            f"[{now}] stage1 {processed:,}/{target:,} ({pct:.1f}%) "
+            f"inventoried={inv_repos:,} pending={pend_repos:,} err={err_repos:,} "
+            f"findings={findings:,} (5m: {findings_recent:+.0f}/min) "
+            f"rate={overall:.1f}/min (5m: {recent:.1f}/min) ETA={eta}"
+        )
+    if stage == 2:
+        findings_recent = _rate(findings_window)
+        return (
+            f"[{now}] stage2 status=checking findings={findings:,} "
+            f"surfaced={surfaced:,} (5m: {findings_recent:+.0f}/min)"
+        )
+    if stage == 3:
+        pending = buckets.get("pending", 0)
+        processed = findings - pending
+        pct = (100.0 * processed / findings) if findings else 0.0
+        inv_with = buckets.get("investigated_with_candidate", 0)
+        inv_no = buckets.get("investigated_no_candidate", 0)
+        derived = buckets.get("derived_candidate", 0)
+        real_invs = inv_with + inv_no
+        yield_str = f"yield={100.0 * inv_with / real_invs:.1f}%" if real_invs else "yield=n/a"
+        skipped_total = (
+            buckets.get("skipped_alive", 0) + buckets.get("skipped_language", 0) + buckets.get("skipped_blocklist", 0)
+        )
+        rate = _rate(stage3_window)
+        eta = _eta_str(pending, rate)
+        return (
+            f"[{now}] stage3 {processed:,}/{findings:,} ({pct:.1f}%) "
+            f"skipped={skipped_total:,} investigated={real_invs:,} {yield_str} "
+            f"cands+={derived:,} (5m: {rate:+.0f}/min) ETA={eta}"
+        )
+    median_str = f" sample_median={snap['median']:.2f}" if snap.get("median") else ""
+    if stage == 4:
+        return f"[{now}] stage4 scoring surfaced={surfaced:,}{median_str}"
+    if stage == 5:
+        return f"[{now}] stage5 status={status} surfaced={surfaced:,}/{findings:,}{median_str}"
+    return f"[{now}] status={status} (no progress data -- stage unknown)"
+
+
+class StatusEmitter:
+    """Background daemon thread that polls the DB and emits a status line
+    every ``interval_s`` seconds via the module logger.
+
+    Started by runner.run_full() at the top, stopped in the finally block.
+    Re-entrant safe: stop() is idempotent.
+    """
+
+    def __init__(
+        self,
+        db: UnifiedDatabase,
+        run_id: str,
+        interval_s: float = DEFAULT_INTERVAL_S,
+        log: logging.Logger | None = None,
+    ) -> None:
+        self._db = db
+        self._run_id = run_id
+        self._interval_s = interval_s
+        self._log = log or logger
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._stage1_window: deque = deque(maxlen=10)
+        self._findings_window: deque = deque(maxlen=10)
+        self._stage3_window: deque = deque(maxlen=10)
+        self._started_mono = time.monotonic()
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._thread = threading.Thread(target=self._run, name=f"status-emitter-{self._run_id}", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=self._interval_s + 5.0)
+
+    def _run(self) -> None:
+        # First emission shortly after start so the operator sees the line
+        # before having to wait a full interval.
+        first_wait = min(2.0, self._interval_s)
+        if self._stop.wait(first_wait):
+            return
+        while not self._stop.is_set():
+            try:
+                snap = snapshot(self._db, self._run_id)
+                if snap:
+                    now_mono = time.monotonic()
+                    counts = snap["counts"]
+                    self._stage1_window.append((now_mono, counts.get("inventoried", 0) + counts.get("error", 0)))
+                    self._findings_window.append((now_mono, snap["total_findings"]))
+                    pending3 = snap.get("inv_buckets", {}).get("pending", 0)
+                    self._stage3_window.append((now_mono, snap["total_findings"] - pending3))
+                    line = render(
+                        snap,
+                        self._stage1_window,
+                        self._findings_window,
+                        self._stage3_window,
+                        self._started_mono,
+                    )
+                    self._log.info(line)
+            except Exception as exc:  # noqa: BLE001
+                self._log.warning("status emitter poll error: %s", exc)
+            if self._stop.wait(self._interval_s):
+                return

--- a/src/gh_link_auditor/bulk_scan/runner.py
+++ b/src/gh_link_auditor/bulk_scan/runner.py
@@ -21,6 +21,7 @@ from gh_link_auditor.bulk_scan import (
     investigation,
     liveness,
     process_lock,
+    progress,
     scoring,
     selection,
     storage,
@@ -433,6 +434,7 @@ def run_full(
     target_count: int,
     token: str | None = None,
     skip_selection: bool = False,
+    status_interval_s: float = 30.0,
 ) -> dict[str, Any]:
     """End-to-end orchestration. Resumable: existing state respected.
 
@@ -440,10 +442,16 @@ def run_full(
     on exit. Concurrent invocations of bulk-scan against the same run-id raise
     LockBusyError, preventing the racing-processes data-loss scenario from
     2026-05-22.
+
+    Emits a stage-aware status line every ``status_interval_s`` seconds via the
+    module logger (which the CLI routes to stderr). One terminal, one process,
+    visible progress -- no separate watcher required (#359).
     """
     # Acquire the per-(run_id, host) lock before any work
     process_lock.acquire(db, run_id)
+    emitter = progress.StatusEmitter(db, run_id, interval_s=status_interval_s)
     try:
+        emitter.start()
         run = storage.get_run(db, run_id)
         if run is None:
             storage.create_run(db, run_id, target_count, {"target_count": target_count})
@@ -472,4 +480,5 @@ def run_full(
         heartbeat.write_heartbeat(db, run_id, HEARTBEAT_FILE)
         return storage.get_run(db, run_id) or {}
     finally:
+        emitter.stop()
         process_lock.release(db, run_id)


### PR DESCRIPTION
## Summary

After PR #354 (CLI log routing) and PR #356 (stage-3 buckets), progress was visible only via a separate `tools/watch_bulk_scan.py` poller in a second terminal. Workaround, not a fix. Operator wants ONE console.

This PR adds in-process status emission. The scan logs its own progress every 30s to the same stderr stream `ghla bulk-scan start` is running on. No second terminal required.

## What changes

`src/gh_link_auditor/bulk_scan/progress.py` (new):
- `snapshot(db, run_id)` — shared DB poll
- `render(snap, ...)` — single source of truth for the status line (matches `finish_stage*.py` / PR #271 shape)
- `StatusEmitter(db, run_id, interval_s)` — daemon thread, INFO logger

`bulk_scan/runner.py`:
- Import `progress`
- `run_full()` starts the emitter at entry, stops it in the `finally` block

## Test plan

- [x] 174 `tests/unit/bulk_scan/` tests pass
- [x] `ruff check` + `ruff format` clean
- [ ] CI green
- [ ] Cerberus-AZ approves
- [ ] (Operator, post-merge) kill the running scan, restart, observe status lines streaming on the same terminal

Closes #359