### PR TITLE
test(blacklist): assert is_blacklisted called with repo_url + maintainer

### DIFF
--- a/src/gh_link_auditor/batch/engine.py
+++ b/src/gh_link_auditor/batch/engine.py
@@ -155,9 +155,10 @@ async def _process_single_repo(
             from gh_link_auditor.unified_db import UnifiedDatabase
 
             repo_url = f"https://github.com/{task.repo_full_name}"
+            maintainer = task.repo_full_name.partition("/")[0]
             udb = UnifiedDatabase(config.db_path)
             try:
-                if udb.is_blacklisted(repo_url):
+                if udb.is_blacklisted(repo_url, maintainer):
                     task.status = TaskStatus.SKIPPED
                     task.error_message = "blacklisted"
                     task.completed_at = now_utc()

--- a/src/gh_link_auditor/pipeline/nodes/n0_load_target.py
+++ b/src/gh_link_auditor/pipeline/nodes/n0_load_target.py
@@ -175,7 +175,7 @@ def n0_load_target(state: PipelineState) -> PipelineState:
             if db_path:
                 udb = UnifiedDatabase(db_path)
                 repo_url = f"https://github.com/{owner}/{repo}"
-                if udb.is_blacklisted(repo_url):
+                if udb.is_blacklisted(repo_url, owner):
                     state["errors"] = state.get("errors", []) + [f"Repo {repo_url} is blacklisted"]
                     udb.close()
                     return state

--- a/src/gh_link_auditor/pr_tracker.py
+++ b/src/gh_link_auditor/pr_tracker.py
@@ -399,7 +399,7 @@ def refresh_pr_outcomes(db_path: Path) -> list[PROutcome]:
             repo_url = f"https://github.com/{outcome.repo_full_name}"
             new_status = _determine_status(api_data)
 
-            if not udb.is_blacklisted(repo_url):
+            if not udb.is_blacklisted(repo_url, owner):
                 hostile = _find_hostile_comments(owner, repo, pr_number)
                 if hostile:
                     first = hostile[0]
@@ -424,7 +424,7 @@ def refresh_pr_outcomes(db_path: Path) -> list[PROutcome]:
                 # Still open — check for unresponsive timeout
                 days_open = (now - outcome.submitted_at).days
                 if days_open >= _UNRESPONSIVE_DAYS:
-                    if not udb.is_blacklisted(repo_url):
+                    if not udb.is_blacklisted(repo_url, owner):
                         expiry = now + timedelta(days=_UNRESPONSIVE_EXPIRY_DAYS)
                         udb.add_to_blacklist(
                             repo_url=repo_url,

--- a/tests/unit/test_blacklist_contract.py
+++ b/tests/unit/test_blacklist_contract.py
@@ -1,0 +1,88 @@
+"""Pin the H5 contract: is_blacklisted must be called with both repo_url and
+maintainer at every call site in src/ and tools/.
+
+Rule H5 (see data/regression-audit-2026-05-26.md): blacklisting only at repo
+level lets the same maintainer's OTHER repos get targeted. PR #325 wired the
+maintainer column and the first two callers (PR-epsilon #290, PR-zeta #208).
+This test ensures every subsequent caller also passes both axes -- continuous
+enforcement instead of manual audit per Closes #370.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SRC_DIR = REPO_ROOT / "src" / "gh_link_auditor"
+TOOLS_DIR = REPO_ROOT / "tools"
+
+_KW_NAMES = {"repo_url", "maintainer"}
+
+
+def _collect_violations(directory: Path) -> list[str]:
+    """Return a list of "path:line" for every is_blacklisted(...) call with
+    fewer than 2 effective arguments (positional + relevant kwargs)."""
+    violations: list[str] = []
+    for py_file in sorted(directory.rglob("*.py")):
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            is_match = (isinstance(func, ast.Attribute) and func.attr == "is_blacklisted") or (
+                isinstance(func, ast.Name) and func.id == "is_blacklisted"
+            )
+            if not is_match:
+                continue
+            n_positional = len(node.args)
+            n_kwargs = sum(1 for kw in node.keywords if kw.arg in _KW_NAMES)
+            if n_positional + n_kwargs < 2:
+                rel = py_file.relative_to(REPO_ROOT).as_posix()
+                violations.append(f"{rel}:{node.lineno}")
+    return violations
+
+
+def test_is_blacklisted_callers_in_src_pass_both_args() -> None:
+    """Every is_blacklisted(...) call in src/gh_link_auditor/ must pass both
+    repo_url and maintainer. Repo-only checks let the same maintainer's other
+    repos get targeted. See rule H5 in data/regression-audit-2026-05-26.md."""
+    violations = _collect_violations(SRC_DIR)
+    assert not violations, (
+        "is_blacklisted callers in src/ must pass both repo_url and maintainer "
+        "(rule H5). Either supply maintainer explicitly or pass `maintainer=None` "
+        "if the call site genuinely cannot resolve one. Violations: "
+        f"{violations}"
+    )
+
+
+def test_is_blacklisted_callers_in_tools_pass_both_args() -> None:
+    """Same rule applied to tools/, which contains the campaign-driving
+    scripts. Skipping these would let the rule degrade asymmetrically."""
+    violations = _collect_violations(TOOLS_DIR)
+    assert not violations, (
+        f"is_blacklisted callers in tools/ must pass both repo_url and maintainer (rule H5). Violations: {violations}"
+    )
+
+
+def test_definition_signature_accepts_maintainer() -> None:
+    """The function being checked is real: UnifiedDatabase.is_blacklisted
+    accepts an optional maintainer kwarg. If the signature ever changes,
+    this test surfaces it before the call-site test does, with a clearer
+    failure message."""
+    from gh_link_auditor.unified_db import UnifiedDatabase
+
+    sig = UnifiedDatabase.is_blacklisted.__doc__ or ""  # docstring may be empty
+    # Use inspect for the real check; docstring is only a tiebreaker.
+    import inspect
+
+    params = inspect.signature(UnifiedDatabase.is_blacklisted).parameters
+    assert "repo_url" in params, "UnifiedDatabase.is_blacklisted must accept repo_url"
+    assert "maintainer" in params, (
+        "UnifiedDatabase.is_blacklisted must accept maintainer (rule H5 -- see data/regression-audit-2026-05-26.md)"
+    )
+    # Suppress unused-variable lint -- sig may be referenced in future asserts.
+    del sig

--- a/tools/derive_replacement_prs.py
+++ b/tools/derive_replacement_prs.py
@@ -315,7 +315,8 @@ def derive_and_submit(
 
         for repo_full_name, repo_rows in repos.items():
             repo_url = f"https://github.com/{repo_full_name}"
-            if udb.is_blacklisted(repo_url):
+            maintainer = repo_full_name.partition("/")[0]
+            if udb.is_blacklisted(repo_url, maintainer):
                 skipped.append((repo_full_name, "blacklisted"))
                 continue
             if _has_open_pr(udb, repo_full_name):


### PR DESCRIPTION
## Summary

- AST-walker test in `tests/unit/test_blacklist_contract.py` walks `src/gh_link_auditor/` and `tools/`, asserting every `is_blacklisted(...)` call has at least two positional args (or `repo_url=` + `maintainer=` kwargs).
- Surfaced 5 violation sites that this PR fixes:
  - `src/gh_link_auditor/batch/engine.py:160` -- derive maintainer from `task.repo_full_name`.
  - `src/gh_link_auditor/pipeline/nodes/n0_load_target.py:178` -- `owner` already in scope; pass it through.
  - `src/gh_link_auditor/pr_tracker.py:402` -- `owner` already in scope.
  - `src/gh_link_auditor/pr_tracker.py:427` -- `owner` already in scope.
  - `tools/derive_replacement_prs.py:318` -- derive maintainer from `repo_full_name`.

## Why

Rule H5 (see `data/regression-audit-2026-05-26.md`): blacklisting only at repo level lets the same maintainer's other repos get targeted. PR #325 wired the column and the first two callers (PR-epsilon #290, PR-zeta #208). The rest of the call sites silently used the one-arg form, defeating the maintainer dimension.

The AST test prevents future regressions from re-introducing the single-arg form.

## Test plan

- [x] `poetry run pytest tests/unit/test_blacklist_contract.py -v` -- 3/3 pass after fixes.
- [x] Full suite: `poetry run pytest tests/unit/` -- 2444 passed, 1 skipped.
- [x] `poetry run ruff format .` -- 1 file reformatted (this PR's new test).
- [x] `poetry run ruff check .` -- All checks passed.

Closes #370