### PR TITLE
feat(cli): surface Stage 3 investigation_state buckets in ghla bulk-scan status

### DIFF
--- a/src/gh_link_auditor/cli/bulk_scan_cmd.py
+++ b/src/gh_link_auditor/cli/bulk_scan_cmd.py
@@ -11,7 +11,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from gh_link_auditor.bulk_scan import scoring, storage
+from gh_link_auditor.bulk_scan import progress, scoring, storage
 from gh_link_auditor.bulk_scan.config import (
     ABORT_FILE,
     DEFAULT_TARGET_REPO_COUNT,
@@ -143,6 +143,7 @@ def _cmd_status(args: argparse.Namespace) -> int:
         total = storage.count_findings(db, run_id)
         surfaced = storage.count_findings(db, run_id, surfaced=True)
         median = scoring.quality_sample_median(db, run_id)
+        buckets = progress.investigation_buckets(db, run_id)
         print(f"run_id:           {run_id}")
         print(f"status:           {run['status']}")
         print(f"started_at:       {run['started_at']}")
@@ -155,6 +156,29 @@ def _cmd_status(args: argparse.Namespace) -> int:
             print(f"sample_median:    {median:.2f}")
         if run.get("quality_aborted"):
             print("QUALITY_ABORTED:  yes")
+        # #277: surface investigation_state buckets so the operator can
+        # see Stage 3 progress without a second tool. After heartbeat
+        # retirement (#369), this is the canonical out-of-band check.
+        non_pending = {k: v for k, v in buckets.items() if k != "pending"}
+        if non_pending or run["status"] in ("investigating", "scoring", "done", "quality_aborted"):
+            pending = buckets.get("pending", 0)
+            inv_no = buckets.get("investigated_no_candidate", 0)
+            inv_yes = buckets.get("investigated_with_candidate", 0)
+            derived = buckets.get("derived_candidate", 0)
+            skipped_alive = buckets.get("skipped_alive", 0)
+            skipped_lang = buckets.get("skipped_language", 0)
+            skipped_block = buckets.get("skipped_blocklist", 0)
+            real = inv_no + inv_yes
+            yield_str = f"{100.0 * inv_yes / real:.1f}%" if real else "n/a"
+            print("investigation:")
+            print(f"  pending:        {pending:,}")
+            print(f"  skipped_alive:  {skipped_alive:,}")
+            print(f"  skipped_lang:   {skipped_lang:,}")
+            print(f"  skipped_block:  {skipped_block:,}")
+            print(f"  inv_no_cand:    {inv_no:,}")
+            print(f"  inv_with_cand:  {inv_yes:,}")
+            print(f"  derived_cands:  {derived:,}")
+            print(f"  yield:          {yield_str}")
         return 0
 
 

--- a/tests/unit/cli/test_bulk_scan_cmd.py
+++ b/tests/unit/cli/test_bulk_scan_cmd.py
@@ -79,6 +79,104 @@ class TestCmdStatus:
         assert rc == 1
         assert "not found" in out
 
+    def test_surfaces_investigation_buckets_when_present(self, tmp_path, capsys) -> None:
+        """#277: when investigation_state buckets are populated, the status
+        output must include them so the operator doesn't need a second tool."""
+        db_path = str(tmp_path / "x.db")
+        with UnifiedDatabase(db_path) as db:
+            storage.create_run(db, "r1", 100, {})
+            storage.update_run_status(db, "r1", "investigating")
+            for i in range(5):
+                storage.add_finding(
+                    db,
+                    "r1",
+                    f"owner/repo{i}",
+                    "README.md",
+                    1,
+                    f"https://x.test/{i}",
+                    candidate_url="",
+                    method="pending",
+                    tier=0,
+                    similarity_score=None,
+                    verified_live=False,
+                    confidence=0.0,
+                )
+            # Flip a few to investigated_with_candidate / no_candidate / skipped
+            db._conn.execute(
+                "UPDATE bulk_scan_findings SET investigation_state = 'investigated_with_candidate' "
+                "WHERE run_id = 'r1' AND line_number = 1 AND dead_url = 'https://x.test/0'"
+            )
+            db._conn.execute(
+                "UPDATE bulk_scan_findings SET investigation_state = 'investigated_no_candidate' "
+                "WHERE run_id = 'r1' AND line_number = 1 AND dead_url = 'https://x.test/1'"
+            )
+            db._conn.execute(
+                "UPDATE bulk_scan_findings SET investigation_state = 'investigated_no_candidate' "
+                "WHERE run_id = 'r1' AND line_number = 1 AND dead_url = 'https://x.test/2'"
+            )
+            db._conn.execute(
+                "UPDATE bulk_scan_findings SET investigation_state = 'skipped_alive' "
+                "WHERE run_id = 'r1' AND line_number = 1 AND dead_url = 'https://x.test/3'"
+            )
+            db._conn.commit()
+
+        rc = _cmd_status(_ns(db_path=db_path, run_id="r1"))
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "investigation:" in out
+        assert "inv_with_cand:  1" in out
+        assert "inv_no_cand:    2" in out
+        assert "skipped_alive:  1" in out
+        # 1 with + 2 no => 1/3 = 33.3%
+        assert "yield:          33.3%" in out
+
+    def test_does_not_show_buckets_when_run_only_selecting(self, tmp_path, capsys) -> None:
+        """Before Stage 3 starts, the investigation block stays hidden so
+        the operator's status output isn't cluttered with zeros."""
+        db_path = str(tmp_path / "x.db")
+        with UnifiedDatabase(db_path) as db:
+            storage.create_run(db, "r1", 100, {})
+            # Default status is 'selecting'; no findings inserted.
+        rc = _cmd_status(_ns(db_path=db_path, run_id="r1"))
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "investigation:" not in out
+
+    def test_shows_buckets_even_with_zero_real_investigations(self, tmp_path, capsys) -> None:
+        """A run that reached 'investigating' but had everything skipped must
+        still surface the skipped totals; yield must read 'n/a' rather than
+        triggering a divide-by-zero."""
+        db_path = str(tmp_path / "x.db")
+        with UnifiedDatabase(db_path) as db:
+            storage.create_run(db, "r1", 100, {})
+            storage.update_run_status(db, "r1", "investigating")
+            for i in range(3):
+                storage.add_finding(
+                    db,
+                    "r1",
+                    f"owner/repo{i}",
+                    "README.md",
+                    1,
+                    f"https://x.test/{i}",
+                    candidate_url="",
+                    method="pending",
+                    tier=0,
+                    similarity_score=None,
+                    verified_live=False,
+                    confidence=0.0,
+                )
+            db._conn.execute(
+                "UPDATE bulk_scan_findings SET investigation_state = 'skipped_blocklist' WHERE run_id = 'r1'"
+            )
+            db._conn.commit()
+
+        rc = _cmd_status(_ns(db_path=db_path, run_id="r1"))
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "investigation:" in out
+        assert "skipped_block:  3" in out
+        assert "yield:          n/a" in out
+
 
 class TestCmdStop:
     def test_writes_abort_marker(self, tmp_path, capsys, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

After #369 retired the heartbeat file, `ghla bulk-scan status` was the operator's only out-of-band check on a running scan -- but it reported run-level state only, not the Stage 3 buckets that matter during a multi-hour investigation. This PR adds them.

## What changes

`_cmd_status` now calls `progress.investigation_buckets` and prints:

```
investigation:
  pending:        N
  skipped_alive:  N
  skipped_lang:   N
  skipped_block:  N
  inv_no_cand:    N
  inv_with_cand:  N
  derived_cands:  N
  yield:          X% (or n/a)
```

The block is hidden when the run hasn't reached Stage 3 (pure 'selecting' state, no findings yet) so early-phase output stays compact. It is shown whenever there's any non-pending bucket OR the run is at `investigating` / `scoring` / `done` / `quality_aborted`.

## Why

Per audit section R8 in `data/regression-audit-2026-05-26.md`. Out-of-band check is the operator's only window into a running scan when the live status line is in another window or has scrolled off.

## Test plan

- [x] `poetry run pytest tests/unit/cli/test_bulk_scan_cmd.py -v` -- 23 passed (+3 new tests).
- [x] Full suite: 2496 passed, 1 skipped (was 2493; +3).
- [x] `poetry run ruff format . && poetry run ruff check .` -- clean.
- [x] Divide-by-zero on the yield%: covered by `test_shows_buckets_even_with_zero_real_investigations`.

Closes #277