### PR TITLE
chore(lint): AST-walker test for subprocess.run(text=True) encoding contract

### DIFF
--- a/src/gh_link_auditor/auth.py
+++ b/src/gh_link_auditor/auth.py
@@ -30,6 +30,8 @@ def resolve_github_token() -> str:
             ["gh", "auth", "token"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
         )
         if result.returncode == 0:

--- a/src/gh_link_auditor/bulk_scan/selection.py
+++ b/src/gh_link_auditor/bulk_scan/selection.py
@@ -77,7 +77,15 @@ def _gh_search_one_slice(
         "fullName,stargazersCount,pushedAt,isArchived,visibility",
     ]
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=120)
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=True,
+            timeout=120,
+        )
         return json.loads(result.stdout)
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError) as e:
         stderr_tail = ""

--- a/src/gh_link_auditor/pipeline/nodes/n6_submit_pr.py
+++ b/src/gh_link_auditor/pipeline/nodes/n6_submit_pr.py
@@ -47,6 +47,8 @@ def _run_gh(args: list[str], cwd: str | None = None) -> subprocess.CompletedProc
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             cwd=cwd,
             timeout=120,
             check=False,
@@ -285,6 +287,8 @@ def n6_submit_pr(state: PipelineState) -> PipelineState:
                 cwd=str(repo_dir),
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=True,
             )
 
@@ -300,6 +304,8 @@ def n6_submit_pr(state: PipelineState) -> PipelineState:
                 cwd=str(repo_dir),
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=True,
             )
             commit_msg = _generate_commit_message(fixes)
@@ -308,6 +314,8 @@ def n6_submit_pr(state: PipelineState) -> PipelineState:
                 cwd=str(repo_dir),
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=True,
             )
 
@@ -317,6 +325,8 @@ def n6_submit_pr(state: PipelineState) -> PipelineState:
                 cwd=str(repo_dir),
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=True,
             )
 

--- a/src/gh_link_auditor/pr_tracker.py
+++ b/src/gh_link_auditor/pr_tracker.py
@@ -72,6 +72,8 @@ def _fetch_pr_status(owner: str, repo: str, pr_number: int) -> dict:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -106,6 +108,8 @@ def _fetch_pr_comments(owner: str, repo: str, pr_number: int) -> list[dict]:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -193,6 +197,8 @@ def _check_maintainer_fixed(
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -210,6 +216,8 @@ def _check_maintainer_fixed(
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )

--- a/src/gh_link_auditor/repo_quality.py
+++ b/src/gh_link_auditor/repo_quality.py
@@ -65,6 +65,8 @@ def fetch_repo_metadata(owner: str, repo: str) -> RepoQuality:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -94,6 +96,8 @@ def fetch_repo_metadata(owner: str, repo: str) -> RepoQuality:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
             check=False,
         )
@@ -133,6 +137,8 @@ def fetch_contributing_guidelines(owner: str, repo: str) -> str:
                 ],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=15,
                 check=False,
             )

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -97,6 +97,8 @@ class TestResolveGithubToken:
                 ["gh", "auth", "token"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
             )
 

--- a/tests/unit/test_subprocess_encoding_contract.py
+++ b/tests/unit/test_subprocess_encoding_contract.py
@@ -1,0 +1,169 @@
+"""Project-wide lint: subprocess.run(..., text=True, ...) must pass encoding=.
+
+PR #338 fixed four sites in the preflight package where ``text=True`` alone
+gave Windows cp1252 stdout, which can't represent UTF-8 GitHub API output
+(emoji, accents, non-Latin chars). PR #367 lifted the preflight fix into
+``preflight/_subproc.py``. This test enforces the same rule project-wide --
+every ``subprocess.run(..., text=True, ...)`` call in ``src/`` and
+``tools/`` must also pass an explicit ``encoding=`` kwarg.
+
+The rule is a pre-commit-style lint check via AST walk. Adding a new
+violating call to any tracked .py file in ``src/`` or ``tools/`` breaks
+this test.
+
+See data/regression-audit-2026-05-26.md section R5 (helper) and R15
+(this rule). #371.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SRC_DIR = REPO_ROOT / "src"
+TOOLS_DIR = REPO_ROOT / "tools"
+
+
+def _has_kwarg(node: ast.Call, name: str) -> bool:
+    return any(kw.arg == name for kw in node.keywords)
+
+
+def _kwarg_is_true(node: ast.Call, name: str) -> bool:
+    for kw in node.keywords:
+        if kw.arg == name and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+            return True
+    return False
+
+
+def _find_violations(directory: Path) -> list[str]:
+    """Return "path:line" for every subprocess.run(... text=True ...) call
+    in `directory` that does not also pass `encoding=`. Returns empty if
+    the directory does not exist (e.g. fresh checkout with no tools/)."""
+    violations: list[str] = []
+    if not directory.exists():
+        return violations
+    for py_file in sorted(directory.rglob("*.py")):
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            # Match subprocess.run(...)
+            if not (
+                isinstance(func, ast.Attribute)
+                and func.attr == "run"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "subprocess"
+            ):
+                continue
+            if not _kwarg_is_true(node, "text"):
+                # text=False (default) -> bytes -> encoding kwarg is irrelevant
+                continue
+            if _has_kwarg(node, "encoding"):
+                continue
+            try:
+                rel = py_file.relative_to(REPO_ROOT).as_posix()
+            except ValueError:
+                # Synthetic tmp_path file in the detector's own tests
+                rel = py_file.as_posix()
+            violations.append(f"{rel}:{node.lineno}")
+    return violations
+
+
+def test_src_subprocess_run_calls_pass_encoding() -> None:
+    """Every subprocess.run(text=True) in src/ must also pass encoding=.
+
+    The encoding default on Windows is cp1252; UTF-8 from the GitHub
+    API breaks decoding on the first non-ASCII byte. Pass
+    encoding="utf-8", errors="replace" to make it cp1252-safe.
+    """
+    violations = _find_violations(SRC_DIR)
+    assert not violations, (
+        "subprocess.run(..., text=True, ...) calls in src/ must also pass "
+        'encoding="utf-8", errors="replace". Without it, Windows cp1252 '
+        "breaks decoding GitHub API responses with non-ASCII bytes. "
+        "See data/regression-audit-2026-05-26.md sections R5/R15. "
+        "Or route through src/gh_link_auditor/preflight/_subproc.py "
+        f"(run_utf8 / gh_api_json). Violations: {violations}"
+    )
+
+
+def test_tools_subprocess_run_calls_pass_encoding() -> None:
+    """Same rule, tools/ scope. tools/ contains campaign-driving scripts
+    that hit the GitHub API; they need the same cp1252 protection."""
+    violations = _find_violations(TOOLS_DIR)
+    assert not violations, (
+        "subprocess.run(..., text=True, ...) calls in tools/ must also pass "
+        'encoding="utf-8", errors="replace". '
+        f"Violations: {violations}"
+    )
+
+
+def test_detector_catches_synthetic_violation(tmp_path: Path) -> None:
+    """Pin the detector itself: a deliberate violation file MUST be
+    flagged. If a future refactor breaks the AST walker, this test fails
+    before the production-code tests do, with a cleaner failure message."""
+    bad = tmp_path / "bad.py"
+    bad.write_text(
+        textwrap.dedent(
+            """
+            import subprocess
+
+            def go() -> None:
+                subprocess.run(["echo", "hi"], capture_output=True, text=True)
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    violations = _find_violations(tmp_path)
+    assert any("bad.py" in v for v in violations), (
+        f"detector failed to flag the synthetic text=True/no-encoding call. violations: {violations}"
+    )
+
+
+def test_detector_accepts_text_with_encoding(tmp_path: Path) -> None:
+    """Pin the detector positively: a compliant call MUST NOT be flagged."""
+    good = tmp_path / "good.py"
+    good.write_text(
+        textwrap.dedent(
+            """
+            import subprocess
+
+            def go() -> None:
+                subprocess.run(
+                    ["echo", "hi"],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                )
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    violations = _find_violations(tmp_path)
+    assert not violations, f"detector wrongly flagged a compliant call: {violations}"
+
+
+def test_detector_ignores_text_false(tmp_path: Path) -> None:
+    """text=False (or default) returns bytes; encoding= is irrelevant
+    there. Detector must not flag that case."""
+    fine = tmp_path / "fine.py"
+    fine.write_text(
+        textwrap.dedent(
+            """
+            import subprocess
+
+            def go() -> None:
+                subprocess.run(["echo", "hi"], capture_output=True)
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    violations = _find_violations(tmp_path)
+    assert not violations, f"detector wrongly flagged a text=False call: {violations}"


### PR DESCRIPTION
## Summary

Extends the R5 encoding contract project-wide via an AST-walker test, then fixes the 14 violations the walker surfaced in src/.

PR #338 fixed four preflight sites for Windows cp1252 vs UTF-8 from the GitHub API. PR #367 (#374) lifted those into a helper. This PR is the project-wide gate so the gotcha can't re-enter via a new untouched module.

## Lint check

- New `tests/unit/test_subprocess_encoding_contract.py` walks every `.py` in `src/` and `tools/`.
- Flags any `subprocess.run(..., text=True, ...)` call missing an explicit `encoding=` kwarg.
- Self-test fixtures pin both positive (compliant call passes) and negative (synthetic violation flagged) directions, plus the `text=False` exclusion.

## Sites fixed (14)

- `src/gh_link_auditor/auth.py:29`
- `src/gh_link_auditor/bulk_scan/selection.py:80`
- `src/gh_link_auditor/pipeline/nodes/n6_submit_pr.py` x5 (`_gh_cmd` + four git calls in the fork/branch/commit/push flow)
- `src/gh_link_auditor/pr_tracker.py` x4 (PR-status / comments / body / commits)
- `src/gh_link_auditor/repo_quality.py` x3 (repo metadata / contributors / CONTRIBUTING)

`tests/unit/test_auth.py::test_passes_correct_args_to_subprocess` updated to mirror the new kwarg shape.

## Test plan

- [x] `poetry run pytest tests/unit/test_subprocess_encoding_contract.py -v` -- 5/5 pass.
- [x] Full suite: `poetry run pytest tests/unit/` -- 2484 passed, 1 skipped (was 2479; +5 net new).
- [x] `poetry run ruff format . && poetry run ruff check .` -- clean.
- [x] Manual sanity: a synthetic `subprocess.run(text=True)` in `src/` (no `encoding=`) makes the test fail with the exact violating line.

Closes #371