### PR TITLE
fix(tools): reset_quality_aborted uses status='checking' + recovers findings

### DIFF
--- a/tests/unit/tools/test_reset_quality_aborted.py
+++ b/tests/unit/tools/test_reset_quality_aborted.py
@@ -2,8 +2,9 @@
 
 The script is an operational recovery helper that mutates a local
 SQLite DB. These tests exercise it against a tmp_path DB seeded with
-the bulk_scan_runs schema, so the agent (or anyone else) can validate
-output and behavior without touching the operator's real ~/.ghla/ghla.db.
+the bulk_scan_runs / bulk_scan_findings / url_check_cache schema, so
+the agent (or anyone else) can validate output and behavior without
+touching the operator's real ghla.db.
 """
 
 from __future__ import annotations
@@ -23,10 +24,43 @@ def _load_script_module():
     spec = importlib.util.spec_from_file_location("reset_quality_aborted_under_test", _SCRIPT_PATH)
     assert spec is not None
     module = importlib.util.module_from_spec(spec)
-    # Avoid polluting sys.modules permanently across test sessions.
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _init_schema(con: sqlite3.Connection) -> None:
+    """Create the narrow schema the script reads/writes."""
+    con.execute(
+        """
+        CREATE TABLE bulk_scan_runs (
+            run_id TEXT PRIMARY KEY,
+            status TEXT,
+            quality_aborted INTEGER,
+            completed_at TEXT
+        )
+        """
+    )
+    con.execute(
+        """
+        CREATE TABLE bulk_scan_findings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            dead_url TEXT NOT NULL,
+            method TEXT NOT NULL DEFAULT 'pending',
+            investigation_state TEXT NOT NULL DEFAULT 'pending',
+            investigation_completed_at TEXT
+        )
+        """
+    )
+    con.execute(
+        """
+        CREATE TABLE url_check_cache (
+            url TEXT PRIMARY KEY,
+            http_status INTEGER
+        )
+        """
+    )
 
 
 def _seed_run(
@@ -37,25 +71,40 @@ def _seed_run(
     quality_aborted: int = 1,
     completed_at: str | None = "2026-05-26T05:31:09.021709+00:00",
 ) -> None:
-    """Create a minimal bulk_scan_runs row matching the production schema
-    fields the script touches. The script only references status,
-    quality_aborted, and completed_at, so we keep the fixture narrow."""
+    """Create the schema + a run row."""
     con = sqlite3.connect(str(db_path))
     try:
-        con.execute(
-            """
-            CREATE TABLE bulk_scan_runs (
-                run_id TEXT PRIMARY KEY,
-                status TEXT,
-                quality_aborted INTEGER,
-                completed_at TEXT
-            )
-            """
-        )
+        _init_schema(con)
         con.execute(
             "INSERT INTO bulk_scan_runs (run_id, status, quality_aborted, completed_at) VALUES (?, ?, ?, ?)",
             (run_id, status, quality_aborted, completed_at),
         )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _add_finding(
+    db_path: Path,
+    *,
+    run_id: str,
+    dead_url: str,
+    investigation_state: str,
+    cache_http_status: int | None,
+) -> None:
+    """Add a Stage 1 placeholder finding plus its url_check_cache row."""
+    con = sqlite3.connect(str(db_path))
+    try:
+        con.execute(
+            "INSERT INTO bulk_scan_findings (run_id, dead_url, method, investigation_state) "
+            "VALUES (?, ?, 'pending', ?)",
+            (run_id, dead_url, investigation_state),
+        )
+        if cache_http_status is not None or True:  # always insert a cache row; status may be None
+            con.execute(
+                "INSERT OR REPLACE INTO url_check_cache (url, http_status) VALUES (?, ?)",
+                (dead_url, cache_http_status),
+            )
         con.commit()
     finally:
         con.close()
@@ -74,11 +123,24 @@ def _read_row(db_path: Path, run_id: str) -> dict | None:
         con.close()
 
 
+def _read_finding_state(db_path: Path, dead_url: str) -> str | None:
+    con = sqlite3.connect(str(db_path))
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute(
+            "SELECT investigation_state FROM bulk_scan_findings WHERE dead_url = ?",
+            (dead_url,),
+        ).fetchone()
+        return row["investigation_state"] if row else None
+    finally:
+        con.close()
+
+
 # --- dry-run ---------------------------------------------------------------
 
 
 class TestDryRun:
-    def test_does_not_mutate_db(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_does_not_mutate_db(self, tmp_path: Path) -> None:
         db_path = tmp_path / "ghla.db"
         _seed_run(db_path)
 
@@ -86,18 +148,15 @@ class TestDryRun:
         rc = module.main(["--db-path", str(db_path), "--dry-run"])
 
         assert rc == 0
-        # DB unchanged
         row = _read_row(db_path, "bulk-20260526T031148Z")
         assert row is not None
         assert row["status"] == "quality_aborted"
         assert row["quality_aborted"] == 1
-        assert row["completed_at"] == "2026-05-26T05:31:09.021709+00:00"
 
-    def test_shows_projected_clean_state(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-        """Regression test for the bug the operator caught: dry-run was
-        re-reading the unchanged row, so the AFTER block showed the same
-        values as BEFORE. AFTER must reflect the PROJECTED post-update
-        state, not a re-read of the still-aborted row."""
+    def test_shows_projected_checking_state(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """Regression for the 2026-05-26 bug: the projected post-reset
+        state must be 'checking' (NOT 'investigating', which skips
+        Stage 2). See #392 / audit lesson 2026-05-22."""
         db_path = tmp_path / "ghla.db"
         _seed_run(db_path)
 
@@ -107,40 +166,42 @@ class TestDryRun:
 
         assert "BEFORE:" in out
         assert "AFTER (projected; not written):" in out
+        after_block = out[out.index("AFTER (projected; not written):") :]
+        assert "checking" in after_block
+        # And the cautionary explanation against 'investigating' must
+        # NOT appear in the AFTER block (only in BEFORE if a stale run
+        # had it -- but our seed has 'quality_aborted', so it shouldn't
+        # appear at all here).
+        assert "Always reset to 'checking'" not in after_block
 
-        # Split into BEFORE / AFTER sections so we can pin each separately.
-        before_idx = out.index("BEFORE:")
-        after_idx = out.index("AFTER (projected; not written):")
-        before_block = out[before_idx:after_idx]
-        after_block = out[after_idx:]
-
-        # BEFORE must show the aborted state.
-        assert "quality_aborted" in before_block
-        assert "yes" in before_block
-        assert "2026-05-26T05:31:09" in before_block
-
-        # AFTER must show the clean state -- this is the bug the operator
-        # found: previously the AFTER block matched BEFORE.
-        assert "investigating" in after_block
-        assert "no   --" in after_block
-        assert "2026-05-26T05:31:09" not in after_block, "AFTER must not show the old completed_at"
-        assert "unset" in after_block
-
-    def test_prints_followup_hint(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_dry_run_does_not_recover_findings(self, tmp_path: Path) -> None:
+        """Even with mis-stamped findings present, --dry-run must not
+        flip them. The fix is computed; verifying happens after apply."""
         db_path = tmp_path / "ghla.db"
         _seed_run(db_path)
+        _add_finding(
+            db_path,
+            run_id="bulk-20260526T031148Z",
+            dead_url="https://dead.example/x",
+            investigation_state="skipped_alive",
+            cache_http_status=404,
+        )
 
         module = _load_script_module()
         module.main(["--db-path", str(db_path), "--dry-run"])
-        out = capsys.readouterr().out
-        assert "re-run without --dry-run to apply" in out
+
+        # Finding still mis-stamped (no write happened).
+        assert _read_finding_state(db_path, "https://dead.example/x") == "skipped_alive"
 
 
 # --- apply -----------------------------------------------------------------
 
 
 class TestApply:
-    def test_mutates_db(self, tmp_path: Path) -> None:
+    def test_sets_status_to_checking_not_investigating(self, tmp_path: Path) -> None:
+        """The load-bearing regression: post-reset status must be
+        'checking', never 'investigating'. The bug that broke the
+        2026-05-26 scan was the script setting 'investigating'."""
         db_path = tmp_path / "ghla.db"
         _seed_run(db_path)
 
@@ -150,27 +211,101 @@ class TestApply:
 
         row = _read_row(db_path, "bulk-20260526T031148Z")
         assert row is not None
-        assert row["status"] == "investigating"
+        assert row["status"] == "checking", (
+            "Post-reset status MUST be 'checking'. 'investigating' skips Stage 2 and "
+            "mis-classifies findings as alive -- see audit lesson 2026-05-22 / #392."
+        )
         assert row["quality_aborted"] == 0
         assert row["completed_at"] is None
 
-    def test_after_block_shows_actual_db_state(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-        """When applying, AFTER reflects the post-UPDATE DB read, not a
-        synthesized projection. Pins that distinction so a refactor can't
-        accidentally drop the verify step."""
+    def test_recovers_mis_stamped_finding(self, tmp_path: Path) -> None:
+        """A finding with state='skipped_alive' but cache says NOT alive
+        (404) must be flipped back to 'pending'."""
         db_path = tmp_path / "ghla.db"
         _seed_run(db_path)
+        _add_finding(
+            db_path,
+            run_id="bulk-20260526T031148Z",
+            dead_url="https://dead.example/x",
+            investigation_state="skipped_alive",
+            cache_http_status=404,
+        )
+
+        module = _load_script_module()
+        module.main(["--db-path", str(db_path)])
+
+        assert _read_finding_state(db_path, "https://dead.example/x") == "pending"
+
+    def test_legitimately_alive_finding_stays_skipped(self, tmp_path: Path) -> None:
+        """A finding with state='skipped_alive' AND cache says alive (200)
+        must NOT be touched. It's legitimately alive; Stage 3 was right
+        to skip it."""
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path)
+        _add_finding(
+            db_path,
+            run_id="bulk-20260526T031148Z",
+            dead_url="https://alive.example/x",
+            investigation_state="skipped_alive",
+            cache_http_status=200,
+        )
+
+        module = _load_script_module()
+        module.main(["--db-path", str(db_path)])
+
+        assert _read_finding_state(db_path, "https://alive.example/x") == "skipped_alive"
+
+    def test_recovers_finding_with_no_cache_entry(self, tmp_path: Path) -> None:
+        """A skipped_alive finding whose dead_url has no url_check_cache
+        entry at all (e.g. cache was cleared) must be treated as
+        not-confirmed-alive and flipped to pending."""
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path)
+        # Insert finding but no cache row
+        con = sqlite3.connect(str(db_path))
+        try:
+            con.execute(
+                "INSERT INTO bulk_scan_findings (run_id, dead_url, method, investigation_state) "
+                "VALUES (?, ?, 'pending', 'skipped_alive')",
+                ("bulk-20260526T031148Z", "https://no-cache.example/x"),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+        module = _load_script_module()
+        module.main(["--db-path", str(db_path)])
+
+        assert _read_finding_state(db_path, "https://no-cache.example/x") == "pending"
+
+    def test_recovery_count_in_output(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """AFTER block must show how many findings were recovered."""
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path)
+        for i in range(3):
+            _add_finding(
+                db_path,
+                run_id="bulk-20260526T031148Z",
+                dead_url=f"https://dead{i}.example/x",
+                investigation_state="skipped_alive",
+                cache_http_status=404,
+            )
+        # And one legit alive
+        _add_finding(
+            db_path,
+            run_id="bulk-20260526T031148Z",
+            dead_url="https://alive.example/x",
+            investigation_state="skipped_alive",
+            cache_http_status=200,
+        )
 
         module = _load_script_module()
         module.main(["--db-path", str(db_path)])
         out = capsys.readouterr().out
 
-        # Header must be the non-dry-run variant.
-        assert "AFTER:" in out
-        assert "AFTER (projected; not written):" not in out
-
-        # And the resume hint must appear.
-        assert "bulk-scan start --run-id bulk-20260526T031148Z" in out
+        after_block = out[out.index("AFTER:") :]
+        assert "recovered:        3" in after_block
+        assert "mis-stamped:      0" in after_block  # all the bad ones recovered
 
     def test_emits_resume_command(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         db_path = tmp_path / "ghla.db"
@@ -186,11 +321,11 @@ class TestApply:
 
 
 class TestNoOp:
-    def test_returns_zero_and_does_not_mutate_when_already_clean(
+    def test_returns_zero_when_run_clean_and_no_mis_stamped(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         db_path = tmp_path / "ghla.db"
-        _seed_run(db_path, status="investigating", quality_aborted=0, completed_at=None)
+        _seed_run(db_path, status="checking", quality_aborted=0, completed_at=None)
 
         module = _load_script_module()
         rc = module.main(["--db-path", str(db_path)])
@@ -198,24 +333,38 @@ class TestNoOp:
         out = capsys.readouterr().out
         assert "nothing to do" in out
 
-        # Still the same row.
-        row = _read_row(db_path, "bulk-20260526T031148Z")
-        assert row is not None
-        assert row["status"] == "investigating"
+    def test_runs_when_clean_run_status_but_mis_stamped_findings_present(self, tmp_path: Path) -> None:
+        """If the run row is already at 'checking'/quality_aborted=0 but
+        there are mis-stamped findings, the script MUST still recover
+        them. 'Clean' is the conjunction of run state AND finding state."""
+        db_path = tmp_path / "ghla.db"
+        _seed_run(db_path, status="checking", quality_aborted=0, completed_at=None)
+        _add_finding(
+            db_path,
+            run_id="bulk-20260526T031148Z",
+            dead_url="https://dead.example/x",
+            investigation_state="skipped_alive",
+            cache_http_status=404,
+        )
+
+        module = _load_script_module()
+        rc = module.main(["--db-path", str(db_path)])
+        assert rc == 0
+        assert _read_finding_state(db_path, "https://dead.example/x") == "pending"
 
 
 # --- errors ----------------------------------------------------------------
 
 
 class TestErrorPaths:
-    def test_missing_db_returns_2(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_missing_db_returns_2(self, tmp_path: Path) -> None:
         db_path = tmp_path / "missing.db"
 
         module = _load_script_module()
         rc = module.main(["--db-path", str(db_path)])
         assert rc == 2
 
-    def test_missing_run_id_returns_3(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_missing_run_id_returns_3(self, tmp_path: Path) -> None:
         db_path = tmp_path / "ghla.db"
         _seed_run(db_path, run_id="someone-elses-run")
 
@@ -228,9 +377,6 @@ class TestErrorPaths:
 
 
 class TestExplanations:
-    """Pin the human-readable explanation strings the operator asked for
-    (no raw 0/1 sqlite booleans in the output)."""
-
     def test_quality_aborted_shows_yes_not_1(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         db_path = tmp_path / "ghla.db"
         _seed_run(db_path)
@@ -239,11 +385,9 @@ class TestExplanations:
         module.main(["--db-path", str(db_path), "--dry-run"])
         out = capsys.readouterr().out
 
-        # BEFORE half must contain 'yes' (the human form), not raw 1.
         before_section = out[out.index("BEFORE:") : out.index("AFTER")]
         assert "yes" in before_section
         assert "quality_aborted:  1\n" not in before_section
-        assert "quality_aborted:  0\n" not in before_section
 
     def test_completed_at_unset_uses_human_phrase(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         db_path = tmp_path / "ghla.db"
@@ -254,5 +398,4 @@ class TestExplanations:
         out = capsys.readouterr().out
         after_section = out[out.index("AFTER") :]
         assert "unset" in after_section
-        # Should NOT show the literal string "None" instead of the explanation
         assert "completed_at:     None" not in after_section

--- a/tools/reset_quality_aborted.py
+++ b/tools/reset_quality_aborted.py
@@ -1,9 +1,22 @@
-"""Reset a bulk-scan run from quality_aborted back to investigating.
+"""Reset a bulk-scan run from quality_aborted back to checking.
 
 Operational recovery for runs that the (now-permanently-disabled, #362)
 quality stop-loss killed mid-flight. The run's url_check_cache and
-findings rows are intact; only the run-level status needs to flip so
-`bulk-scan start --run-id <id>` resumes from Stage 3 instead of refusing.
+findings rows are intact; flipping the run-level status to ``'checking'``
+lets ``bulk-scan start --run-id <id>`` resume cleanly through Stage 2's
+cache lookup and into Stage 3 with a populated liveness_results dict.
+
+Why 'checking' and NOT 'investigating': audit lesson 2026-05-22 (R6 /
+LLD-244) -- resetting to 'investigating' skips Stage 2 entirely, so
+Stage 3 sees an empty liveness_results, and `runner.py:307-313`'s "URL
+is alive" branch fires on every pending finding. The 2026-05-26 13:10
+incident saw 22,863 findings stamped 'skipped_alive' in 48 seconds for
+exactly this reason.
+
+This script also recovers findings whose ``investigation_state`` is
+'skipped_alive' but whose ``url_check_cache.http_status`` is NULL or
+>= 400 -- those were mis-stamped by an earlier bad reset and need to
+go back to 'pending' so Stage 3 can investigate them.
 
 Why a script instead of a one-liner: PowerShell quoting around sqlite3
 + embedded SQL is genuinely fragile. This removes the quoting risk and
@@ -27,18 +40,24 @@ from pathlib import Path
 
 DEFAULT_RUN_ID = "bulk-20260526T031148Z"
 DEFAULT_DB_PATH = Path.home() / ".ghla" / "ghla.db"
+RESET_TARGET_STATUS = "checking"
 
 
 def _explain_status(status: str | None) -> str:
     if status == "quality_aborted":
         return "quality_aborted  -- scan was killed mid-flight; will NOT resume in this state"
+    if status == "checking":
+        return "checking         -- Stage 2 ready; 'bulk-scan start --run-id' will resume here"
     if status == "investigating":
-        return "investigating    -- Stage 3 ready; 'bulk-scan start --run-id' will resume here"
+        return (
+            "investigating    -- Stage 3 ready in theory, BUT this state skips Stage 2 and "
+            "mis-classifies pending findings as alive (#392). Always reset to 'checking' instead."
+        )
     if status == "aborted":
         return "aborted          -- operator stopped the scan; resumable"
     if status == "done":
         return "done             -- scan completed normally"
-    if status in {"selecting", "inventorying", "checking", "scoring"}:
+    if status in {"selecting", "inventorying", "scoring"}:
         return f"{status:16s} -- mid-stage; intentional reset is unusual"
     return f"{status!r}"
 
@@ -55,6 +74,52 @@ def _explain_completed_at(v: str | None) -> str:
     if v is None:
         return "(unset; the scan has not finished, which is what we want for resume)"
     return f"{v}  -- stamped when the scan exited; must be cleared to resume"
+
+
+def _count_mis_stamped(con: sqlite3.Connection, run_id: str) -> int:
+    """Count findings whose investigation_state is 'skipped_alive' but
+    whose url_check_cache entry contradicts that (no cache OR status >= 400).
+
+    These are the rows that an earlier bad reset to 'investigating'
+    incorrectly stamped. They need to go back to 'pending' so Stage 3
+    can investigate them."""
+    row = con.execute(
+        """
+        SELECT COUNT(*) AS n
+        FROM bulk_scan_findings bsf
+        LEFT JOIN url_check_cache ucc ON ucc.url = bsf.dead_url
+        WHERE bsf.run_id = ?
+          AND bsf.method = 'pending'
+          AND bsf.investigation_state = 'skipped_alive'
+          AND (ucc.http_status IS NULL OR ucc.http_status >= 400)
+        """,
+        (run_id,),
+    ).fetchone()
+    return int(row["n"])
+
+
+def _recover_mis_stamped(con: sqlite3.Connection, run_id: str) -> int:
+    """Flip mis-stamped 'skipped_alive' findings back to 'pending'.
+    Returns the number of rows affected."""
+    cur = con.execute(
+        """
+        UPDATE bulk_scan_findings
+        SET investigation_state = 'pending',
+            investigation_completed_at = NULL
+        WHERE run_id = ?
+          AND method = 'pending'
+          AND investigation_state = 'skipped_alive'
+          AND dead_url IN (
+              SELECT bsf2.dead_url
+              FROM bulk_scan_findings bsf2
+              LEFT JOIN url_check_cache ucc ON ucc.url = bsf2.dead_url
+              WHERE bsf2.run_id = ?
+                AND (ucc.http_status IS NULL OR ucc.http_status >= 400)
+          )
+        """,
+        (run_id, run_id),
+    )
+    return cur.rowcount
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -95,6 +160,8 @@ def main(argv: list[str] | None = None) -> int:
             sys.stderr.write(f"run not found: {args.run_id!r}\n")
             return 3
 
+        mis_stamped_before = _count_mis_stamped(con, args.run_id)
+
         print(f"run_id:  {args.run_id}")
         print(f"db:      {db_path}")
         print()
@@ -102,22 +169,33 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  status:           {_explain_status(row['status'])}")
         print(f"  quality_aborted:  {_explain_quality_aborted(row['quality_aborted'])}")
         print(f"  completed_at:     {_explain_completed_at(row['completed_at'])}")
+        print(
+            f"  mis-stamped:      {mis_stamped_before:,}  -- findings marked 'skipped_alive' "
+            "but cache says NOT alive; need to go back to 'pending'"
+        )
 
-        already_clean = row["status"] == "investigating" and not row["quality_aborted"]
+        run_status_clean = row["status"] == RESET_TARGET_STATUS and not row["quality_aborted"]
+        already_clean = run_status_clean and mis_stamped_before == 0
         if already_clean:
             print()
-            print("nothing to do -- the run is already in 'investigating' with quality_aborted=0.")
+            print(
+                f"nothing to do -- the run is already at '{RESET_TARGET_STATUS}', "
+                "quality_aborted=0, and no mis-stamped findings."
+            )
             return 0
 
         if args.dry_run:
-            after_status: str | None = "investigating"
+            after_status: str | None = RESET_TARGET_STATUS
             after_qa: int | None = 0
             after_completed_at: str | None = None
+            after_mis_stamped = 0
+            recovered_count = mis_stamped_before
         else:
             con.execute(
                 "UPDATE bulk_scan_runs SET status = ?, quality_aborted = ?, completed_at = ? WHERE run_id = ?",
-                ("investigating", 0, None, args.run_id),
+                (RESET_TARGET_STATUS, 0, None, args.run_id),
             )
+            recovered_count = _recover_mis_stamped(con, args.run_id)
             con.commit()
             verified = con.execute(
                 "SELECT status, quality_aborted, completed_at FROM bulk_scan_runs WHERE run_id = ?",
@@ -126,12 +204,18 @@ def main(argv: list[str] | None = None) -> int:
             after_status = verified["status"]
             after_qa = verified["quality_aborted"]
             after_completed_at = verified["completed_at"]
+            after_mis_stamped = _count_mis_stamped(con, args.run_id)
 
         print()
         print("AFTER (projected; not written):" if args.dry_run else "AFTER:")
         print(f"  status:           {_explain_status(after_status)}")
         print(f"  quality_aborted:  {_explain_quality_aborted(after_qa)}")
         print(f"  completed_at:     {_explain_completed_at(after_completed_at)}")
+        print(f"  mis-stamped:      {after_mis_stamped:,}  -- remaining after recovery")
+        print(
+            f"  recovered:        {recovered_count:,}  -- findings flipped from 'skipped_alive' "
+            "back to 'pending' for re-investigation"
+        )
 
         if args.dry_run:
             print()


### PR DESCRIPTION
## Summary

The 2026-05-26 13:10 resume failed catastrophically because this script defaulted to `status='investigating'`. Per audit lesson 2026-05-22 (R6 / LLD-244), `'investigating'` skips Stage 2, so `run_investigation` sees an empty `liveness_results` dict, and `runner.py:307-313`'s "URL is alive" branch fires on every pending finding. **22,863 findings got stamped `skipped_alive` in 48 seconds**; the run finished `done` with zero investigations.

## What changes

1. **Default reset target is now `'checking'`** (not `'investigating'`). With the run at `'checking'`, `bulk-scan start` re-runs Stage 2's cache lookup -- cheap (no probes for already-cached URLs) and populates `liveness_results` for Stage 3.

2. **Also recovers findings** whose `investigation_state='skipped_alive'` but whose `url_check_cache.http_status` is NULL or >= 400. Those were mis-stamped by an earlier bad reset; flipping them to `'pending'` lets Stage 3 investigate them properly. Findings whose cache says alive (200-399) STAY `skipped_alive` -- legitimate skips are not touched.

3. **BEFORE / AFTER blocks** now include `mis-stamped` and `recovered` counts so the operator sees both pieces of the fix.

4. The status explanation for `'investigating'` was updated to flag the trap (so anyone reading a BEFORE block where this somehow appears sees the reason in human terms).

## Test plan

15 tests total. Load-bearing ones:

- `test_sets_status_to_checking_not_investigating` -- regression for the 2026-05-26 catastrophe.
- `test_recovers_mis_stamped_finding` -- 404-cached row flips back to pending.
- `test_legitimately_alive_finding_stays_skipped` -- 200-cached row stays skipped (no over-recovery).
- `test_recovers_finding_with_no_cache_entry` -- NULL-cache row flips back.
- `test_recovery_count_in_output` -- AFTER block shows the count.
- `test_runs_when_clean_run_status_but_mis_stamped_findings_present` -- "clean" requires both run state AND finding state.

Plus existing dry-run / error-path / explanation tests updated to assert `'checking'`.

- [x] `poetry run pytest tests/unit/tools/test_reset_quality_aborted.py -v` -- 15/15 pass.
- [x] Full suite: 2589 passed, 1 skipped.
- [x] `poetry run ruff format . && poetry run ruff check .` -- clean.

## Recovery for the 2026-05-26 run

After this PR merges, running `poetry run python tools/reset_quality_aborted.py` against `bulk-20260526T031148Z` will: flip the 2,417 mis-stamped findings back to `pending`, set the run to `'checking'`, and let `bulk-scan start --run-id` resume cleanly. The 24,644 truly-alive findings stay `skipped_alive`.

Closes #392