### PR TITLE
feat(bulk-scan): auto-derive host-blocklist candidates at end of each run

### DIFF
--- a/src/gh_link_auditor/bulk_scan/host_blocklist_telemetry.py
+++ b/src/gh_link_auditor/bulk_scan/host_blocklist_telemetry.py
@@ -1,0 +1,306 @@
+"""Derive host-blocklist candidates from completed/partial bulk-scan telemetry.
+
+Productionized version of ``tools/derive_host_blocklist.py``. Run at the
+end of each bulk scan to surface hosts that consumed real investigation
+budget and produced zero (or near-zero) tier-1 candidates. The output is
+a markdown report at ``data/host-blocklist-candidates.md`` for operator
+review -- this module does NOT mutate the static blocklist itself.
+
+The audit (#258 / R4) explicitly forbids silent auto-addition. New
+candidates must surface in the post-run report; the operator wires them
+into ``ALWAYS_ALIVE_DOMAINS`` via a separate PR (see #366 for the
+canonical pattern).
+
+Filtering:
+
+- Hosts already in ``false_positives.ALWAYS_ALIVE_DOMAINS`` are
+  suppressed so the report only surfaces NEW candidates worth adding.
+- ``real_investigations >= MIN_INVESTIGATIONS`` filters thin samples.
+- ``tier1_yield_rate <= MAX_TIER1_YIELD_RATE`` selects zero-yield
+  hosts.
+- ``near_misses`` (yield in [1%, 5%]) are also surfaced for operator
+  awareness.
+
+Safe to run while Stage 3 is still draining (WAL mode + read-only).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from gh_link_auditor.false_positives import ALWAYS_ALIVE_DOMAINS
+from gh_link_auditor.unified_db import UnifiedDatabase
+
+logger = logging.getLogger(__name__)
+
+MIN_INVESTIGATIONS = 30
+MAX_TIER1_YIELD_RATE = 0.01
+NEAR_MISS_UPPER_BOUND = 0.05
+SAMPLE_URLS_PER_HOST = 5
+REPORT_PATH = Path("data/host-blocklist-candidates.md")
+
+
+@dataclass
+class HostStats:
+    host: str
+    total: int = 0
+    unique_urls: int = 0
+    alive: int = 0
+    lang: int = 0
+    no_cand: int = 0
+    with_cand: int = 0
+    pending: int = 0
+    real: int = 0
+    yield_rate: float = 0.0
+    bot_signal_rate: float = 0.0
+    wasted: int = 0
+    top_status: list[tuple[int, int]] = field(default_factory=list)
+    samples: list[str] = field(default_factory=list)
+
+
+def _host_of(url: str) -> str | None:
+    try:
+        netloc = urlparse(url).netloc.lower()
+        return netloc or None
+    except Exception:
+        return None
+
+
+def _already_blocklisted(host: str) -> bool:
+    """True if the host is already covered by ALWAYS_ALIVE_DOMAINS.
+
+    Matches the suffix logic in ``is_always_alive_domain``: exact or
+    ``*.domain`` match.
+    """
+    for domain in ALWAYS_ALIVE_DOMAINS:
+        if host == domain or host.endswith(f".{domain}"):
+            return True
+    return False
+
+
+def derive_blocklist_candidates(db: UnifiedDatabase, run_id: str) -> dict[str, list[HostStats]]:
+    """Return per-bucket host statistics for the run.
+
+    Buckets:
+
+    - ``candidates`` -- hosts meeting the thresholds (recommended adds)
+    - ``near_misses`` -- borderline hosts in the 1%-5% yield band
+    - ``all`` -- every host with any real investigations (for diagnostics)
+
+    Already-blocklisted hosts are filtered out from ``candidates`` and
+    ``near_misses`` so the report surfaces only new actionable adds.
+    """
+    rows = db._conn.execute(
+        """
+        SELECT bsf.dead_url, bsf.investigation_state, bsf.method, ucc.http_status
+        FROM bulk_scan_findings bsf
+        LEFT JOIN url_check_cache ucc ON ucc.url = bsf.dead_url
+        WHERE bsf.run_id = ?
+        """,
+        (run_id,),
+    ).fetchall()
+
+    host_state_counts: dict[str, Counter] = defaultdict(Counter)
+    host_status_counts: dict[str, Counter] = defaultdict(Counter)
+    host_sample_urls: dict[str, list[str]] = defaultdict(list)
+    host_unique_urls: dict[str, set[str]] = defaultdict(set)
+
+    for r in rows:
+        url = r["dead_url"] or ""
+        host = _host_of(url)
+        if host is None:
+            continue
+        method = r["method"] or "pending"
+        # method == 'pending' is a Stage 1 placeholder row. method != 'pending'
+        # is a Stage-3 derived candidate (output, not input).
+        if method != "pending":
+            continue
+        state = r["investigation_state"] or "pending"
+        host_state_counts[host][state] += 1
+        host_unique_urls[host].add(url)
+        if r["http_status"] is not None:
+            host_status_counts[host][int(r["http_status"])] += 1
+        else:
+            host_status_counts[host][-1] += 1
+        if len(host_sample_urls[host]) < SAMPLE_URLS_PER_HOST and url not in host_sample_urls[host]:
+            host_sample_urls[host].append(url)
+
+    all_records: list[HostStats] = []
+    for host, state_counts in host_state_counts.items():
+        total = sum(state_counts.values())
+        no_cand = state_counts.get("investigated_no_candidate", 0)
+        with_cand = state_counts.get("investigated_with_candidate", 0)
+        real = no_cand + with_cand
+        yield_rate = (with_cand / real) if real > 0 else 0.0
+        unique_with_status = sum(host_status_counts[host].values())
+        if unique_with_status > 0:
+            bot_signals = (
+                host_status_counts[host].get(-1, 0)
+                + host_status_counts[host].get(403, 0)
+                + host_status_counts[host].get(429, 0)
+                + host_status_counts[host].get(503, 0)
+            )
+            bot_signal_rate = bot_signals / unique_with_status
+        else:
+            bot_signal_rate = 0.0
+        all_records.append(
+            HostStats(
+                host=host,
+                total=total,
+                unique_urls=len(host_unique_urls[host]),
+                alive=state_counts.get("skipped_alive", 0),
+                lang=state_counts.get("skipped_language", 0),
+                no_cand=no_cand,
+                with_cand=with_cand,
+                pending=state_counts.get("pending", 0),
+                real=real,
+                yield_rate=yield_rate,
+                bot_signal_rate=bot_signal_rate,
+                wasted=real - with_cand,
+                top_status=host_status_counts[host].most_common(4),
+                samples=host_sample_urls[host],
+            )
+        )
+
+    def _eligible(record: HostStats, upper_yield: float) -> bool:
+        return (
+            record.real >= MIN_INVESTIGATIONS
+            and record.yield_rate <= upper_yield
+            and not _already_blocklisted(record.host)
+        )
+
+    candidates = sorted(
+        (r for r in all_records if _eligible(r, MAX_TIER1_YIELD_RATE)),
+        key=lambda r: r.wasted,
+        reverse=True,
+    )
+    near_misses = sorted(
+        (r for r in all_records if _eligible(r, NEAR_MISS_UPPER_BOUND) and r.yield_rate > MAX_TIER1_YIELD_RATE),
+        key=lambda r: r.wasted,
+        reverse=True,
+    )
+    return {"candidates": candidates, "near_misses": near_misses, "all": all_records}
+
+
+def render_candidates_markdown(
+    buckets: dict[str, list[HostStats]],
+    *,
+    run_id: str,
+    db_path: str,
+    total_findings: int,
+) -> str:
+    """Markdown report for operator review. ASCII-safe (no em-dashes / arrows)."""
+    candidates = buckets["candidates"]
+    near_misses = buckets["near_misses"]
+    all_records = buckets["all"]
+    lines: list[str] = []
+    lines.append(f"# Host blocklist candidates from `{run_id}`\n")
+    lines.append(f"Generated: {datetime.now(timezone.utc).isoformat()}\n")
+    lines.append(f"Source DB: `{db_path}`\n")
+    lines.append(f"Total findings considered: {total_findings:,}\n")
+    lines.append(f"Distinct hosts found: {len(all_records):,}\n\n")
+    lines.append("## Thresholds applied\n\n")
+    lines.append(f"- `real_investigations >= {MIN_INVESTIGATIONS}`\n")
+    lines.append(f"- `tier1_yield_rate <= {MAX_TIER1_YIELD_RATE:.1%}`\n")
+    lines.append("- already-blocklisted hosts (ALWAYS_ALIVE_DOMAINS) are filtered out\n\n")
+    lines.append("## Hosts recommended for blocklist\n\n")
+    lines.append(f"**{len(candidates)} hosts**, ranked by wasted-investigation cost.\n\n")
+    if not candidates:
+        lines.append("_None met the thresholds for this run._\n\n")
+    else:
+        lines.append("| Host | Findings | Real | with_cand | Yield | Wasted | Bot% | Top statuses |\n")
+        lines.append("|---|---:|---:|---:|---:|---:|---:|---|\n")
+        for r in candidates:
+            top_status_str = ", ".join(f"{('None' if k == -1 else str(k))}:{v:,}" for k, v in r.top_status)
+            lines.append(
+                f"| `{r.host}` | {r.total:,} | {r.real:,} | "
+                f"{r.with_cand:,} | {r.yield_rate:.2%} | {r.wasted:,} | "
+                f"{r.bot_signal_rate:.0%} | {top_status_str} |\n"
+            )
+        lines.append("\n### Sample URLs per host (top 10 candidates)\n\n")
+        for r in candidates[:10]:
+            lines.append(
+                f"**`{r.host}`** -- {r.total:,} findings, {r.real:,} investigated, "
+                f"{r.with_cand:,} with candidate ({r.yield_rate:.2%})\n"
+            )
+            for u in r.samples:
+                lines.append(f"- `{u}`\n")
+            lines.append("\n")
+    lines.append("## Near-miss hosts (1%-5% yield)\n\n")
+    lines.append(f"**{len(near_misses)} hosts**. Borderline.\n\n")
+    if near_misses:
+        lines.append("| Host | Findings | Real | with_cand | Yield | Wasted | Bot% |\n")
+        lines.append("|---|---:|---:|---:|---:|---:|---:|\n")
+        for r in near_misses[:30]:
+            lines.append(
+                f"| `{r.host}` | {r.total:,} | {r.real:,} | "
+                f"{r.with_cand:,} | {r.yield_rate:.2%} | {r.wasted:,} | "
+                f"{r.bot_signal_rate:.0%} |\n"
+            )
+        lines.append("\n")
+    lines.append("## How to use\n\n")
+    lines.append("1. Review the recommended list and the sample URLs per host.\n")
+    lines.append("2. Reject hosts that look like single-repo typos or operator-actionable bugs.\n")
+    lines.append("3. Approved hosts go into `false_positives.ALWAYS_ALIVE_DOMAINS` via a focused PR.\n")
+    lines.append("4. Add per-host tests in `tests/unit/test_false_positives.py::TestIsAlwaysAliveDomain`.\n")
+    lines.append("5. The next bulk scan will skip these hosts entirely (Stage 1, 2, and 3).\n")
+    return "".join(lines)
+
+
+def write_candidates_report(
+    db: UnifiedDatabase,
+    run_id: str,
+    *,
+    db_path: str,
+    out_path: Path = REPORT_PATH,
+) -> Path:
+    """Compute and write the markdown candidates report. Returns the path.
+
+    Logs a single info-level banner with the count of new candidates so
+    the operator sees the result inline with the rest of the run output.
+    """
+    buckets = derive_blocklist_candidates(db, run_id)
+    total_findings = db._conn.execute(
+        "SELECT COUNT(*) AS n FROM bulk_scan_findings WHERE run_id = ?",
+        (run_id,),
+    ).fetchone()["n"]
+    body = render_candidates_markdown(
+        buckets,
+        run_id=run_id,
+        db_path=db_path,
+        total_findings=total_findings,
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(body, encoding="utf-8")
+    n_cand = len(buckets["candidates"])
+    n_near = len(buckets["near_misses"])
+    logger.info(
+        "host-blocklist-telemetry: %d new candidate(s), %d near-miss(es) -- review %s",
+        n_cand,
+        n_near,
+        out_path,
+    )
+    return out_path
+
+
+__all__ = [
+    "MIN_INVESTIGATIONS",
+    "MAX_TIER1_YIELD_RATE",
+    "NEAR_MISS_UPPER_BOUND",
+    "REPORT_PATH",
+    "HostStats",
+    "derive_blocklist_candidates",
+    "render_candidates_markdown",
+    "write_candidates_report",
+]
+
+
+# Suppress unused-import warning -- `Any` is intentionally reserved for
+# extending HostStats with arbitrary metadata in a future revision.
+_ = Any

--- a/src/gh_link_auditor/bulk_scan/runner.py
+++ b/src/gh_link_auditor/bulk_scan/runner.py
@@ -445,6 +445,20 @@ def run_full(
         if run["status"] not in ("aborted", "done"):
             run_scoring(db, run_id)
 
+        # #258: at end-of-run, derive host-blocklist candidates from this
+        # run's telemetry and write a markdown report for operator review.
+        # The operator wires approved hosts into ALWAYS_ALIVE_DOMAINS via a
+        # focused PR (see #366 for the canonical pattern). NEVER mutate the
+        # static blocklist silently.
+        final_run = storage.get_run(db, run_id)
+        if final_run and final_run["status"] == "done":
+            try:
+                from gh_link_auditor.bulk_scan.host_blocklist_telemetry import write_candidates_report
+
+                write_candidates_report(db, run_id, db_path=str(getattr(db, "_path", "")))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("host-blocklist-telemetry failed (non-fatal): %s", exc)
+
         return storage.get_run(db, run_id) or {}
     finally:
         emitter.stop()

--- a/tests/unit/bulk_scan/test_host_blocklist_telemetry.py
+++ b/tests/unit/bulk_scan/test_host_blocklist_telemetry.py
@@ -1,0 +1,182 @@
+"""Tests for ``gh_link_auditor.bulk_scan.host_blocklist_telemetry`` (#258)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gh_link_auditor.bulk_scan import host_blocklist_telemetry as hbt
+from gh_link_auditor.bulk_scan import storage
+from gh_link_auditor.unified_db import UnifiedDatabase
+
+
+def _seed_findings(
+    db: UnifiedDatabase,
+    run_id: str,
+    *,
+    host: str,
+    n: int,
+    state: str,
+    status: int | None = 404,
+) -> None:
+    """Insert n Stage-1 placeholder findings for `host` and set their
+    investigation_state, plus seed url_check_cache with `status`."""
+    storage.update_run_status(db, run_id, "investigating")
+    for i in range(n):
+        url = f"https://{host}/p{i}"
+        storage.add_finding(
+            db,
+            run_id,
+            f"owner/repo{i}",
+            "README.md",
+            1,
+            url,
+            candidate_url="",
+            method="pending",
+            tier=0,
+            similarity_score=None,
+            verified_live=False,
+            confidence=0.0,
+        )
+        if status is not None:
+            db.cache_url_check(url, http_status=status, final_url=url, is_bot_blocked=False)
+    db._conn.execute(
+        "UPDATE bulk_scan_findings SET investigation_state = ? WHERE run_id = ? AND method = 'pending'",
+        (state, run_id),
+    )
+    db._conn.commit()
+
+
+def test_zero_yield_host_surfaces_as_candidate(tmp_path: Path) -> None:
+    """A host with all real investigations no-cand and >= MIN gets flagged."""
+    db_path = str(tmp_path / "x.db")
+    with UnifiedDatabase(db_path) as db:
+        storage.create_run(db, "r1", 100, {})
+        _seed_findings(db, "r1", host="zerohost.example", n=hbt.MIN_INVESTIGATIONS, state="investigated_no_candidate")
+        buckets = hbt.derive_blocklist_candidates(db, "r1")
+
+    candidates = buckets["candidates"]
+    assert len(candidates) == 1
+    assert candidates[0].host == "zerohost.example"
+    assert candidates[0].real == hbt.MIN_INVESTIGATIONS
+    assert candidates[0].with_cand == 0
+    assert candidates[0].yield_rate == 0.0
+
+
+def test_below_min_investigations_does_not_surface(tmp_path: Path) -> None:
+    """A host with too few real investigations is excluded -- thin samples
+    don't deserve a blocklist entry."""
+    db_path = str(tmp_path / "x.db")
+    with UnifiedDatabase(db_path) as db:
+        storage.create_run(db, "r1", 100, {})
+        _seed_findings(
+            db, "r1", host="rarehost.example", n=hbt.MIN_INVESTIGATIONS - 1, state="investigated_no_candidate"
+        )
+        buckets = hbt.derive_blocklist_candidates(db, "r1")
+
+    assert buckets["candidates"] == []
+
+
+def test_high_yield_host_does_not_surface(tmp_path: Path) -> None:
+    """Hosts where Stage 3 succeeded should not get blocklisted -- they
+    produce real PR candidates."""
+    db_path = str(tmp_path / "x.db")
+    with UnifiedDatabase(db_path) as db:
+        storage.create_run(db, "r1", 100, {})
+        # 30 with-candidate findings -> 100% yield, not a blocklist candidate
+        _seed_findings(db, "r1", host="goodhost.example", n=hbt.MIN_INVESTIGATIONS, state="investigated_with_candidate")
+        buckets = hbt.derive_blocklist_candidates(db, "r1")
+
+    assert buckets["candidates"] == []
+    # Should NOT appear in near-miss either (100% yield is far above 5%)
+    assert buckets["near_misses"] == []
+
+
+def test_near_miss_band_surfaces_separately(tmp_path: Path) -> None:
+    """A host with 2-4% yield is in the near-miss band, not the recommended list."""
+    db_path = str(tmp_path / "x.db")
+    with UnifiedDatabase(db_path) as db:
+        storage.create_run(db, "r1", 100, {})
+        # Seed 50 findings: 1 with-cand, 49 no-cand -> 2% yield
+        # First create them all as no-cand:
+        _seed_findings(db, "r1", host="nearhost.example", n=50, state="investigated_no_candidate")
+        # Flip one to with-candidate
+        db._conn.execute(
+            "UPDATE bulk_scan_findings SET investigation_state = 'investigated_with_candidate' "
+            "WHERE run_id = 'r1' AND dead_url = 'https://nearhost.example/p0'"
+        )
+        db._conn.commit()
+        buckets = hbt.derive_blocklist_candidates(db, "r1")
+
+    assert buckets["candidates"] == []  # 2% > 1% -> not in recommended
+    assert len(buckets["near_misses"]) == 1
+    assert buckets["near_misses"][0].host == "nearhost.example"
+    assert 0.01 < buckets["near_misses"][0].yield_rate <= 0.05
+
+
+def test_already_blocklisted_host_is_filtered_out(tmp_path: Path) -> None:
+    """The report only surfaces NEW candidates -- already-blocklisted hosts
+    shouldn't re-appear in the recommended list every run."""
+    db_path = str(tmp_path / "x.db")
+    with UnifiedDatabase(db_path) as db:
+        storage.create_run(db, "r1", 100, {})
+        # medium.com is in ALWAYS_ALIVE_DOMAINS (per #358)
+        _seed_findings(db, "r1", host="medium.com", n=hbt.MIN_INVESTIGATIONS, state="investigated_no_candidate")
+        buckets = hbt.derive_blocklist_candidates(db, "r1")
+
+    assert buckets["candidates"] == []
+    # The host is in `all` for diagnostics, just not in `candidates`/`near_misses`
+    assert any(r.host == "medium.com" for r in buckets["all"])
+
+
+def test_subdomain_of_blocklisted_root_is_filtered_out(tmp_path: Path) -> None:
+    """Subdomain matching is consistent with is_always_alive_domain."""
+    db_path = str(tmp_path / "x.db")
+    with UnifiedDatabase(db_path) as db:
+        storage.create_run(db, "r1", 100, {})
+        _seed_findings(db, "r1", host="english.medium.com", n=hbt.MIN_INVESTIGATIONS, state="investigated_no_candidate")
+        buckets = hbt.derive_blocklist_candidates(db, "r1")
+
+    assert buckets["candidates"] == []
+
+
+def test_write_candidates_report_emits_markdown(tmp_path: Path) -> None:
+    """The on-disk report has the expected sections and the candidate host name."""
+    db_path = str(tmp_path / "x.db")
+    out_path = tmp_path / "out.md"
+    with UnifiedDatabase(db_path) as db:
+        storage.create_run(db, "r1", 100, {})
+        _seed_findings(
+            db, "r1", host="another-zero.example", n=hbt.MIN_INVESTIGATIONS, state="investigated_no_candidate"
+        )
+        result_path = hbt.write_candidates_report(db, "r1", db_path=db_path, out_path=out_path)
+
+    assert result_path == out_path
+    body = out_path.read_text(encoding="utf-8")
+    assert "# Host blocklist candidates from `r1`" in body
+    assert "another-zero.example" in body
+    assert "## Hosts recommended for blocklist" in body
+    assert "## Near-miss hosts (1%-5% yield)" in body
+
+
+def test_pending_findings_count_but_dont_count_as_real(tmp_path: Path) -> None:
+    """Pending (un-investigated) findings should not contribute to real_investigations."""
+    db_path = str(tmp_path / "x.db")
+    with UnifiedDatabase(db_path) as db:
+        storage.create_run(db, "r1", 100, {})
+        _seed_findings(db, "r1", host="pendinghost.example", n=hbt.MIN_INVESTIGATIONS, state="pending")
+        buckets = hbt.derive_blocklist_candidates(db, "r1")
+
+    # All pending -> 0 real -> doesn't meet MIN_INVESTIGATIONS -> not a candidate
+    assert buckets["candidates"] == []
+
+
+def test_skipped_alive_findings_dont_count_as_real(tmp_path: Path) -> None:
+    """skipped_alive means Stage 3 didn't investigate (URL was 2xx); should
+    not count toward real_investigations or the wasted figure."""
+    db_path = str(tmp_path / "x.db")
+    with UnifiedDatabase(db_path) as db:
+        storage.create_run(db, "r1", 100, {})
+        _seed_findings(db, "r1", host="alivehost.example", n=hbt.MIN_INVESTIGATIONS, state="skipped_alive")
+        buckets = hbt.derive_blocklist_candidates(db, "r1")
+
+    assert buckets["candidates"] == []


### PR DESCRIPTION
## Summary

Lifts the host-blocklist derivation from an untracked tools/ script into the package and hooks it into `runner.run_full` so the candidates report regenerates automatically at end-of-run. The audit (#258 / R4) explicitly forbids silent auto-addition; this PR surfaces candidates for review without mutating `ALWAYS_ALIVE_DOMAINS`.

## What changes

- New module `src/gh_link_auditor/bulk_scan/host_blocklist_telemetry.py`:
  - `HostStats` dataclass per host
  - `derive_blocklist_candidates(db, run_id)` -> three buckets: `candidates` (>= MIN_INVESTIGATIONS, <= 1% yield, not already blocklisted), `near_misses` (1%-5% band), `all` (diagnostic)
  - `render_candidates_markdown(buckets, ...)` -> ASCII-safe markdown matching the format the operator already reads
  - `write_candidates_report(db, run_id, db_path, out_path)` -> end-to-end: compute, render, write, log a one-line banner
- `runner.run_full` calls `write_candidates_report` only when run status is `done` (skip aborted runs). Wrapped in try/except: telemetry must not break the run.
- Already-blocklisted hosts (exact or subdomain match against `ALWAYS_ALIVE_DOMAINS`) are filtered out -- the report surfaces only NEW candidates worth wiring.

## Why

Per audit section R4 in `data/regression-audit-2026-05-26.md`: every new corpus discovery used to add operator-review burden. End-of-run automation eliminates the "remember to re-run the script" overhead while keeping the human in the loop for the actual blocklist change.

## Test plan

- [x] `poetry run pytest tests/unit/bulk_scan/test_host_blocklist_telemetry.py -v` -- 9/9 pass.
- [x] Full suite: 2512 passed, 1 skipped (was 2503; +9).
- [x] `poetry run ruff format . && poetry run ruff check .` -- clean.
- [x] Already-blocklisted host scenarios covered: `medium.com` (exact) and `english.medium.com` (subdomain) both filtered.

Closes #258