### PR TITLE
refactor(tools): retrofit watch_bulk_scan.py to reuse bulk_scan/progress

### DIFF
--- a/tests/unit/bulk_scan/test_progress.py
+++ b/tests/unit/bulk_scan/test_progress.py
@@ -1,0 +1,223 @@
+"""Tests for ``gh_link_auditor.bulk_scan.progress``.
+
+The progress module is the single source of truth for bulk-scan status
+lines, used by both ``runner.run_full()``'s in-process emitter and the
+``tools/watch_bulk_scan.py`` out-of-process poller. The byte-format
+matches the PR #271 schema and ``tools/finish_stage*.py``.
+
+These tests pin the rendered format so the next refactor can't silently
+change it. See #368.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from collections import deque
+
+from gh_link_auditor.bulk_scan import progress
+
+
+def _empty_window() -> deque:
+    return deque(maxlen=10)
+
+
+def _stage1_snapshot(
+    *,
+    target: int = 100,
+    inventoried: int = 50,
+    pending: int = 50,
+    error: int = 0,
+    total_findings: int = 1234,
+    surfaced: int = 0,
+) -> dict:
+    return {
+        "status": "inventorying",
+        "counts": {"inventoried": inventoried, "pending": pending, "error": error},
+        "total_findings": total_findings,
+        "surfaced": surfaced,
+        "median": 0.0,
+        "target": target,
+        "inv_buckets": {},
+    }
+
+
+def _stage3_snapshot(
+    *,
+    total_findings: int = 10000,
+    pending: int = 6000,
+    investigated_no: int = 3000,
+    investigated_with: int = 100,
+    derived: int = 110,
+    skipped_alive: int = 800,
+    skipped_language: int = 0,
+    skipped_blocklist: int = 0,
+) -> dict:
+    return {
+        "status": "investigating",
+        "counts": {"inventoried": 0, "pending": 0, "error": 0},
+        "total_findings": total_findings,
+        "surfaced": 0,
+        "median": 0.0,
+        "target": 0,
+        "inv_buckets": {
+            "pending": pending,
+            "investigated_no_candidate": investigated_no,
+            "investigated_with_candidate": investigated_with,
+            "derived_candidate": derived,
+            "skipped_alive": skipped_alive,
+            "skipped_language": skipped_language,
+            "skipped_blocklist": skipped_blocklist,
+        },
+    }
+
+
+# --- Stage 1 ---------------------------------------------------------------
+
+
+def test_render_stage1_has_canonical_shape() -> None:
+    snap = _stage1_snapshot(target=100, inventoried=42, pending=58, error=0, total_findings=3500)
+    line = progress.render(
+        snap,
+        _empty_window(),
+        _empty_window(),
+        _empty_window(),
+        started_mono=time.monotonic() - 60,  # 1 minute ago
+    )
+    # Expected: [HH:MM:SS] stage1 42/100 (42.0%) inventoried=42 pending=58 err=0
+    # findings=3,500 (5m: +0/min) rate=N/min (5m: N/min) ETA=?
+    assert re.match(
+        r"^\[\d{2}:\d{2}:\d{2}\] stage1 42/100 \(42\.0%\) "
+        r"inventoried=42 pending=58 err=0 "
+        r"findings=3,500 \(5m: \+0/min\) "
+        r"rate=\d+\.\d+/min \(5m: \d+\.\d+/min\) ETA=",
+        line,
+    ), line
+
+
+def test_render_stage1_zero_target_does_not_divide_by_zero() -> None:
+    snap = _stage1_snapshot(target=0, inventoried=0, pending=0)
+    line = progress.render(snap, _empty_window(), _empty_window(), _empty_window(), started_mono=time.monotonic())
+    assert "0.0%" in line
+
+
+# --- Stage 2 ---------------------------------------------------------------
+
+
+def test_render_stage2_has_canonical_shape() -> None:
+    snap = _stage1_snapshot()
+    snap["status"] = "checking"
+    line = progress.render(snap, _empty_window(), _empty_window(), _empty_window(), started_mono=time.monotonic())
+    assert "stage2" in line
+    assert "findings=" in line
+    assert "(5m:" in line
+
+
+# --- Stage 3 ---------------------------------------------------------------
+
+
+def test_render_stage3_has_canonical_shape() -> None:
+    snap = _stage3_snapshot(
+        total_findings=10000,
+        pending=6000,
+        investigated_no=3000,
+        investigated_with=100,
+        derived=110,
+        skipped_alive=800,
+    )
+    line = progress.render(snap, _empty_window(), _empty_window(), _empty_window(), started_mono=time.monotonic())
+    # Schema: stage3 4,000/10,000 (40.0%) skipped=800 investigated=3,100 yield=3.2% cands+=110 (5m: +0/min) ETA=?
+    assert re.search(
+        r"stage3 4,000/10,000 \(40\.0%\) "
+        r"skipped=800 investigated=3,100 yield=3\.2% "
+        r"cands\+=110 \(5m: ",
+        line,
+    ), line
+
+
+def test_render_stage3_yield_n_a_when_no_real_investigations() -> None:
+    snap = _stage3_snapshot(
+        total_findings=1000,
+        pending=1000,
+        investigated_no=0,
+        investigated_with=0,
+        derived=0,
+        skipped_alive=0,
+    )
+    line = progress.render(snap, _empty_window(), _empty_window(), _empty_window(), started_mono=time.monotonic())
+    assert "yield=n/a" in line
+
+
+def test_render_stage3_zero_findings_does_not_divide_by_zero() -> None:
+    snap = _stage3_snapshot(total_findings=0, pending=0, investigated_no=0, investigated_with=0, derived=0)
+    line = progress.render(snap, _empty_window(), _empty_window(), _empty_window(), started_mono=time.monotonic())
+    assert "stage3 0/0 (0.0%)" in line
+
+
+# --- Stage 4/5 ---------------------------------------------------------------
+
+
+def test_render_stage4_scoring() -> None:
+    snap = _stage1_snapshot()
+    snap["status"] = "scoring"
+    snap["surfaced"] = 50
+    snap["median"] = 0.85
+    line = progress.render(snap, _empty_window(), _empty_window(), _empty_window(), started_mono=time.monotonic())
+    assert "stage4" in line
+    assert "surfaced=50" in line
+    assert "sample_median=0.85" in line
+
+
+def test_render_stage5_done() -> None:
+    snap = _stage1_snapshot()
+    snap["status"] = "done"
+    snap["surfaced"] = 50
+    snap["total_findings"] = 100
+    line = progress.render(snap, _empty_window(), _empty_window(), _empty_window(), started_mono=time.monotonic())
+    assert "stage5" in line
+    assert "status=done" in line
+    assert "surfaced=50/100" in line
+
+
+# --- Unknown status fallback ----------------------------------------------
+
+
+def test_render_unknown_status_does_not_crash() -> None:
+    snap = _stage1_snapshot()
+    snap["status"] = "nonsense-status"
+    line = progress.render(snap, _empty_window(), _empty_window(), _empty_window(), started_mono=time.monotonic())
+    assert "status=nonsense-status" in line
+    assert "stage unknown" in line
+
+
+# --- Rate calculation ------------------------------------------------------
+
+
+def test_rate_returns_zero_with_fewer_than_two_samples() -> None:
+    window: deque = deque(maxlen=10)
+    assert progress._rate(window) == 0.0
+    window.append((100.0, 42))
+    assert progress._rate(window) == 0.0
+
+
+def test_rate_per_minute_over_window() -> None:
+    """120 items processed over 1 minute -> 120/min."""
+    window: deque = deque(maxlen=10)
+    window.append((100.0, 0))
+    window.append((160.0, 120))  # 60s later, 120 more items
+    rate = progress._rate(window)
+    assert abs(rate - 120.0) < 0.01
+
+
+def test_eta_str_question_mark_when_rate_zero() -> None:
+    assert progress._eta_str(100, 0.0) == "?"
+
+
+def test_eta_str_minutes_when_under_60min() -> None:
+    # 100 remaining at 10/min -> 10m
+    assert progress._eta_str(100, 10.0) == "10m"
+
+
+def test_eta_str_hours_when_over_60min() -> None:
+    # 6000 remaining at 10/min -> 600m -> 10.0h
+    assert progress._eta_str(6000, 10.0) == "10.0h"

--- a/tools/watch_bulk_scan.py
+++ b/tools/watch_bulk_scan.py
@@ -1,13 +1,16 @@
 """Stream a bulk-scan run's progress to stdout as a single status line per
-tick, matching the shape of tools/finish_stage{1,2,3}.py.
+tick.
 
-Out-of-process: polls the DB; never touches the running scan. Run in a
-second terminal alongside `ghla bulk-scan start`.
+Out-of-process: polls the DB; never touches the running scan. Use for
+inspecting non-active runs (post-mortem) or alongside a stage that emits
+to a different log destination. The in-process emitter inside
+``runner.run_full()`` is the primary visibility surface during a live
+scan (PR #360).
 
-Shape per tick (matches PR #271 / finish_stage*.py render_line):
-
-    [HH:MM:SS] stage<N> processed/total (pct%) bucket=<count> ...
-        findings+=<N> rate=<r>/min (5m: <r>/min) ETA=<T>
+Shape per tick matches ``tools/finish_stage*.py`` and the in-process
+emitter (PR #271 schema) -- both delegate to
+``gh_link_auditor.bulk_scan.progress.render``. The two code paths are
+guaranteed not to drift because they call the same function (#368).
 
 Usage::
 
@@ -23,64 +26,13 @@ import argparse
 import sys
 import time
 from collections import deque
-from datetime import datetime
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "src"))
 
-from gh_link_auditor.bulk_scan import scoring, storage  # noqa: E402
+from gh_link_auditor.bulk_scan import progress, storage  # noqa: E402
 from gh_link_auditor.unified_db import DEFAULT_DB_PATH, UnifiedDatabase  # noqa: E402
-
-# Map bulk_scan_runs.status -> stage number for the prefix
-STAGE_MAP = {
-    "selecting": 1,
-    "inventorying": 1,
-    "checking": 2,
-    "investigating": 3,
-    "scoring": 4,
-    "done": 5,
-    "quality_aborted": 5,
-    "aborted": 5,
-}
-
-
-def _investigation_buckets(db: UnifiedDatabase, run_id: str) -> dict[str, int]:
-    """Group bulk_scan_findings by investigation_state for the run.
-
-    Mirrors finish_stage3.py's Stats buckets:
-    - pending: stage-2 left these for stage 3
-    - skipped_alive / skipped_language / skipped_blocklist: outside stage 3 work
-    - investigated_no_candidate / investigated_with_candidate: real stage-3 investigations
-    - derived_candidate: an inserted candidate row (cands+)
-    - dropped_unsafe_url: filtered out post-investigation
-    """
-    rows = db._conn.execute(
-        "SELECT investigation_state, COUNT(*) AS n FROM bulk_scan_findings "
-        "WHERE run_id = ? GROUP BY investigation_state",
-        (run_id,),
-    ).fetchall()
-    return {r["investigation_state"]: r["n"] for r in rows}
-
-
-def _snapshot(db: UnifiedDatabase, run_id: str) -> dict:
-    run = storage.get_run(db, run_id)
-    if run is None:
-        return {}
-    counts = storage.get_repo_count_by_status(db, run_id)
-    total = storage.count_findings(db, run_id)
-    surfaced = storage.count_findings(db, run_id, surfaced=True)
-    median = scoring.quality_sample_median(db, run_id)
-    inv_buckets = _investigation_buckets(db, run_id)
-    return {
-        "status": run["status"],
-        "counts": counts,
-        "total_findings": total,
-        "surfaced": surfaced,
-        "median": median,
-        "target": run.get("target_repo_count") or 0,
-        "inv_buckets": inv_buckets,
-    }
 
 
 def _resolve_run_id(db: UnifiedDatabase, requested: str | None) -> str | None:
@@ -88,98 +40,6 @@ def _resolve_run_id(db: UnifiedDatabase, requested: str | None) -> str | None:
         return requested
     runs = storage.list_runs(db, limit=1)
     return runs[0]["run_id"] if runs else None
-
-
-def _eta_str(remaining: int, rate_per_min: float) -> str:
-    if rate_per_min <= 0:
-        return "?"
-    m = remaining / rate_per_min
-    return f"{m:.0f}m" if m < 60 else f"{m / 60:.1f}h"
-
-
-def _five_min_rate(window: deque) -> float:
-    """Rate per minute over the rolling window. Returns 0 if insufficient samples."""
-    if len(window) < 2:
-        return 0.0
-    ts0, v0 = window[0]
-    ts1, v1 = window[-1]
-    dt = ts1 - ts0
-    if dt <= 0:
-        return 0.0
-    return (v1 - v0) / (dt / 60.0)
-
-
-def _render(snap: dict, run_id: str, mono_window: deque, findings_window: deque, started_mono: float) -> str:
-    now = datetime.now().strftime("%H:%M:%S")
-    status = snap["status"]
-    stage = STAGE_MAP.get(status, 0)
-    counts = snap["counts"]
-    target = snap["target"]
-    inv = counts.get("inventoried", 0)
-    pend = counts.get("pending", 0)
-    err = counts.get("error", 0)
-    findings = snap["total_findings"]
-    surfaced = snap["surfaced"]
-
-    processed = inv + err
-    pct = (100.0 * processed / target) if target else 0.0
-
-    elapsed_min = (time.monotonic() - started_mono) / 60.0
-    overall_rate = (processed / elapsed_min) if elapsed_min > 0.1 else 0.0
-    recent_rate = _five_min_rate(mono_window)
-    findings_rate = _five_min_rate(findings_window)
-    remaining = max(target - processed, 0)
-    eta = _eta_str(remaining, recent_rate if recent_rate > 0 else overall_rate)
-
-    median_str = f" sample_median={snap['median']:.2f}" if snap.get("median") else ""
-
-    if stage == 1:
-        # Stage 1 -- selection + inventory. Per-repo progress is the headline.
-        return (
-            f"[{now}] stage1 {processed:,}/{target:,} ({pct:.1f}%) "
-            f"inventoried={inv:,} pending={pend:,} err={err:,} "
-            f"findings={findings:,} (5m: {findings_rate:+.0f}/min) "
-            f"rate={overall_rate:.1f}/min (5m: {recent_rate:.1f}/min) "
-            f"ETA={eta}"
-        )
-    if stage == 2:
-        # Stage 2 -- liveness. Findings probed is the headline; no per-repo bucket.
-        return (
-            f"[{now}] stage2 status=checking findings={findings:,} surfaced={surfaced:,} (5m: {findings_rate:+.0f}/min)"
-        )
-    if stage == 3:
-        # Stage 3 -- investigation. Mirror finish_stage3.py: processed/total
-        # with yield% over REAL investigations, candidate-insert count, rate,
-        # ETA -- not the surfaced count (that flips later at PR-submit).
-        buckets = snap.get("inv_buckets", {})
-        total_findings_local = findings
-        pending = buckets.get("pending", 0)
-        processed_findings = total_findings_local - pending
-        pct_proc = (100.0 * processed_findings / total_findings_local) if total_findings_local else 0.0
-        inv_with = buckets.get("investigated_with_candidate", 0)
-        inv_no = buckets.get("investigated_no_candidate", 0)
-        derived = buckets.get("derived_candidate", 0)
-        real_invs = inv_with + inv_no
-        yield_str = f"yield={100.0 * inv_with / real_invs:.1f}%" if real_invs else "yield=n/a"
-        skipped_total = (
-            buckets.get("skipped_alive", 0) + buckets.get("skipped_language", 0) + buckets.get("skipped_blocklist", 0)
-        )
-        # Rate based on the processed-findings delta in the rolling window
-        # (the findings_window samples track *total* findings; for stage 3
-        # the total is fixed and only `pending` shrinks. Pass processed.)
-        rate_per_min = _five_min_rate(findings_window)
-        eta_local = _eta_str(pending, rate_per_min if rate_per_min > 0 else overall_rate)
-        return (
-            f"[{now}] stage3 {processed_findings:,}/{total_findings_local:,} ({pct_proc:.1f}%) "
-            f"skipped={skipped_total:,} investigated={real_invs:,} {yield_str} "
-            f"cands+={derived:,} "
-            f"(5m: {rate_per_min:+.0f}/min) ETA={eta_local}"
-        )
-    if stage == 4:
-        return f"[{now}] stage4 scoring surfaced={surfaced:,}{median_str}"
-    if stage == 5:
-        return f"[{now}] stage5 status={status} surfaced={surfaced:,}/{findings:,}{median_str}"
-    return f"[{now}] status={status} (no progress data — stage unknown)"
 
 
 def main() -> int:
@@ -193,12 +53,9 @@ def main() -> int:
     args = parser.parse_args()
 
     started_mono = time.monotonic()
-    # Rolling windows: (monotonic_ts, value) per stage's relevant counter.
-    # mono_window tracks repo-processed (stage 1).
-    # findings_window tracks total_findings (stage 2) -- grows when new URLs probed.
-    # stage3_window tracks processed_findings = total - pending (stage 3) -- only
-    # this one moves during investigation.
-    mono_window: deque = deque(maxlen=10)
+    # Three rolling windows matching the in-process StatusEmitter:
+    # stage1 (repo-processed), findings (total URLs), stage3 (processed URLs).
+    stage1_window: deque = deque(maxlen=10)
     findings_window: deque = deque(maxlen=10)
     stage3_window: deque = deque(maxlen=10)
 
@@ -209,7 +66,7 @@ def main() -> int:
                 if not run_id:
                     print("no runs found", flush=True)
                     return 1
-                snap = _snapshot(db, run_id)
+                snap = progress.snapshot(db, run_id)
         except Exception as exc:  # noqa: BLE001
             print(f"poll error: {exc}", flush=True)
             time.sleep(args.interval)
@@ -220,21 +77,14 @@ def main() -> int:
             return 1
 
         counts = snap["counts"]
-        processed = counts.get("inventoried", 0) + counts.get("error", 0)
         now_mono = time.monotonic()
-        mono_window.append((now_mono, processed))
+        stage1_window.append((now_mono, counts.get("inventoried", 0) + counts.get("error", 0)))
         findings_window.append((now_mono, snap["total_findings"]))
-        # stage 3: processed_findings = total - pending. Sample even outside
-        # stage 3 so when the transition happens the window already has data.
         pending3 = snap.get("inv_buckets", {}).get("pending", 0)
         stage3_window.append((now_mono, snap["total_findings"] - pending3))
 
-        # Pick the window that matches the current stage so the (5m: ...) rate
-        # in the rendered line is the stage's relevant rate.
-        stage_for_window = STAGE_MAP.get(snap["status"], 0)
-        active_window = stage3_window if stage_for_window == 3 else findings_window
-
-        print(_render(snap, run_id, mono_window, active_window, started_mono), flush=True)
+        line = progress.render(snap, stage1_window, findings_window, stage3_window, started_mono)
+        print(line, flush=True)
 
         if snap["status"] in ("done", "quality_aborted", "aborted"):
             print(f"\nrun finished with status: {snap['status']}", flush=True)


### PR DESCRIPTION
## Summary

PR #360 made `bulk_scan/progress.py` the in-process source of truth for the bulk-scan status line. `tools/watch_bulk_scan.py` (from PR #354) kept its own duplicate of snapshot + render + window logic -- two code paths guaranteed to drift the next time the status-line schema changed. This collapses them.

## What changes

- `tools/watch_bulk_scan.py`: 251 -> 101 lines. Now a thin polling loop that calls `progress.snapshot()` and `progress.render()`.
- Removed local duplicates: `_investigation_buckets`, `_snapshot`, `_render`, `_eta_str`, `_five_min_rate`, `STAGE_MAP`.
- New `tests/unit/bulk_scan/test_progress.py`: 14 tests pinning the canonical status-line format for stage 1 / 2 / 3 (yield, no-investigations, zero-findings) / 4 / 5 / unknown status / rate / ETA. The watcher and the in-process StatusEmitter cannot drift because both call the same `progress.render` against the same snapshot dict.

## Why

Per audit section R6 in `data/regression-audit-2026-05-26.md`: PR #360 deferred the watcher's deduplication. Each refactor of the status-line schema since would silently leave the watcher behind, undoing the operator's "one source of truth" requirement.

## Test plan

- [x] `poetry run pytest tests/unit/bulk_scan/test_progress.py -v` -- 14/14 pass.
- [x] Full suite: 2498 passed, 1 skipped (was 2484; +14).
- [x] `poetry run ruff format . && poetry run ruff check .` -- clean.
- [x] Manual sanity: byte-identical line for the same snapshot dict pre/post retrofit (now enforced by the new tests against `progress.render`).

Closes #368