### PR TITLE
feat(bulk-scan): wire 12 remaining host-blocklist candidates from telemetry

### DIFF
--- a/src/gh_link_auditor/false_positives.py
+++ b/src/gh_link_auditor/false_positives.py
@@ -72,6 +72,25 @@ ALWAYS_ALIVE_DOMAINS: set[str] = {
     "bibliography.lingpy.org",
     "pyspedas.readthedocs.io",
     "mfa-models.readthedocs.io",
+    # Round 2 (2026-05-26, #366): remaining 0%-yield hosts from the
+    # 2026-05-23 telemetry that were deferred in PR #358. None had any
+    # tier-1 candidate in tens-to-hundreds of real investigations. The
+    # exclusions per PR #358 (github.com, arxiv.org, doi.org, huggingface.co,
+    # web.archive.org, learn.microsoft.com, raw.githubusercontent.com)
+    # remain excluded -- those hosts have specific handlers or are useful
+    # signal sources.
+    "drive.google.com",
+    "asusrouter.vaskivskyi.com",
+    "opencollective.com",
+    "gitter.im",
+    "mapping-commons.github.io",
+    "facebook.github.io",
+    "cherry-rl.net",
+    "zh.wiktionary.org",
+    "youtube.com",
+    "mindspore.cn",
+    "gnu.org",
+    "img.shields.io",
 }
 
 # Domains that return 403/429 to bots but work fine in browsers.

--- a/tests/unit/test_false_positives.py
+++ b/tests/unit/test_false_positives.py
@@ -443,6 +443,53 @@ class TestIsAlwaysAliveDomain:
     def test_http_scheme_too(self) -> None:
         assert is_always_alive_domain("http://stackoverflow.com/a/1") is True
 
+    # Round 2 wired hosts (#366, 2026-05-26). Each host had 0 tier-1
+    # candidates across tens-to-hundreds of real investigations in the
+    # 2026-05-23 telemetry; pin them so the next refactor of
+    # ALWAYS_ALIVE_DOMAINS doesn't silently drop them.
+    def test_drive_google_com(self) -> None:
+        assert is_always_alive_domain("https://drive.google.com/file/d/abc/view") is True
+
+    def test_asusrouter_vaskivskyi_com(self) -> None:
+        assert is_always_alive_domain("https://asusrouter.vaskivskyi.com/devices/") is True
+
+    def test_opencollective_com(self) -> None:
+        assert is_always_alive_domain("https://opencollective.com/example") is True
+
+    def test_gitter_im(self) -> None:
+        assert is_always_alive_domain("https://gitter.im/some-org/room") is True
+
+    def test_mapping_commons_github_io(self) -> None:
+        assert is_always_alive_domain("https://mapping-commons.github.io/dosdp/") is True
+
+    def test_facebook_github_io(self) -> None:
+        assert is_always_alive_domain("https://facebook.github.io/react/") is True
+
+    def test_cherry_rl_net(self) -> None:
+        assert is_always_alive_domain("https://cherry-rl.net/docs/") is True
+
+    def test_zh_wiktionary_org(self) -> None:
+        assert is_always_alive_domain("https://zh.wiktionary.org/wiki/test") is True
+
+    def test_youtube_com(self) -> None:
+        assert is_always_alive_domain("https://www.youtube.com/watch?v=abc") is True
+        assert is_always_alive_domain("https://youtube.com/watch?v=abc") is True
+
+    def test_mindspore_cn(self) -> None:
+        assert is_always_alive_domain("https://www.mindspore.cn/docs/") is True
+
+    def test_gnu_org(self) -> None:
+        assert is_always_alive_domain("https://www.gnu.org/software/bash/") is True
+        assert is_always_alive_domain("https://gnu.org/software/bash/") is True
+
+    def test_img_shields_io(self) -> None:
+        assert is_always_alive_domain("https://img.shields.io/badge/x-y-blue") is True
+
+    def test_github_io_does_not_match_other_subdomains(self) -> None:
+        # mapping-commons.github.io and facebook.github.io are specific; other
+        # *.github.io sites should NOT be blocked by these entries.
+        assert is_always_alive_domain("https://some-other-user.github.io/repo/") is False
+
     def test_unrelated_domain_not_skipped(self) -> None:
         assert is_always_alive_domain("https://example.com/") is False
 


### PR DESCRIPTION
## Summary

Wires the 12 remaining 0%-yield hosts from the 2026-05-23 telemetry into `ALWAYS_ALIVE_DOMAINS`. PR #358 wired 24 of 42; this completes the picture minus the 7 hosts deferred per #358 for having specific handlers (github.com, arxiv.org, doi.org, huggingface.co, web.archive.org, learn.microsoft.com, raw.githubusercontent.com).

Hosts added:

| Host | Why |
|---|---|
| drive.google.com | Auth/share-link gated; nothing repairable |
| asusrouter.vaskivskyi.com | 100% 404 niche dev site |
| opencollective.com | Donation platform (also in DONATION_DOMAINS) |
| gitter.im | Dead service (acquired by Element) |
| mapping-commons.github.io | 100% 404 Pages site |
| facebook.github.io | 92% 404 Pages site (many tools moved) |
| cherry-rl.net | 100% 404 niche site |
| zh.wiktionary.org | Multilingual wiki, transient bot-block |
| youtube.com | Videos go private/deleted, no repair target |
| mindspore.cn | Huawei DL framework, geo-blocked |
| gnu.org | GNU site, anti-bot None responses |
| img.shields.io | Badge service, not repair target |

The two `.github.io` entries are specific subdomains -- not the .github.io TLD. Other user-pages still get investigated. A guard test pins that constraint.

## Why

Per audit section R3 in `data/regression-audit-2026-05-26.md`: every un-wired host burns archive_client / CDX cycles per scan with no candidate yield. Cumulative cost across the 2026-05-23 corpus was over 1,000 wasted real investigations on these 12.

## Test plan

- [x] `poetry run pytest tests/unit/test_false_positives.py -v` -- 146 passed (was 134; added 13 tests).
- [x] Full suite: 2457 passed, 1 skipped (was 2444).
- [x] `poetry run ruff format . && poetry run ruff check .` -- clean.
- [x] Guard test: `is_always_alive_domain("https://some-other-user.github.io/repo/")` returns False (only the two listed `.github.io` subdomains match).

Closes #366