### PR TITLE
feat(detective): whole-domain rebrand sunset table + LinkDetective hook

### DIFF
--- a/src/gh_link_auditor/domain_rebrand.py
+++ b/src/gh_link_auditor/domain_rebrand.py
@@ -1,0 +1,167 @@
+"""Whole-domain rebrand / migration detection (#262).
+
+When a dead URL's host has been entirely rebranded (e.g.
+``play.picoctf.org -> learn.cylabacademy.org``), the per-URL probe sees
+nothing -- the original domain is gone. LinkDetective's URL-level
+redirect handling can't recover the new URL because there's no live
+redirect chain to follow.
+
+This module ships a hand-curated sunset table mapping known-rebranded
+hosts to their canonical successor. ``find_rebrand_target`` returns a
+candidate replacement URL (path preserved) when the dead URL's host is
+in the table.
+
+The audit (#262 / 2026-05-23) named these as high-value PR opportunities
+that are currently invisible. The table starts small with the operator's
+named examples; new entries are added via PR as the operator discovers
+them in scan output.
+
+Adding a host:
+
+1. Confirm via browser that the OLD host is genuinely dead or auto-
+   redirects to the new host. If the old host still responds, the
+   existing URL-level redirect resolver handles it.
+2. Confirm the NEW host serves the same content class (docs, blog,
+   tutorial, etc.) -- different content domains aren't a fair
+   replacement even if the company is the same.
+3. Add the entry below with a short ``reason`` and ``since`` year.
+4. Add a test in ``tests/unit/test_domain_rebrand.py``.
+
+A ``replacement_host=None`` entry means the host shut down with no
+successor (gfycat, hipchat). The pipeline records the diagnostic but
+emits no candidate -- removal proposals must still go through
+operator review (see #261 / temporary-failure routing).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+from urllib.parse import urlparse, urlunparse
+
+
+@dataclass(frozen=True)
+class SunsetEntry:
+    """A single entry in the sunset table."""
+
+    old_host: str
+    replacement_host: str | None
+    since: str  # year as string
+    reason: str = ""
+
+
+SUNSET_DOMAINS: Final[dict[str, SunsetEntry]] = {
+    # picoCTF tutorial site -> CyLab Academy (Carnegie Mellon).
+    # Original observation: 132 findings with None status, audit #262.
+    "play.picoctf.org": SunsetEntry(
+        old_host="play.picoctf.org",
+        replacement_host="learn.cylabacademy.org",
+        since="2023",
+        reason="picoCTF platform migrated to CyLab Academy",
+    ),
+    # Gitter chat acquired by Element / Matrix.org (2022).
+    "gitter.im": SunsetEntry(
+        old_host="gitter.im",
+        replacement_host="element.io",
+        since="2022",
+        reason="acquired by Element; chat lives in Matrix rooms",
+    ),
+    # SignalFx APM acquired by Splunk; docs moved.
+    "docs.signalfx.com": SunsetEntry(
+        old_host="docs.signalfx.com",
+        replacement_host="docs.splunk.com",
+        since="2022",
+        reason="SignalFx acquired by Splunk; docs subdomain consolidated",
+    ),
+    "signalfx.com": SunsetEntry(
+        old_host="signalfx.com",
+        replacement_host="splunk.com",
+        since="2022",
+        reason="SignalFx acquired by Splunk",
+    ),
+    # HipChat shut down (Atlassian sold to Slack).
+    "hipchat.com": SunsetEntry(
+        old_host="hipchat.com",
+        replacement_host=None,
+        since="2019",
+        reason="shutdown; users migrated to Slack but no canonical successor URL",
+    ),
+    # Gfycat shut down 2023; archived only.
+    "gfycat.com": SunsetEntry(
+        old_host="gfycat.com",
+        replacement_host=None,
+        since="2023",
+        reason="shutdown; no replacement",
+    ),
+}
+
+
+def find_rebrand_target(url: str) -> str | None:
+    """Return a candidate replacement URL when ``url``'s host is in the
+    sunset table and has a ``replacement_host``. Path / query / fragment
+    are preserved on the new host.
+
+    Returns ``None`` when:
+
+    - the host is not in the sunset table, OR
+    - the host is in the table but its ``replacement_host`` is ``None``
+      (the service shut down with no successor).
+
+    Callers can use ``find_sunset_entry`` for the full record when the
+    "no successor" case is also actionable (operator-driven removal).
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return None
+    entry = SUNSET_DOMAINS.get(host)
+    if entry is None:
+        return None
+    if entry.replacement_host is None:
+        return None
+    # Preserve scheme, path, params, query, fragment; swap netloc.
+    return urlunparse(
+        (
+            parsed.scheme or "https",
+            entry.replacement_host,
+            parsed.path,
+            parsed.params,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
+def find_sunset_entry(url: str) -> SunsetEntry | None:
+    """Return the full SunsetEntry for ``url``'s host, or None.
+
+    Useful for the operator-facing "this host is sunsetted but had no
+    successor" diagnostic. ``find_rebrand_target`` skips no-successor
+    entries because they can't produce a candidate URL.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return None
+    return SUNSET_DOMAINS.get(host)
+
+
+def is_sunsetted_host(url: str) -> bool:
+    """True if the URL's host is in the sunset table (with or without
+    a successor)."""
+    return find_sunset_entry(url) is not None
+
+
+__all__ = [
+    "SUNSET_DOMAINS",
+    "SunsetEntry",
+    "find_rebrand_target",
+    "find_sunset_entry",
+    "is_sunsetted_host",
+]

--- a/src/gh_link_auditor/link_detective.py
+++ b/src/gh_link_auditor/link_detective.py
@@ -17,6 +17,7 @@ from enum import Enum
 from urllib.parse import quote, unquote, urlparse
 
 from gh_link_auditor.archive_client import ArchiveClient
+from gh_link_auditor.domain_rebrand import find_rebrand_target
 from gh_link_auditor.false_positives import PARKING_DOMAINS
 from gh_link_auditor.github_resolver import GitHubResolver
 from gh_link_auditor.redirect_resolver import RedirectResolver, SSRFBlocked
@@ -46,6 +47,7 @@ class InvestigationMethod(Enum):
     SITEMAP_SEARCH = "sitemap_search"
     WIKIPEDIA_SUGGEST = "wikipedia_suggest"
     GITHUB_API_REDIRECT = "github_api_redirect"
+    DOMAIN_REBRAND = "domain_rebrand"
     ARCHIVE_ONLY = "archive_only"
 
 
@@ -474,6 +476,36 @@ class LinkDetective:
                         log.append(f"GitHub redirect: {dead_url} -> {new_file_url}")
             except Exception as e:
                 log.append(f"GitHub resolution failed: {e}")
+
+        # 9.5. Domain-rebrand sunset table (#262).
+        # If the dead URL's host is in the sunset table (e.g. play.picoctf.org
+        # -> learn.cylabacademy.org), propose the rebranded URL as a
+        # candidate. The host's been retired or migrated, so the URL-level
+        # redirect resolver above can't recover the new URL on its own.
+        # verify_live: the redirect resolver verifies actual reachability of
+        # the rebranded target before we surface this as a high-confidence
+        # candidate; otherwise the sunset table itself can rot.
+        try:
+            rebrand_target = find_rebrand_target(dead_url)
+        except Exception as exc:  # noqa: BLE001
+            rebrand_target = None
+            log.append(f"Domain-rebrand lookup failed: {exc}")
+        if rebrand_target is not None:
+            verified = False
+            try:
+                verified = self._redirect_resolver.verify_live(rebrand_target)
+            except Exception as exc:  # noqa: BLE001
+                log.append(f"Domain-rebrand verify_live failed: {exc}")
+            similarity = 0.9 if verified else 0.5
+            candidates.append(
+                CandidateReplacement(
+                    url=rebrand_target,
+                    method=InvestigationMethod.DOMAIN_REBRAND,
+                    similarity_score=similarity,
+                    verified_live=verified,
+                )
+            )
+            log.append(f"Domain-rebrand candidate {rebrand_target} (verified_live={verified}, #262)")
 
         # 10. Archive-only fallback
         if archive_snapshot and not any(c.verified_live for c in candidates):

--- a/tests/unit/test_domain_rebrand.py
+++ b/tests/unit/test_domain_rebrand.py
@@ -1,0 +1,127 @@
+"""Tests for ``gh_link_auditor.domain_rebrand`` (#262)."""
+
+from __future__ import annotations
+
+import pytest
+
+from gh_link_auditor.domain_rebrand import (
+    SUNSET_DOMAINS,
+    SunsetEntry,
+    find_rebrand_target,
+    find_sunset_entry,
+    is_sunsetted_host,
+)
+
+
+class TestFindRebrandTarget:
+    def test_picoctf_to_cylab(self) -> None:
+        """The motivating example from the #262 audit observation."""
+        target = find_rebrand_target("https://play.picoctf.org/challenges/cryptography")
+        assert target == "https://learn.cylabacademy.org/challenges/cryptography"
+
+    def test_path_with_query_and_fragment_preserved(self) -> None:
+        target = find_rebrand_target("https://gitter.im/some-org/room?utm=x#anchor")
+        assert target == "https://element.io/some-org/room?utm=x#anchor"
+
+    def test_signalfx_subdomain(self) -> None:
+        """The docs.signalfx.com case from the audit."""
+        target = find_rebrand_target("https://docs.signalfx.com/en/latest/index.html")
+        assert target == "https://docs.splunk.com/en/latest/index.html"
+
+    def test_scheme_preserved(self) -> None:
+        target = find_rebrand_target("http://gitter.im/foo/bar")
+        assert target == "http://element.io/foo/bar"
+
+    def test_unknown_host_returns_none(self) -> None:
+        assert find_rebrand_target("https://this-domain-is-fine.example/anywhere") is None
+
+    def test_host_case_insensitive(self) -> None:
+        """Hosts are case-insensitive per RFC; sunset table matches that."""
+        target = find_rebrand_target("https://GITTER.IM/path")
+        assert target == "https://element.io/path"
+
+    def test_root_path(self) -> None:
+        target = find_rebrand_target("https://gitter.im")
+        # urlparse on a URL with no path yields path="" -- preserved as such.
+        assert target == "https://element.io"
+
+    def test_no_successor_returns_none(self) -> None:
+        """hipchat.com shut down with no replacement; no candidate URL
+        can be synthesized."""
+        assert find_rebrand_target("https://hipchat.com/sign_in") is None
+
+    def test_invalid_url_returns_none(self) -> None:
+        assert find_rebrand_target("not-a-url") is None
+
+    def test_url_without_host_returns_none(self) -> None:
+        assert find_rebrand_target("https://") is None
+
+
+class TestFindSunsetEntry:
+    def test_returns_entry_for_known_host(self) -> None:
+        entry = find_sunset_entry("https://play.picoctf.org/x")
+        assert isinstance(entry, SunsetEntry)
+        assert entry.old_host == "play.picoctf.org"
+        assert entry.replacement_host == "learn.cylabacademy.org"
+        assert entry.since == "2023"
+
+    def test_returns_entry_with_none_replacement(self) -> None:
+        """No-successor case -- entry is still returned so the operator
+        can see the diagnostic."""
+        entry = find_sunset_entry("https://gfycat.com/something")
+        assert entry is not None
+        assert entry.replacement_host is None
+        assert "shutdown" in entry.reason.lower()
+
+    def test_unknown_host_returns_none(self) -> None:
+        assert find_sunset_entry("https://wikipedia.org/wiki/x") is None
+
+    def test_invalid_url_returns_none(self) -> None:
+        assert find_sunset_entry("not-a-url") is None
+
+
+class TestIsSunsetted:
+    def test_known_host_returns_true(self) -> None:
+        assert is_sunsetted_host("https://play.picoctf.org/x") is True
+
+    def test_known_no_successor_host_returns_true(self) -> None:
+        """is_sunsetted is host-presence; replacement-availability is
+        find_rebrand_target's concern. A shut-down host IS sunsetted."""
+        assert is_sunsetted_host("https://hipchat.com/x") is True
+
+    def test_unknown_host_returns_false(self) -> None:
+        assert is_sunsetted_host("https://github.com/x") is False
+
+
+class TestSunsetTableShape:
+    """Pin invariants on the table so a future addition can't subtly
+    break the contract."""
+
+    @pytest.mark.parametrize("host,entry", list(SUNSET_DOMAINS.items()))
+    def test_table_keys_match_old_host_field(self, host: str, entry: SunsetEntry) -> None:
+        """The dict key must equal the entry's ``old_host`` so lookups
+        and diagnostics stay consistent."""
+        assert host == entry.old_host
+
+    @pytest.mark.parametrize("host,entry", list(SUNSET_DOMAINS.items()))
+    def test_host_is_lowercase(self, host: str, entry: SunsetEntry) -> None:
+        """The lookup normalizes input to lowercase; table entries must
+        also be lowercase."""
+        assert host == host.lower()
+
+    @pytest.mark.parametrize("host,entry", list(SUNSET_DOMAINS.items()))
+    def test_entry_has_since_year(self, host: str, entry: SunsetEntry) -> None:
+        """Every entry must record when the rebrand happened so the
+        operator can sanity-check (if the rebrand was 10+ years ago and
+        we never noticed, the corpus probably has bigger problems)."""
+        assert entry.since
+        # 4-digit year sanity check
+        assert entry.since.isdigit() and len(entry.since) == 4
+
+    @pytest.mark.parametrize("host,entry", list(SUNSET_DOMAINS.items()))
+    def test_no_successor_entries_have_reason(self, host: str, entry: SunsetEntry) -> None:
+        """If there's no replacement_host the operator needs to know why
+        (shutdown? bought and content deleted?) -- the reason field is
+        load-bearing for the no-successor case."""
+        if entry.replacement_host is None:
+            assert entry.reason

--- a/tests/unit/test_link_detective.py
+++ b/tests/unit/test_link_detective.py
@@ -323,6 +323,86 @@ class TestArchiveOnlyFallback:
 
 
 # ---------------------------------------------------------------------------
+# Domain-rebrand sunset table (#262)
+# ---------------------------------------------------------------------------
+
+
+class TestDomainRebrand:
+    def test_sunset_host_produces_domain_rebrand_candidate(self):
+        """play.picoctf.org is in the sunset table -> emit a DOMAIN_REBRAND
+        candidate even when nothing else surfaces."""
+        detective = _make_detective()
+        # No URL-level redirects, no archive, no heuristics, no GH redirect.
+        detective._redirect_resolver = FakeRedirectResolver()
+        detective._archive_client = make_archive_miss()
+        detective._url_heuristic = FakeURLHeuristic()
+        detective._github_resolver = FakeGitHubResolver()
+
+        report = detective.investigate("https://play.picoctf.org/challenges", "error")
+
+        rebrand = [
+            c for c in report.investigation.candidate_replacements if c.method == InvestigationMethod.DOMAIN_REBRAND
+        ]
+        assert len(rebrand) == 1
+        assert rebrand[0].url == "https://learn.cylabacademy.org/challenges"
+        # No live verification stubbed -> not verified, similarity 0.5
+        assert rebrand[0].verified_live is False
+        assert rebrand[0].similarity_score == 0.5
+
+    def test_verified_live_rebrand_has_higher_similarity(self):
+        """When verify_live succeeds, the rebrand candidate is more
+        confident -- similarity 0.9 instead of 0.5."""
+        detective = _make_detective()
+        detective._redirect_resolver = FakeRedirectResolver(
+            live_urls={"https://element.io/foo/room"},
+        )
+        detective._archive_client = make_archive_miss()
+        detective._url_heuristic = FakeURLHeuristic()
+        detective._github_resolver = FakeGitHubResolver()
+
+        report = detective.investigate("https://gitter.im/foo/room", "error")
+
+        rebrand = [
+            c for c in report.investigation.candidate_replacements if c.method == InvestigationMethod.DOMAIN_REBRAND
+        ]
+        assert len(rebrand) == 1
+        assert rebrand[0].url == "https://element.io/foo/room"
+        assert rebrand[0].verified_live is True
+        assert rebrand[0].similarity_score == 0.9
+
+    def test_unknown_host_emits_no_rebrand(self):
+        """Hosts not in the sunset table produce no DOMAIN_REBRAND."""
+        detective = _make_detective()
+        detective._redirect_resolver = FakeRedirectResolver()
+        detective._archive_client = make_archive_miss()
+        detective._url_heuristic = FakeURLHeuristic()
+        detective._github_resolver = FakeGitHubResolver()
+
+        report = detective.investigate("https://unknown-host.example/x", 404)
+
+        rebrand = [
+            c for c in report.investigation.candidate_replacements if c.method == InvestigationMethod.DOMAIN_REBRAND
+        ]
+        assert rebrand == []
+
+    def test_shutdown_host_emits_no_rebrand(self):
+        """hipchat.com has no replacement_host -> no candidate URL can be
+        synthesized; we don't fake one up."""
+        detective = _make_detective()
+        detective._redirect_resolver = FakeRedirectResolver()
+        detective._archive_client = make_archive_miss()
+        detective._url_heuristic = FakeURLHeuristic()
+        detective._github_resolver = FakeGitHubResolver()
+
+        report = detective.investigate("https://hipchat.com/sign_in", "error")
+
+        rebrand = [
+            c for c in report.investigation.candidate_replacements if c.method == InvestigationMethod.DOMAIN_REBRAND
+        ]
+        assert rebrand == []
+
+
+# ---------------------------------------------------------------------------
 # URL heuristic with content similarity
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

LinkDetective currently emits zero candidates when the dead URL's host has been entirely rebranded (e.g. `play.picoctf.org -> learn.cylabacademy.org`) because the per-URL probe sees nothing -- the original domain is gone and there's no live redirect chain to follow. The audit #262 observation: 132 findings on play.picoctf.org all None status, all zero candidates, all high-value PR opportunities.

This PR ships a hand-curated sunset table + the LinkDetective hook that consumes it.

## What changes

- New module `src/gh_link_auditor/domain_rebrand.py`:
  - `SUNSET_DOMAINS` -- dict[old_host -> SunsetEntry] with initial entries: `play.picoctf.org`, `gitter.im`, `docs.signalfx.com`, `signalfx.com`, `hipchat.com` (no-successor), `gfycat.com` (no-successor).
  - `find_rebrand_target(url) -> str | None` -- synthesize candidate URL preserving scheme + path + query + fragment.
  - `find_sunset_entry(url)` and `is_sunsetted_host(url)` for diagnostics.
- New `InvestigationMethod.DOMAIN_REBRAND` value.
- `LinkDetective.investigate` step 9.5 (before archive_only fallback):
  - Calls `find_rebrand_target` on the dead URL.
  - Calls `redirect_resolver.verify_live` on the synthesized target.
  - Emits a `DOMAIN_REBRAND` candidate with similarity 0.9 (verified) or 0.5 (unverified).
  - Shut-down hosts (no successor) emit no candidate -- removal proposals stay an operator decision.

## Why

Per audit section R12 / #262. Pairs with #261's failure-class classification: the cert/DNS/refused signal tells the operator WHY the host is unreachable; the sunset table tells the pipeline WHERE the content moved when we know.

## Test plan

- [x] `poetry run pytest tests/unit/test_domain_rebrand.py -v` -- 41 cases (10 functional + 4 sunset-entry + 3 is-sunsetted + parametric table invariants across every entry).
- [x] `poetry run pytest tests/unit/test_link_detective.py::TestDomainRebrand -v` -- 4 integration cases.
- [x] Full suite: 2569 passed, 1 skipped (was 2524; +45).
- [x] `poetry run ruff format . && poetry run ruff check .` -- clean.
- [x] No-successor handling: `hipchat.com` and `gfycat.com` are in the table but `find_rebrand_target` returns None for them.

Closes #262