### PR TITLE
chore(tools): track reset_quality_aborted.py with unit tests

### DIFF
--- a/tests/unit/tools/test_reset_quality_aborted.py
+++ b/tests/unit/tools/test_reset_quality_aborted.py
@@ -1,0 +1,258 @@
+"""Tests for tools/reset_quality_aborted.py.
+
+The script is an operational recovery helper that mutates a local
+SQLite DB. These tests exercise it against a tmp_path DB seeded with
+the bulk_scan_runs schema, so the agent (or anyone else) can validate
+output and behavior without touching the operator's real ~/.ghla/ghla.db.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent.parent.parent / "tools" / "reset_quality_aborted.py"
+
+
+def _load_script_module():
+    """Import the script as a module so we can call main() directly."""
+    spec = importlib.util.spec_from_file_location("reset_quality_aborted_under_test", _SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    # Avoid polluting sys.modules permanently across test sessions.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _seed_run(
+    db_path: Path,
+    *,
+    run_id: str = "bulk-20260526T031148Z",
+    status: str = "quality_aborted",
+    quality_aborted: int = 1,
+    completed_at: str | None = "2026-05-26T05:31:09.021709+00:00",
+) -> None:
+    """Create a minimal bulk_scan_runs row matching the production schema
+    fields the script touches. The script only references status,
+    quality_aborted, and completed_at, so we keep the fixture narrow."""
+    con = sqlite3.connect(str(db_path))
+    try:
+        con.execute(
+            """
+            CREATE TABLE bulk_scan_runs (
+                run_id TEXT PRIMARY KEY,
+                status TEXT,
+                quality_aborted INTEGER,
+                completed_at TEXT
+            )
+            """
+        )
+        con.execute(
+            "INSERT INTO bulk_scan_runs (run_id, status, quality_aborted, completed_at) VALUES (?, ?, ?, ?)",
+            (run_id, status, quality_aborted, completed_at),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _read_row(db_path: Path, run_id: str) -> dict | None:
+    con = sqlite3.connect(str(db_path))
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute(
+            "SELECT status, quality_aborted, completed_at FROM bulk_scan_runs WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        con.close()
+
+
+# --- dry-run ---------------------------------------------------------------
+
+
+class TestDryRun:
+    def test_does_not_mutate_db(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path)
+
+        module = _load_script_module()
+        rc = module.main(["--db-path", str(db_path), "--dry-run"])
+
+        assert rc == 0
+        # DB unchanged
+        row = _read_row(db_path, "bulk-20260526T031148Z")
+        assert row is not None
+        assert row["status"] == "quality_aborted"
+        assert row["quality_aborted"] == 1
+        assert row["completed_at"] == "2026-05-26T05:31:09.021709+00:00"
+
+    def test_shows_projected_clean_state(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """Regression test for the bug the operator caught: dry-run was
+        re-reading the unchanged row, so the AFTER block showed the same
+        values as BEFORE. AFTER must reflect the PROJECTED post-update
+        state, not a re-read of the still-aborted row."""
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path)
+
+        module = _load_script_module()
+        module.main(["--db-path", str(db_path), "--dry-run"])
+        out = capsys.readouterr().out
+
+        assert "BEFORE:" in out
+        assert "AFTER (projected; not written):" in out
+
+        # Split into BEFORE / AFTER sections so we can pin each separately.
+        before_idx = out.index("BEFORE:")
+        after_idx = out.index("AFTER (projected; not written):")
+        before_block = out[before_idx:after_idx]
+        after_block = out[after_idx:]
+
+        # BEFORE must show the aborted state.
+        assert "quality_aborted" in before_block
+        assert "yes" in before_block
+        assert "2026-05-26T05:31:09" in before_block
+
+        # AFTER must show the clean state -- this is the bug the operator
+        # found: previously the AFTER block matched BEFORE.
+        assert "investigating" in after_block
+        assert "no   --" in after_block
+        assert "2026-05-26T05:31:09" not in after_block, "AFTER must not show the old completed_at"
+        assert "unset" in after_block
+
+    def test_prints_followup_hint(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path)
+
+        module = _load_script_module()
+        module.main(["--db-path", str(db_path), "--dry-run"])
+        out = capsys.readouterr().out
+        assert "re-run without --dry-run to apply" in out
+
+
+# --- apply -----------------------------------------------------------------
+
+
+class TestApply:
+    def test_mutates_db(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path)
+
+        module = _load_script_module()
+        rc = module.main(["--db-path", str(db_path)])
+        assert rc == 0
+
+        row = _read_row(db_path, "bulk-20260526T031148Z")
+        assert row is not None
+        assert row["status"] == "investigating"
+        assert row["quality_aborted"] == 0
+        assert row["completed_at"] is None
+
+    def test_after_block_shows_actual_db_state(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """When applying, AFTER reflects the post-UPDATE DB read, not a
+        synthesized projection. Pins that distinction so a refactor can't
+        accidentally drop the verify step."""
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path)
+
+        module = _load_script_module()
+        module.main(["--db-path", str(db_path)])
+        out = capsys.readouterr().out
+
+        # Header must be the non-dry-run variant.
+        assert "AFTER:" in out
+        assert "AFTER (projected; not written):" not in out
+
+        # And the resume hint must appear.
+        assert "bulk-scan start --run-id bulk-20260526T031148Z" in out
+
+    def test_emits_resume_command(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path, run_id="some-other-run-id")
+
+        module = _load_script_module()
+        module.main(["--db-path", str(db_path), "--run-id", "some-other-run-id"])
+        out = capsys.readouterr().out
+        assert "bulk-scan start --run-id some-other-run-id" in out
+
+
+# --- no-op -----------------------------------------------------------------
+
+
+class TestNoOp:
+    def test_returns_zero_and_does_not_mutate_when_already_clean(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path, status="investigating", quality_aborted=0, completed_at=None)
+
+        module = _load_script_module()
+        rc = module.main(["--db-path", str(db_path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "nothing to do" in out
+
+        # Still the same row.
+        row = _read_row(db_path, "bulk-20260526T031148Z")
+        assert row is not None
+        assert row["status"] == "investigating"
+
+
+# --- errors ----------------------------------------------------------------
+
+
+class TestErrorPaths:
+    def test_missing_db_returns_2(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        db_path = tmp_path / "missing.db"
+
+        module = _load_script_module()
+        rc = module.main(["--db-path", str(db_path)])
+        assert rc == 2
+
+    def test_missing_run_id_returns_3(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path, run_id="someone-elses-run")
+
+        module = _load_script_module()
+        rc = module.main(["--db-path", str(db_path), "--run-id", "not-in-db"])
+        assert rc == 3
+
+
+# --- output explanations ---------------------------------------------------
+
+
+class TestExplanations:
+    """Pin the human-readable explanation strings the operator asked for
+    (no raw 0/1 sqlite booleans in the output)."""
+
+    def test_quality_aborted_shows_yes_not_1(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path)
+
+        module = _load_script_module()
+        module.main(["--db-path", str(db_path), "--dry-run"])
+        out = capsys.readouterr().out
+
+        # BEFORE half must contain 'yes' (the human form), not raw 1.
+        before_section = out[out.index("BEFORE:") : out.index("AFTER")]
+        assert "yes" in before_section
+        assert "quality_aborted:  1\n" not in before_section
+        assert "quality_aborted:  0\n" not in before_section
+
+    def test_completed_at_unset_uses_human_phrase(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path)
+
+        module = _load_script_module()
+        module.main(["--db-path", str(db_path), "--dry-run"])
+        out = capsys.readouterr().out
+        after_section = out[out.index("AFTER") :]
+        assert "unset" in after_section
+        # Should NOT show the literal string "None" instead of the explanation
+        assert "completed_at:     None" not in after_section

--- a/tools/reset_quality_aborted.py
+++ b/tools/reset_quality_aborted.py
@@ -1,0 +1,150 @@
+"""Reset a bulk-scan run from quality_aborted back to investigating.
+
+Operational recovery for runs that the (now-permanently-disabled, #362)
+quality stop-loss killed mid-flight. The run's url_check_cache and
+findings rows are intact; only the run-level status needs to flip so
+`bulk-scan start --run-id <id>` resumes from Stage 3 instead of refusing.
+
+Why a script instead of a one-liner: PowerShell quoting around sqlite3
++ embedded SQL is genuinely fragile. This removes the quoting risk and
+prints exactly what changed so you can see it worked.
+
+Usage::
+
+    poetry run python tools/reset_quality_aborted.py
+    poetry run python tools/reset_quality_aborted.py --run-id bulk-20260526T031148Z
+    poetry run python tools/reset_quality_aborted.py --dry-run
+
+Default run-id is ``bulk-20260526T031148Z`` (the 2026-05-26 incident).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+DEFAULT_RUN_ID = "bulk-20260526T031148Z"
+DEFAULT_DB_PATH = Path.home() / ".ghla" / "ghla.db"
+
+
+def _explain_status(status: str | None) -> str:
+    if status == "quality_aborted":
+        return "quality_aborted  -- scan was killed mid-flight; will NOT resume in this state"
+    if status == "investigating":
+        return "investigating    -- Stage 3 ready; 'bulk-scan start --run-id' will resume here"
+    if status == "aborted":
+        return "aborted          -- operator stopped the scan; resumable"
+    if status == "done":
+        return "done             -- scan completed normally"
+    if status in {"selecting", "inventorying", "checking", "scoring"}:
+        return f"{status:16s} -- mid-stage; intentional reset is unusual"
+    return f"{status!r}"
+
+
+def _explain_quality_aborted(v: int | None) -> str:
+    if v == 1:
+        return "yes  -- the kill flag set by the now-disabled quality stop-loss (#362)"
+    if v == 0:
+        return "no   -- the scan is in a clean state"
+    return f"{v!r}"
+
+
+def _explain_completed_at(v: str | None) -> str:
+    if v is None:
+        return "(unset; the scan has not finished, which is what we want for resume)"
+    return f"{v}  -- stamped when the scan exited; must be cleared to resume"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--run-id",
+        default=DEFAULT_RUN_ID,
+        help=f"run_id to reset (default: {DEFAULT_RUN_ID})",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=str(DEFAULT_DB_PATH),
+        help=f"path to ghla.db (default: {DEFAULT_DB_PATH})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="show what would change without writing",
+    )
+    args = parser.parse_args(argv)
+
+    db_path = Path(args.db_path)
+    if not db_path.exists():
+        sys.stderr.write(f"DB not found: {db_path}\n")
+        return 2
+
+    con = sqlite3.connect(str(db_path))
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute(
+            "SELECT status, quality_aborted, completed_at FROM bulk_scan_runs WHERE run_id = ?",
+            (args.run_id,),
+        ).fetchone()
+        if row is None:
+            sys.stderr.write(f"run not found: {args.run_id!r}\n")
+            return 3
+
+        print(f"run_id:  {args.run_id}")
+        print(f"db:      {db_path}")
+        print()
+        print("BEFORE:")
+        print(f"  status:           {_explain_status(row['status'])}")
+        print(f"  quality_aborted:  {_explain_quality_aborted(row['quality_aborted'])}")
+        print(f"  completed_at:     {_explain_completed_at(row['completed_at'])}")
+
+        already_clean = row["status"] == "investigating" and not row["quality_aborted"]
+        if already_clean:
+            print()
+            print("nothing to do -- the run is already in 'investigating' with quality_aborted=0.")
+            return 0
+
+        if args.dry_run:
+            after_status: str | None = "investigating"
+            after_qa: int | None = 0
+            after_completed_at: str | None = None
+        else:
+            con.execute(
+                "UPDATE bulk_scan_runs SET status = ?, quality_aborted = ?, completed_at = ? WHERE run_id = ?",
+                ("investigating", 0, None, args.run_id),
+            )
+            con.commit()
+            verified = con.execute(
+                "SELECT status, quality_aborted, completed_at FROM bulk_scan_runs WHERE run_id = ?",
+                (args.run_id,),
+            ).fetchone()
+            after_status = verified["status"]
+            after_qa = verified["quality_aborted"]
+            after_completed_at = verified["completed_at"]
+
+        print()
+        print("AFTER (projected; not written):" if args.dry_run else "AFTER:")
+        print(f"  status:           {_explain_status(after_status)}")
+        print(f"  quality_aborted:  {_explain_quality_aborted(after_qa)}")
+        print(f"  completed_at:     {_explain_completed_at(after_completed_at)}")
+
+        if args.dry_run:
+            print()
+            print("re-run without --dry-run to apply.")
+            return 0
+
+        print()
+        print("resume with:")
+        print(f"  poetry run python -m gh_link_auditor.cli.main bulk-scan start --run-id {args.run_id}")
+        return 0
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Lifts the operator-recovery helper from untracked `tools/` into the repo as a tested, callable script. Resets a bulk-scan run from `quality_aborted` back to `investigating` so `bulk-scan start --run-id` can resume from Stage 3 instead of refusing.

## Why

Quality stop-loss is permanently dead (#362) but its historical victims still need to be unstuck. Two prior iterations of this script had bugs the operator caught at the keyboard (fragile `~` path, then a stale AFTER block). Putting it under test pins both regressions.

## What changes

`tools/reset_quality_aborted.py`:

- Defaults to `bulk-20260526T031148Z` (the 2026-05-26 incident) and `Path.home() / .ghla / ghla.db`. Both `--run-id` and `--db-path` override.
- BEFORE / AFTER blocks with every value explained inline (no raw 0/1 sqlite booleans surfaced).
- `--dry-run` synthesizes the projected AFTER state from the would-be UPDATE values; non-dry-run re-reads the DB to verify the write.
- No-op when the row is already `investigating` + `quality_aborted=0`.
- Returns 2 on missing DB, 3 on missing run_id.

`tests/unit/tools/test_reset_quality_aborted.py` (11 cases):

- `TestDryRun` -- doesn't mutate; projected AFTER matches the would-be clean state (regression for the bug the operator caught).
- `TestApply` -- mutates correctly; AFTER reflects actual post-update read; resume hint emitted.
- `TestNoOp` -- already-clean state returns 0 with `nothing to do`.
- `TestErrorPaths` -- missing DB -> 2, missing run-id -> 3.
- `TestExplanations` -- pins `yes`/`no` instead of raw 0/1; pins `unset` phrase for None completed_at.

## Test plan

- [x] `poetry run pytest tests/unit/tools/test_reset_quality_aborted.py -v` -- 11/11 pass.
- [x] `poetry run ruff format . && poetry run ruff check .` -- clean.

Closes #383