### PR TITLE
feat(network): granular failure-class classification per #261

### DIFF
--- a/src/gh_link_auditor/network.py
+++ b/src/gh_link_auditor/network.py
@@ -312,19 +312,38 @@ def _make_request(
         return exc.code, None, elapsed_ms, retry_after, final_url
     except urllib.error.URLError as exc:
         elapsed_ms = int((time.monotonic() - start) * 1000)
-        reason_str = str(exc.reason)
-        if "timed out" in reason_str or isinstance(exc.reason, socket.timeout):
+        reason = exc.reason
+        # #261: distinguish failure classes so downstream can route per
+        # category. SSL/cert is OFTEN TEMPORARY (operator note 2026-05-26
+        # on issue #261): expired certs, CA chain hiccups, CDN edge issues.
+        # Downstream must NOT propose removal on first cert_invalid -- defer
+        # and re-check after N days instead.
+        if isinstance(reason, ssl.SSLError):
+            return None, "cert_invalid", elapsed_ms, None, None
+        if isinstance(reason, socket.timeout) or "timed out" in str(reason):
             return None, "timeout", elapsed_ms, None, None
-        # DNS / name resolution failures
-        if isinstance(exc.reason, OSError):
+        if isinstance(reason, ConnectionRefusedError):
+            return None, "connection_refused", elapsed_ms, None, None
+        if isinstance(reason, socket.gaierror):
             return None, "dns_failure", elapsed_ms, None, None
-        return None, "dns_failure", elapsed_ms, None, None
+        if isinstance(reason, OSError):
+            # Catch-all transport error: network unreachable, EHOSTUNREACH,
+            # other low-level OS errors. Distinct from DNS / refused / cert
+            # so downstream can decide retry policy per class.
+            return None, "transport_error", elapsed_ms, None, None
+        return None, "transport_error", elapsed_ms, None, None
+    except ssl.SSLError:
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        return None, "cert_invalid", elapsed_ms, None, None
     except socket.timeout:
         elapsed_ms = int((time.monotonic() - start) * 1000)
         return None, "timeout", elapsed_ms, None, None
     except (http.client.RemoteDisconnected, ConnectionResetError, BrokenPipeError):
         elapsed_ms = int((time.monotonic() - start) * 1000)
         return None, "connection_reset", elapsed_ms, None, None
+    except ConnectionRefusedError:
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        return None, "connection_refused", elapsed_ms, None, None
     except Exception:
         elapsed_ms = int((time.monotonic() - start) * 1000)
         return None, "invalid", elapsed_ms, None, None
@@ -352,6 +371,11 @@ def _classify_status(status_code: int | None, error_type: str | None) -> str:
         return "disconnected"
     if error_type == "dns_failure":
         return "failed"
+    # #261: cert_invalid, connection_refused, transport_error all map to
+    # "failed" for the legacy schema field; the granular category lives
+    # on the error_type / failure_class side of the RequestResult.
+    if error_type in {"cert_invalid", "connection_refused", "transport_error"}:
+        return "failed"
     if error_type == "invalid":
         return "invalid"
 
@@ -361,6 +385,67 @@ def _classify_status(status_code: int | None, error_type: str | None) -> str:
         return "error"
 
     return "invalid"
+
+
+# ---------------------------------------------------------------------------
+# Failure-class classification (#261)
+# ---------------------------------------------------------------------------
+
+
+# Granular error-type values that ``_make_request`` may produce. Each
+# represents a distinct probe-failure mode -- the downstream "what to do"
+# decision (defer / retry / propose removal / no-op) routes off these.
+ERROR_TYPES_TEMPORARY: frozenset[str] = frozenset(
+    {
+        # #261 operator note 2026-05-26: cert errors are OFTEN TEMPORARY.
+        # Expired certs renewed within hours; CA chain hiccups; CDN edge
+        # issues. NEVER propose removal on first cert_invalid -- defer.
+        "cert_invalid",
+        # Server load / network jitter -- often transient.
+        "timeout",
+        # Network-unreachable / EHOSTUNREACH / other low-level OS errors
+        # that may be operator-side (VPN flap, DNS resolver bouncing).
+        "transport_error",
+        # Server temporarily closed the socket.
+        "connection_reset",
+    }
+)
+ERROR_TYPES_DURABLE: frozenset[str] = frozenset(
+    {
+        # DNS resolution returned NXDOMAIN. More likely permanent than
+        # cert errors, but DNS can hiccup too -- caller may still want to
+        # re-check after N days before proposing removal.
+        "dns_failure",
+        # Service explicitly refused connection on the port. Durable in
+        # the sense that the operator/service has to act to bring it back.
+        "connection_refused",
+    }
+)
+ERROR_TYPES_UNKNOWN: frozenset[str] = frozenset({"invalid"})
+
+
+def classify_failure(error_type: str | None) -> str:
+    """Map a granular probe error_type to a coarse handling class.
+
+    Returns one of:
+
+    - ``"temporary"`` -- cert / timeout / transport / connection reset.
+      Downstream should defer (re-check after N days) before proposing
+      any removal PR. The operator clarified on #261 (2026-05-26) that
+      cert_invalid in particular is frequently transient.
+    - ``"durable"`` -- DNS NXDOMAIN / connection refused. More likely to
+      survive across re-checks, but still warrants a defer-then-confirm
+      cycle before a removal proposal.
+    - ``"unknown"`` -- catch-all "invalid" bucket; treat conservatively.
+    - ``"none"`` -- error_type is None (no failure observed).
+    """
+    if error_type is None:
+        return "none"
+    if error_type in ERROR_TYPES_TEMPORARY:
+        return "temporary"
+    if error_type in ERROR_TYPES_DURABLE:
+        return "durable"
+    return "unknown"
 
 
 def _build_error_message(status_code: int | None, error_type: str | None) -> str | None:
@@ -379,6 +464,15 @@ def _build_error_message(status_code: int | None, error_type: str | None) -> str
         return "Remote server disconnected"
     if error_type == "dns_failure":
         return "DNS resolution failed"
+    if error_type == "cert_invalid":
+        # #261: surface the granular class so operator logs distinguish
+        # cert from DNS-dead. Action class is "temporary" -- see
+        # classify_failure().
+        return "SSL/TLS certificate error"
+    if error_type == "connection_refused":
+        return "Connection refused"
+    if error_type == "transport_error":
+        return "Network transport error"
     if error_type == "invalid":
         return "Unexpected error during request"
 

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -1481,3 +1481,127 @@ class TestCheckUrlFinalUrl:
         assert result["status"] == "error"
         assert result["status_code"] == 404
         assert result["final_url"] == "https://example.com/missing"
+
+
+# ---------------------------------------------------------------------------
+# Failure-class classification (#261)
+# ---------------------------------------------------------------------------
+
+
+class TestFailureClassification:
+    """Cover the granular error_type values introduced for #261, plus the
+    coarse ``classify_failure`` helper used by downstream defer/retry
+    routing."""
+
+    def test_cert_invalid_distinct_from_dns_failure(self):
+        """SSLError must produce error_type='cert_invalid', not 'dns_failure'.
+        Pre-#261 the URLError(reason=SSLError) path got conflated with DNS."""
+        with mock.patch(
+            "gh_link_auditor.network.urllib.request.urlopen",
+            side_effect=urllib.error.URLError(ssl.SSLError("CERTIFICATE_VERIFY_FAILED")),
+        ):
+            _, error_type, _, _, _ = _make_request(
+                "https://bad-cert.example",
+                "HEAD",
+                create_request_config(),
+            )
+        assert error_type == "cert_invalid"
+
+    def test_dns_failure_uses_gaierror_path(self):
+        with mock.patch(
+            "gh_link_auditor.network.urllib.request.urlopen",
+            side_effect=urllib.error.URLError(socket.gaierror("nodename nor servname")),
+        ):
+            _, error_type, _, _, _ = _make_request(
+                "https://nx.invalid",
+                "HEAD",
+                create_request_config(),
+            )
+        assert error_type == "dns_failure"
+
+    def test_connection_refused_distinct_from_dns(self):
+        """ConnectionRefusedError must surface as 'connection_refused' --
+        distinct from 'dns_failure' so downstream knows the host resolved
+        but no service is listening."""
+        with mock.patch(
+            "gh_link_auditor.network.urllib.request.urlopen",
+            side_effect=urllib.error.URLError(ConnectionRefusedError("connection refused")),
+        ):
+            _, error_type, _, _, _ = _make_request(
+                "https://refused.example",
+                "HEAD",
+                create_request_config(),
+            )
+        assert error_type == "connection_refused"
+
+    def test_transport_error_for_other_os_errors(self):
+        """Generic OSError that isn't a known subclass goes into
+        'transport_error' bucket, not the catch-all 'invalid'."""
+        with mock.patch(
+            "gh_link_auditor.network.urllib.request.urlopen",
+            side_effect=urllib.error.URLError(OSError("network unreachable")),
+        ):
+            _, error_type, _, _, _ = _make_request(
+                "https://unreachable.example",
+                "HEAD",
+                create_request_config(),
+            )
+        assert error_type == "transport_error"
+
+    def test_classify_failure_temporary_for_cert(self):
+        """Operator note 2026-05-26 on #261: cert_invalid is OFTEN
+        TEMPORARY. classify_failure must return 'temporary' so downstream
+        routing defers re-check rather than proposing removal."""
+        from gh_link_auditor.network import classify_failure
+
+        assert classify_failure("cert_invalid") == "temporary"
+
+    def test_classify_failure_temporary_for_timeout_and_transport(self):
+        from gh_link_auditor.network import classify_failure
+
+        assert classify_failure("timeout") == "temporary"
+        assert classify_failure("transport_error") == "temporary"
+        assert classify_failure("connection_reset") == "temporary"
+
+    def test_classify_failure_durable_for_dns_and_refused(self):
+        from gh_link_auditor.network import classify_failure
+
+        assert classify_failure("dns_failure") == "durable"
+        assert classify_failure("connection_refused") == "durable"
+
+    def test_classify_failure_unknown_for_invalid_bucket(self):
+        from gh_link_auditor.network import classify_failure
+
+        assert classify_failure("invalid") == "unknown"
+
+    def test_classify_failure_none_for_no_error(self):
+        from gh_link_auditor.network import classify_failure
+
+        assert classify_failure(None) == "none"
+
+    def test_temporary_and_durable_are_disjoint(self):
+        from gh_link_auditor.network import ERROR_TYPES_DURABLE, ERROR_TYPES_TEMPORARY
+
+        assert ERROR_TYPES_TEMPORARY.isdisjoint(ERROR_TYPES_DURABLE)
+
+    def test_classify_status_failed_for_cert_invalid(self):
+        """Legacy '00008-schema' status field maps cert_invalid -> 'failed'.
+        The granular class lives on error_type / classify_failure, not on
+        the schema field."""
+        from gh_link_auditor.network import _classify_status
+
+        assert _classify_status(None, "cert_invalid") == "failed"
+        assert _classify_status(None, "connection_refused") == "failed"
+        assert _classify_status(None, "transport_error") == "failed"
+
+    def test_check_url_returns_failed_with_cert_invalid_error(self, no_retry_backoff_config):
+        """End-to-end: cert error -> RequestResult.status == 'failed' with
+        a cert-specific error message."""
+        with mock.patch(
+            "gh_link_auditor.network.urllib.request.urlopen",
+            side_effect=urllib.error.URLError(ssl.SSLError("CERTIFICATE_VERIFY_FAILED")),
+        ):
+            result = check_url("https://bad-cert.example", backoff_config=no_retry_backoff_config)
+        assert result["status"] == "failed"
+        assert result["status_code"] is None
+        assert "certificate" in (result["error"] or "").lower()


### PR DESCRIPTION
## Summary

Refines `network._make_request` to distinguish probe-failure modes instead of collapsing every transport error into `dns_failure`. Surfaces a new `classify_failure` helper that maps the granular error_type to a coarse routing class so downstream can defer / retry / propose-removal per category.

Implements the operator clarification on #261 (2026-05-26 comment): cert_invalid is FREQUENTLY TEMPORARY. The audit's original "cert-invalid = removal PR with 100% confidence" framing is wrong; removals must wait for multiple re-checks.

## What changes

`src/gh_link_auditor/network.py`:

- `_make_request` now produces granular `error_type` values:
  - `cert_invalid` (SSL/TLS errors)
  - `connection_refused`
  - `dns_failure` (existing semantics, narrowed to socket.gaierror)
  - `transport_error` (other OSError)
  - `timeout`, `connection_reset`, `invalid` (existing)
- `_classify_status` maps all the new types to the legacy `'failed'` schema field.
- `_build_error_message` returns cert-specific, refused-specific, and transport-specific messages.
- New `ERROR_TYPES_TEMPORARY` and `ERROR_TYPES_DURABLE` frozensets.
- New `classify_failure(error_type) -> 'temporary' | 'durable' | 'unknown' | 'none'` helper.

## Why

Per audit section R11 / #261, plus the 2026-05-26 operator note on the cert_invalid handling: defer-and-recheck is the correct policy, not removal. Granular classification surfaces enough signal for the downstream router (future PR) to do the right thing per class. This PR only refines the classifier and exposes the helper; the routing changes are intentionally out of scope.

## Test plan

- [x] `poetry run pytest tests/unit/test_network.py -v` -- 88 passed (was 76; +12 new in TestFailureClassification).
- [x] Full suite: 2524 passed, 1 skipped (was 2512; +12).
- [x] `poetry run ruff format . && poetry run ruff check .` -- clean.
- [x] Disjointness: `ERROR_TYPES_TEMPORARY.isdisjoint(ERROR_TYPES_DURABLE)`.

Closes #261