### PR TITLE
fix(progress): StatusEmitter opens its own thread-local DB connection

### DIFF
--- a/src/gh_link_auditor/bulk_scan/progress.py
+++ b/src/gh_link_auditor/bulk_scan/progress.py
@@ -172,6 +172,11 @@ class StatusEmitter:
 
     Started by runner.run_full() at the top, stopped in the finally block.
     Re-entrant safe: stop() is idempotent.
+
+    The daemon thread opens its OWN ``UnifiedDatabase`` (#390 / #F3):
+    sqlite3 connections have ``check_same_thread=True`` by default, so
+    sharing the caller's connection would raise ``ProgrammingError`` on
+    every poll tick and silently lose every status line.
     """
 
     def __init__(
@@ -180,7 +185,21 @@ class StatusEmitter:
         run_id: str,
         interval_s: float = DEFAULT_INTERVAL_S,
         log: logging.Logger | None = None,
+        *,
+        db_path: str | None = None,
     ) -> None:
+        # Resolve the DB path now so the daemon thread can open its own
+        # connection. Fall back to the supplied db's ``_db_path`` for
+        # backwards compatibility with callers that don't pass db_path.
+        resolved_db_path = db_path or getattr(db, "_db_path", None)
+        if not resolved_db_path:
+            raise ValueError(
+                "StatusEmitter needs a db_path -- pass db_path explicitly or "
+                "ensure the supplied UnifiedDatabase exposes _db_path."
+            )
+        self._db_path: str = str(resolved_db_path)
+        # _db is retained for backwards-compat in case any external caller
+        # touches it, but is NOT used from the daemon thread.
         self._db = db
         self._run_id = run_id
         self._interval_s = interval_s
@@ -204,30 +223,39 @@ class StatusEmitter:
             self._thread.join(timeout=self._interval_s + 5.0)
 
     def _run(self) -> None:
-        # First emission shortly after start so the operator sees the line
-        # before having to wait a full interval.
-        first_wait = min(2.0, self._interval_s)
-        if self._stop.wait(first_wait):
-            return
-        while not self._stop.is_set():
-            try:
-                snap = snapshot(self._db, self._run_id)
-                if snap:
-                    now_mono = time.monotonic()
-                    counts = snap["counts"]
-                    self._stage1_window.append((now_mono, counts.get("inventoried", 0) + counts.get("error", 0)))
-                    self._findings_window.append((now_mono, snap["total_findings"]))
-                    pending3 = snap.get("inv_buckets", {}).get("pending", 0)
-                    self._stage3_window.append((now_mono, snap["total_findings"] - pending3))
-                    line = render(
-                        snap,
-                        self._stage1_window,
-                        self._findings_window,
-                        self._stage3_window,
-                        self._started_mono,
-                    )
-                    self._log.info(line)
-            except Exception as exc:  # noqa: BLE001
-                self._log.warning("status emitter poll error: %s", exc)
-            if self._stop.wait(self._interval_s):
+        # Open a thread-local UnifiedDatabase. The caller's db._conn cannot
+        # be used from this thread (sqlite3 ProgrammingError); see #390.
+        thread_db = UnifiedDatabase(self._db_path)
+        try:
+            # First emission shortly after start so the operator sees the
+            # line before having to wait a full interval.
+            first_wait = min(2.0, self._interval_s)
+            if self._stop.wait(first_wait):
                 return
+            while not self._stop.is_set():
+                try:
+                    snap = snapshot(thread_db, self._run_id)
+                    if snap:
+                        now_mono = time.monotonic()
+                        counts = snap["counts"]
+                        self._stage1_window.append((now_mono, counts.get("inventoried", 0) + counts.get("error", 0)))
+                        self._findings_window.append((now_mono, snap["total_findings"]))
+                        pending3 = snap.get("inv_buckets", {}).get("pending", 0)
+                        self._stage3_window.append((now_mono, snap["total_findings"] - pending3))
+                        line = render(
+                            snap,
+                            self._stage1_window,
+                            self._findings_window,
+                            self._stage3_window,
+                            self._started_mono,
+                        )
+                        self._log.info(line)
+                except Exception as exc:  # noqa: BLE001
+                    self._log.warning("status emitter poll error: %s", exc)
+                if self._stop.wait(self._interval_s):
+                    return
+        finally:
+            try:
+                thread_db.close()
+            except Exception:  # noqa: BLE001
+                pass

--- a/src/gh_link_auditor/bulk_scan/runner.py
+++ b/src/gh_link_auditor/bulk_scan/runner.py
@@ -455,7 +455,7 @@ def run_full(
             try:
                 from gh_link_auditor.bulk_scan.host_blocklist_telemetry import write_candidates_report
 
-                write_candidates_report(db, run_id, db_path=str(getattr(db, "_path", "")))
+                write_candidates_report(db, run_id, db_path=str(getattr(db, "_db_path", "")))
             except Exception as exc:  # noqa: BLE001
                 logger.warning("host-blocklist-telemetry failed (non-fatal): %s", exc)
 

--- a/tests/unit/bulk_scan/test_progress.py
+++ b/tests/unit/bulk_scan/test_progress.py
@@ -221,3 +221,117 @@ def test_eta_str_minutes_when_under_60min() -> None:
 def test_eta_str_hours_when_over_60min() -> None:
     # 6000 remaining at 10/min -> 600m -> 10.0h
     assert progress._eta_str(6000, 10.0) == "10.0h"
+
+
+# ---------------------------------------------------------------------------
+# StatusEmitter thread-local DB (#390)
+# ---------------------------------------------------------------------------
+
+
+class TestStatusEmitterThreadLocalDb:
+    """Pin the #390 fix: StatusEmitter must NOT share the caller's
+    sqlite3 connection across threads. Each daemon-thread invocation
+    opens its own UnifiedDatabase using the supplied db_path.
+    """
+
+    def test_init_resolves_db_path_from_unified_database(self, tmp_path):
+        """When constructed with a UnifiedDatabase, StatusEmitter reads
+        ``_db_path`` so it can re-open in the daemon thread."""
+        from gh_link_auditor.bulk_scan import storage
+        from gh_link_auditor.bulk_scan.progress import StatusEmitter
+        from gh_link_auditor.unified_db import UnifiedDatabase
+
+        db_path = tmp_path / "ghla.db"
+        with UnifiedDatabase(str(db_path)) as db:
+            storage.create_run(db, "r1", 100, {})
+            emitter = StatusEmitter(db, "r1", interval_s=0.1)
+
+        assert emitter._db_path == str(db_path)
+
+    def test_init_accepts_explicit_db_path(self, tmp_path):
+        """The explicit ``db_path`` kwarg overrides the supplied db's
+        attribute (useful when the caller has a fake db without
+        ``_db_path``)."""
+        from gh_link_auditor.bulk_scan import storage
+        from gh_link_auditor.bulk_scan.progress import StatusEmitter
+        from gh_link_auditor.unified_db import UnifiedDatabase
+
+        db_path = tmp_path / "ghla.db"
+        with UnifiedDatabase(str(db_path)) as db:
+            storage.create_run(db, "r1", 100, {})
+            emitter = StatusEmitter(db, "r1", interval_s=0.1, db_path="/custom/path/x.db")
+
+        assert emitter._db_path == "/custom/path/x.db"
+
+    def test_init_raises_without_resolvable_db_path(self):
+        """A fake db without ``_db_path`` and no explicit db_path kwarg
+        must fail at __init__ rather than crash inside the daemon
+        thread where the error would be swallowed by the existing
+        try/except."""
+        import pytest
+
+        from gh_link_auditor.bulk_scan.progress import StatusEmitter
+
+        class FakeDbNoPath:
+            pass
+
+        with pytest.raises(ValueError, match="db_path"):
+            StatusEmitter(FakeDbNoPath(), "r1", interval_s=0.1)
+
+    def test_daemon_thread_emits_status_line_without_sqlite_error(self, tmp_path, caplog):
+        """The load-bearing regression test for #390. With the buggy
+        shared-connection code, the daemon thread's snapshot() call
+        raised sqlite3.ProgrammingError (different thread) and the
+        WARNING handler caught it -- no INFO lines ever appeared.
+        After the fix, INFO lines do appear and no WARNINGs about
+        thread misuse fire."""
+        import logging
+
+        from gh_link_auditor.bulk_scan import storage
+        from gh_link_auditor.bulk_scan.progress import StatusEmitter
+        from gh_link_auditor.unified_db import UnifiedDatabase
+
+        db_path = tmp_path / "ghla.db"
+        with UnifiedDatabase(str(db_path)) as db:
+            storage.create_run(db, "r1", 100, {})
+
+            caplog.set_level(logging.INFO, logger="gh_link_auditor.bulk_scan.progress")
+            emitter = StatusEmitter(db, "r1", interval_s=0.5)
+            emitter.start()
+            try:
+                # Wait long enough for the first emission (first_wait = 2.0,
+                # but capped at interval_s=0.5) plus a buffer.
+                time.sleep(1.5)
+            finally:
+                emitter.stop()
+
+        records = caplog.records
+        # No ProgrammingError-style warnings.
+        for r in records:
+            assert "objects created in a thread can only be used" not in r.getMessage(), (
+                f"daemon thread still sharing main-thread connection: {r.getMessage()}"
+            )
+        # At least one INFO line emitted (the status line).
+        info_lines = [r.getMessage() for r in records if r.levelno == logging.INFO]
+        assert info_lines, "StatusEmitter produced no INFO status lines"
+        assert any("stage" in line for line in info_lines), info_lines
+
+    def test_thread_local_db_is_closed_on_stop(self, tmp_path):
+        """The daemon thread should close its UnifiedDatabase when the
+        thread exits so the WAL file gets a chance to checkpoint and
+        the connection isn't leaked."""
+        from gh_link_auditor.bulk_scan import storage
+        from gh_link_auditor.bulk_scan.progress import StatusEmitter
+        from gh_link_auditor.unified_db import UnifiedDatabase
+
+        db_path = tmp_path / "ghla.db"
+        with UnifiedDatabase(str(db_path)) as db:
+            storage.create_run(db, "r1", 100, {})
+            emitter = StatusEmitter(db, "r1", interval_s=0.5)
+            emitter.start()
+            time.sleep(1.2)
+            emitter.stop()
+            # If the thread leaked its connection, the file would still
+            # be locked. The outer `with` close will catch leaks via
+            # exception on Windows.
+        # If we got here without exception, the thread cleaned up.


### PR DESCRIPTION
## Summary

The 2026-05-26 13:10 resume logged `SQLite objects created in a thread can only be used in that same thread` on every status tick. Root cause: sqlite3 connections default to `check_same_thread=True`, and `StatusEmitter` daemon thread was calling `snapshot()` against the main thread's `UnifiedDatabase`. Every poll raised `ProgrammingError`, the existing try/except caught it as WARNING, and zero status lines made it out during a multi-minute run.

Same class as `#F3` in `data/regression-audit-2026-05-26.md`: DB writes (and here, reads) must use a thread-local connection.

## What changes

- `StatusEmitter.__init__` resolves a `db_path` (explicit kwarg first, then the supplied db's `_db_path` attr). Raises `ValueError` if neither is available -- surfaces misconfiguration at construction, not inside the daemon thread where the existing try/except would swallow it.
- `_run` opens a thread-local `UnifiedDatabase` from `db_path`, uses that for all `snapshot()` reads, closes it in `finally`.
- Also fixes a pre-existing typo at `runner.run_full:458` -- `getattr(db, "_path", "")` was returning empty string because the actual attribute is `_db_path`. The host-blocklist-candidates report header was silently misconfigured.

## Test plan

- [x] `tests/unit/bulk_scan/test_progress.py::TestStatusEmitterThreadLocalDb` -- 5 cases, including the load-bearing regression test that pins "daemon thread emits an INFO status line with no thread-misuse WARNING".
- [x] Full suite: 2585 passed, 1 skipped.
- [x] `poetry run ruff format . && poetry run ruff check .` -- clean.

Closes #390