### PR TITLE
feat(security): least-priv campaign PAT + single decrypt

### DIFF
--- a/docs/lld/active/LLD-397-398.md
+++ b/docs/lld/active/LLD-397-398.md
@@ -1,0 +1,190 @@
+# LLD-397-398: least-privilege campaign PAT + single classic-PAT session per submission
+
+**Issues:** #397, #398
+**Status:** Active
+**Companion ADR update:** martymcenroe/AssemblyZero#1344
+
+## 1. Problem
+
+The campaign's fork-and-PR flow (`src/gh_link_auditor/pipeline/nodes/n6_submit_pr.py`) has two coupled defects, both surfaced by the 2026-05-26 OasisLMF/OasisLMF submission:
+
+1. **Wrong credential.** It decrypts the **admin-scope** classic PAT at `~/.secrets/classic-pat.gpg` even though it only needs `public_repo`. A leak of that token gives an attacker admin authority across the entire `martymcenroe/*` fleet (branch protection on AssemblyZero, Talos, Aletheia), not just "spam noise on public repos." Violates the Principle of Least Privilege (Saltzer & Schroeder, 1975).
+2. **Double decrypt.** `_fork_repo` (line 85) and `_create_pr` (line 124) each open their own `with classic_pat_session() as pat:` block. gpg-agent TTL is 0 per ADR-0216, so each block re-prompts pinentry. Operator types passphrase twice per submission. Worse, because Python strings are immutable and `del pat` does NOT zero bytes (per `_pat_session.py:14-18`), each `with` block leaves a fresh PAT-byte copy in heap floating for GC — two blocks means two copies. Fewer `with` blocks is *safer*, not less safe.
+
+Both issues are independent but their fixes touch the same two files, share the same operator validation step (a real PR submission with the new flow), and have no value separately. Ship together as one PR.
+
+## 2. Solution
+
+**Add a second encrypted PAT** scoped to `public_repo` only, at `~/.secrets/link-auditor-pat.gpg`. Add a new shim `link_auditor_pat_session()` in `src/gh_link_auditor/classic_pat.py` that wraps the existing parameterized `_pat_session.classic_pat_session(pat_path=...)` (already pat_path-aware at `AssemblyZero/tools/_pat_session.py:67`).
+
+**Refactor `n6_submit_pr`** to open exactly one `with link_auditor_pat_session() as pat:` block per submission, wrapping the fork-API call, the gh-CLI clone/edit/push work, and the PR-API call. The two private helpers `_fork_repo` and `_create_pr` accept the decrypted `pat` as a parameter and use it in the `Authorization: Bearer` header.
+
+The admin-scope `classic_pat_session()` shim is **removed** from `src/gh_link_auditor/classic_pat.py` — no consumers remain in `src/` after the refactor. The `tools/` scripts (`add_test_workflow.py`, `file_python_guide_numpy_pr.py`) keep importing AssemblyZero's `_pat_session.classic_pat_session` directly; they need elevated scope for their one-shot operations (workflow files, etc.) and are out of scope for this LLD.
+
+## 3. Design
+
+### 3.1 New constant + shim in `src/gh_link_auditor/classic_pat.py`
+
+```python
+LINK_AUDITOR_PAT_PATH = Path.home() / ".secrets" / "link-auditor-pat.gpg"
+
+@contextmanager
+def link_auditor_pat_session() -> Iterator[str]:
+    """Yield the gpg-decrypted campaign-scoped PAT (public_repo only).
+
+    Replaces the admin-scope classic_pat_session for the campaign's
+    fork-and-PR flow. Same shim/dynamic-import pattern as before;
+    only the underlying file path differs.
+
+    Raises:
+        RuntimeError: If AssemblyZero is unavailable.
+        FileNotFoundError: From _pat_session if the encrypted file is missing.
+            Message includes the gpg-encrypt one-time setup command.
+    """
+    if not ASSEMBLYZERO_TOOLS.exists():
+        raise RuntimeError(
+            f"Campaign PAT requires AssemblyZero at {ASSEMBLYZERO_TOOLS}. "
+            f"See LLD-397-398 and AZ#1344 for the least-privilege PAT pattern."
+        )
+    if str(ASSEMBLYZERO_TOOLS) not in sys.path:
+        sys.path.insert(0, str(ASSEMBLYZERO_TOOLS))
+    from _pat_session import classic_pat_session as _real_session  # noqa: E402
+    with _real_session(pat_path=LINK_AUDITOR_PAT_PATH) as pat:
+        yield pat
+```
+
+### 3.2 Removed: `classic_pat_session` from gh_link_auditor
+
+No callers remain in `src/`. Tests update their mock target from `gh_link_auditor.classic_pat.classic_pat_session` to `gh_link_auditor.pipeline.nodes.n6_submit_pr.link_auditor_pat_session` (mocking at the import site, per existing pattern).
+
+### 3.3 Refactored `n6_submit_pr.py`
+
+**Helper signatures change to accept `pat`:**
+
+```python
+def _fork_repo(owner: str, repo: str, pat: str) -> str:
+    """Fork via REST. No internal context manager — caller holds the PAT."""
+    r = httpx.post(
+        f"{_GH_API}/repos/{owner}/{repo}/forks",
+        headers={**_GH_API_HEADERS_BASE, "Authorization": f"Bearer {pat}"},
+        timeout=_GH_API_TIMEOUT_S,
+    )
+    if r.status_code >= 400:
+        raise RuntimeError(...)
+    return r.json()["full_name"]
+
+
+def _create_pr(
+    upstream_owner: str,
+    upstream_repo: str,
+    head: str,
+    base: str,
+    title: str,
+    body: str,
+    pat: str,
+) -> tuple[str, int]:
+    """Open cross-fork PR. No internal context manager — caller holds the PAT."""
+    r = httpx.post(
+        f"{_GH_API}/repos/{upstream_owner}/{upstream_repo}/pulls",
+        json={"title": title, "head": head, "base": base, "body": body},
+        headers={**_GH_API_HEADERS_BASE, "Authorization": f"Bearer {pat}"},
+        timeout=_GH_API_TIMEOUT_S,
+    )
+    if r.status_code >= 400:
+        raise RuntimeError(...)
+    data = r.json()
+    return data["html_url"], data["number"]
+```
+
+**`n6_submit_pr` opens the session once:**
+
+```python
+def n6_submit_pr(state):
+    ...
+    try:
+        with link_auditor_pat_session() as pat:
+            # Step 1: Fork (uses pat)
+            fork_full_name = _fork_repo(repo_owner, repo_name_short, pat)
+            logger.info("N6: Fork ready: %s", fork_full_name)
+
+            with tempfile.TemporaryDirectory(prefix="ghla-pr-") as tmp_dir:
+                work_dir = Path(tmp_dir)
+                # Steps 2-5: clone, apply fixes, commit, push (gh CLI — does NOT use pat)
+                ...
+
+                # Step 6: Create PR (uses pat)
+                pr_url, pr_number = _create_pr(
+                    repo_owner, repo_name_short, head, base, title, body, pat,
+                )
+    except ...:
+        ...
+```
+
+The `pat` parameter is in scope from fork through PR-create. Heap residency: ~3-10s typical (the clone + apply + commit + push window). Within the operating-scope bounds established by ADR-0216 ("primary protection is process scope") — no new threat model.
+
+### 3.4 Trade-off, surfaced honestly
+
+The campaign PAT lives in heap for the duration of the `with` block (~3-10s) instead of two briefer windows (sub-second each). Both still defeated by Python's lack of secure-memory primitives: the bytes persist until GC regardless. Single-block is strictly better — one immutable string copy floating for GC instead of two.
+
+## 4. Tests
+
+### 4.1 New (`tests/unit/test_classic_pat.py`)
+
+- `test_link_auditor_pat_path_constant_value`: `LINK_AUDITOR_PAT_PATH` equals `Path.home() / ".secrets" / "link-auditor-pat.gpg"`.
+- `test_link_auditor_pat_session_is_context_manager`: callable, returns a context manager.
+- `test_link_auditor_pat_session_yields_token_when_underlying_succeeds`: with `_pat_session.classic_pat_session` mocked to yield "ghp_fake_campaign", `link_auditor_pat_session()` yields the same.
+- `test_link_auditor_pat_session_passes_pat_path_to_underlying`: assert the underlying `_real_session` is invoked with `pat_path=LINK_AUDITOR_PAT_PATH`.
+- `test_link_auditor_pat_session_propagates_filenotfound`: if the encrypted file is missing, the underlying `FileNotFoundError` propagates.
+- `test_link_auditor_pat_session_propagates_runtime_error_if_assemblyzero_missing`: simulate `ASSEMBLYZERO_TOOLS.exists()` returning False; assert the helpful RuntimeError.
+
+### 4.2 Updated (`tests/unit/pipeline/test_n6.py`)
+
+- `TestForkRepo`: call `_fork_repo("org", "repo", "ghp_fake_campaign")` directly with the token as third positional arg. Drop the `_fake_classic_pat` mock — `_fork_repo` no longer opens any session.
+- `TestCreatePr`: call `_create_pr("org", "repo", "user:branch", "main", "title", "body", "ghp_fake_campaign")` with the token as last positional arg. Drop the `_fake_classic_pat` mock.
+- `test_propagates_classic_pat_decryption_failure`: move from `TestForkRepo` into a new home (or rename + relocate), test that `link_auditor_pat_session` exceptions propagate out of `n6_submit_pr` (not `_fork_repo`), because the session is opened at the orchestrator level now.
+- Happy-path tests (`test_happy_path_mocked`, `test_writes_tier1_pending_trust_on_success`, etc.): add a mock for `gh_link_auditor.pipeline.nodes.n6_submit_pr.link_auditor_pat_session` (using the same `_fake_classic_pat`-style helper, renamed `_fake_link_auditor_pat`). Without this, the test would try to gpg-decrypt the real file.
+
+### 4.3 New behavioral assertions
+
+- `test_n6_submit_pr_enters_session_exactly_once`: mock `link_auditor_pat_session` with a `MagicMock`-free counter (the project bans MagicMock; use a sentinel counter wrapping `contextmanager`), assert one entry per `n6_submit_pr` call.
+- `test_fork_repo_does_not_open_session`: with `link_auditor_pat_session` mocked to count entries, call `_fork_repo(..., "fake_pat")` directly and assert zero session entries.
+- `test_create_pr_does_not_open_session`: same as above for `_create_pr`.
+
+## 5. Operator workflow
+
+After the PR merges, the operator must do a **one-time setup** before the next submission:
+
+1. GitHub Settings → Developer settings → Personal access tokens → Tokens (classic) → Generate new token. Name: `gh-link-auditor-campaign`. Scope: `public_repo` only. Expiry: operator's call (1 year recommended).
+2. Save to clipboard, then in terminal:
+   ```bash
+   mkdir -p ~/.secrets
+   cat /dev/clipboard | gpg -c -o ~/.secrets/link-auditor-pat.gpg
+   ```
+3. Per ADR-0216 surface checklist: clear clipboard (`Set-Clipboard -Value $null` PowerShell, or `echo -n "" | clip`); clear browser download history; verify no editor caches the PAT page.
+
+Until the operator does this, `link_auditor_pat_session()` raises `FileNotFoundError` with a helpful message including the gpg-encrypt command — same pattern as the existing admin-PAT shim.
+
+## 6. Acceptance
+
+- Code:
+  - `src/gh_link_auditor/classic_pat.py`: contains `LINK_AUDITOR_PAT_PATH`, `link_auditor_pat_session`. Does NOT contain `classic_pat_session` (removed; no callers in `src/`).
+  - `src/gh_link_auditor/pipeline/nodes/n6_submit_pr.py`: `_fork_repo(owner, repo, pat)` and `_create_pr(..., pat)` accept the token as a parameter. Neither helper opens a context manager. `n6_submit_pr` opens `link_auditor_pat_session` exactly once per call.
+- Tests:
+  - `tests/unit/test_classic_pat.py` exists with the cases in §4.1.
+  - `tests/unit/pipeline/test_n6.py` updated per §4.2 + §4.3.
+  - Full pytest GREEN. Coverage ≥95% on changed lines.
+- Lint: `ruff check .` clean; `ruff format .` no diffs.
+
+## 7. Out of scope
+
+- Subprocess isolation of PAT operations (alternative C in the discussion thread). Significant work; deferred.
+- GitHub App replacement (alternative D). Deferred to a separate research issue.
+- ADR-0216 text update — separate issue (AZ#1344), separate PR.
+- CLI heartbeat / startup acknowledgement fix — separate issue (#399), separate PR.
+- The `tools/` script PAT consumers (`add_test_workflow.py`, `file_python_guide_numpy_pr.py`). They keep using AssemblyZero's admin classic-PAT directly; they perform elevated-scope operations.
+
+## 8. Risk
+
+- **Operator setup gap.** Until the operator gpg-encrypts the new PAT to `~/.secrets/link-auditor-pat.gpg`, the next submission errors out with `FileNotFoundError`. Mitigation: the error message includes the exact gpg-encrypt command, mirroring the existing admin-PAT pattern.
+- **Wrong PAT scope chosen.** If the operator accidentally grants `repo` or `workflow` scope to the new PAT, the least-privilege benefit is partly lost. Mitigation: LLD step 1 explicitly says `public_repo` only.
+- **Test coverage gap during refactor.** Existing tests that mocked `classic_pat_session` need to mock `link_auditor_pat_session` instead. Missing one means the test hits the real `~/.secrets` file, which doesn't exist in CI/dev → fails. Mitigation: §4.2 enumerates every test needing the update; the lint+test gate catches any missed mock.

--- a/src/gh_link_auditor/classic_pat.py
+++ b/src/gh_link_auditor/classic_pat.py
@@ -1,19 +1,28 @@
-"""Lazy-import shim for AssemblyZero's classic-PAT context manager.
+"""Lazy-import shim for AssemblyZero's PAT context manager — campaign-scoped.
 
-The classic PAT is required for two operations the fine-grained PAT cannot
-perform: forking arbitrary public repos and opening cross-fork PRs (see
-issue #185). The PAT itself lives encrypted at ~/.secrets/classic-pat.gpg
-and is decrypted in-process by ``AssemblyZero/tools/_pat_session.py``
-(ADR-0216).
+The campaign-scoped classic PAT is used for two operations the fine-grained
+PAT cannot perform: forking arbitrary public repos and opening cross-fork
+PRs (see issue #185). It is least-privilege by design: ``public_repo`` scope
+only, no admin or workflow rights (see LLD-397-398, issue #397).
 
+The encrypted PAT lives at ``~/.secrets/link-auditor-pat.gpg`` and is
+decrypted in-process by ``AssemblyZero/tools/_pat_session.py`` (ADR-0216).
 This module does NOT import from AssemblyZero at module-load time. The
 sys.path manipulation and underlying import are deferred until the
-``classic_pat_session()`` function is actually called. This way:
+``link_auditor_pat_session()`` function is actually called. This way:
 
-- ``from gh_link_auditor.classic_pat import classic_pat_session`` is safe
-  to do anywhere (including CI where AssemblyZero isn't installed).
+- ``from gh_link_auditor.classic_pat import link_auditor_pat_session`` is
+  safe to do anywhere (including CI where AssemblyZero isn't installed).
 - The error message is clear if a caller invokes it without AssemblyZero
   present.
+
+Historical note: this module previously exported ``classic_pat_session``
+(admin-scope). That function was removed in #397/#398 because nothing in
+``src/`` consumed it — n6_submit_pr now uses the least-privilege shim
+below. The ``tools/`` scripts (``add_test_workflow.py``,
+``file_python_guide_numpy_pr.py``) import AssemblyZero's
+``_pat_session.classic_pat_session`` directly; they need elevated scope
+for their one-shot operations and are out of scope for this module.
 """
 
 from __future__ import annotations
@@ -24,28 +33,36 @@ from pathlib import Path
 from typing import Iterator
 
 ASSEMBLYZERO_TOOLS = Path.home() / "Projects" / "AssemblyZero" / "tools"
+LINK_AUDITOR_PAT_PATH = Path.home() / ".secrets" / "link-auditor-pat.gpg"
 
 
 @contextmanager
-def classic_pat_session() -> Iterator[str]:
-    """Yield the decrypted classic PAT for the duration of the with-block.
+def link_auditor_pat_session() -> Iterator[str]:
+    """Yield the decrypted campaign-scoped PAT for the with-block duration.
+
+    The PAT has ``public_repo`` scope only — enough to fork public repos
+    and open cross-fork PRs, nothing else. A leak's blast radius is
+    bounded to "spam PRs on public repos," not the admin-scope catastrophe
+    a leaked classic PAT would cause across the fleet.
 
     Raises:
         RuntimeError: If the AssemblyZero tools directory cannot be found.
         FileNotFoundError: From the underlying _pat_session if the encrypted
-            PAT file is missing.
-        Other exceptions: From the underlying _pat_session if gpg fails.
+            PAT file is missing. The error message includes the gpg-encrypt
+            one-time setup command per ADR-0216 surface checklist.
+        Other exceptions: From the underlying _pat_session if gpg fails
+            (timeout, max-retry exceeded, etc.).
     """
     if not ASSEMBLYZERO_TOOLS.exists():
         raise RuntimeError(
-            f"Classic PAT requires AssemblyZero at {ASSEMBLYZERO_TOOLS}. "
-            f"This pipeline node needs the elevated-scope token for forking "
-            f"external repos and opening cross-fork PRs (see issue #185)."
+            f"Campaign PAT requires AssemblyZero at {ASSEMBLYZERO_TOOLS}. "
+            f"See LLD-397-398 and AssemblyZero ADR-0216 / issue #1344 for "
+            f"the least-privilege PAT pattern."
         )
     if str(ASSEMBLYZERO_TOOLS) not in sys.path:
         sys.path.insert(0, str(ASSEMBLYZERO_TOOLS))
 
     from _pat_session import classic_pat_session as _real_session  # noqa: E402
 
-    with _real_session() as pat:
+    with _real_session(pat_path=LINK_AUDITOR_PAT_PATH) as pat:
         yield pat

--- a/src/gh_link_auditor/pipeline/nodes/n6_submit_pr.py
+++ b/src/gh_link_auditor/pipeline/nodes/n6_submit_pr.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import httpx
 
+from gh_link_auditor.classic_pat import link_auditor_pat_session
 from gh_link_auditor.pipeline.state import FixPatch, PipelineState
 
 logger = logging.getLogger(__name__)
@@ -62,13 +63,13 @@ def _run_gh(args: list[str], cwd: str | None = None) -> subprocess.CompletedProc
         raise RuntimeError(msg) from exc
 
 
-def _fork_repo(owner: str, repo: str) -> str:
-    """Fork a repository via the GitHub REST API + classic PAT.
+def _fork_repo(owner: str, repo: str, pat: str) -> str:
+    """Fork a repository via the GitHub REST API.
 
-    The fine-grained PAT can't fork arbitrary external repos (issue #185),
-    so we route this call through the classic PAT in-process context
-    manager (ADR-0216). The PAT lives only in the heap during the `with`
-    block.
+    The caller (``n6_submit_pr``) holds the decrypted campaign PAT in a
+    single ``with link_auditor_pat_session()`` block and passes the
+    token in; this helper does NOT open any context manager itself. See
+    LLD-397-398 (issue #398) for the single-decrypt rationale.
 
     Idempotent: POST /forks against an already-forked repo returns the
     existing fork.
@@ -76,18 +77,16 @@ def _fork_repo(owner: str, repo: str) -> str:
     Args:
         owner: Upstream repository owner.
         repo: Repository name.
+        pat: Decrypted campaign PAT (``public_repo`` scope, #397).
 
     Returns:
         Fork full name from the API response, e.g. "martymcenroe/flask".
     """
-    from gh_link_auditor.classic_pat import classic_pat_session
-
-    with classic_pat_session() as pat:
-        r = httpx.post(
-            f"{_GH_API}/repos/{owner}/{repo}/forks",
-            headers={**_GH_API_HEADERS_BASE, "Authorization": f"Bearer {pat}"},
-            timeout=_GH_API_TIMEOUT_S,
-        )
+    r = httpx.post(
+        f"{_GH_API}/repos/{owner}/{repo}/forks",
+        headers={**_GH_API_HEADERS_BASE, "Authorization": f"Bearer {pat}"},
+        timeout=_GH_API_TIMEOUT_S,
+    )
     if r.status_code >= 400:
         msg = f"GitHub fork API failed for {owner}/{repo}: HTTP {r.status_code} — {r.text[:200]}"
         raise RuntimeError(msg)
@@ -101,12 +100,14 @@ def _create_pr(
     base: str,
     title: str,
     body: str,
+    pat: str,
 ) -> tuple[str, int]:
-    """Open a cross-fork PR via the GitHub REST API + classic PAT.
+    """Open a cross-fork PR via the GitHub REST API.
 
-    The fine-grained PAT can't open cross-fork PRs against arbitrary
-    external repos (issue #185), so this routes through the classic PAT
-    in-process context manager (ADR-0216).
+    The caller (``n6_submit_pr``) holds the decrypted campaign PAT in a
+    single ``with link_auditor_pat_session()`` block and passes the
+    token in; this helper does NOT open any context manager itself. See
+    LLD-397-398 (issue #398) for the single-decrypt rationale.
 
     Args:
         upstream_owner: Owner of the upstream (target) repo.
@@ -115,19 +116,17 @@ def _create_pr(
         base: Base branch on upstream (e.g. "main").
         title: PR title.
         body: PR body (Markdown).
+        pat: Decrypted campaign PAT (``public_repo`` scope, #397).
 
     Returns:
         Tuple of (html_url, pr_number) from the API response.
     """
-    from gh_link_auditor.classic_pat import classic_pat_session
-
-    with classic_pat_session() as pat:
-        r = httpx.post(
-            f"{_GH_API}/repos/{upstream_owner}/{upstream_repo}/pulls",
-            json={"title": title, "head": head, "base": base, "body": body},
-            headers={**_GH_API_HEADERS_BASE, "Authorization": f"Bearer {pat}"},
-            timeout=_GH_API_TIMEOUT_S,
-        )
+    r = httpx.post(
+        f"{_GH_API}/repos/{upstream_owner}/{upstream_repo}/pulls",
+        json={"title": title, "head": head, "base": base, "body": body},
+        headers={**_GH_API_HEADERS_BASE, "Authorization": f"Bearer {pat}"},
+        timeout=_GH_API_TIMEOUT_S,
+    )
     if r.status_code >= 400:
         msg = (
             f"GitHub PR-create API failed for {upstream_owner}/{upstream_repo} "
@@ -270,103 +269,109 @@ def n6_submit_pr(state: PipelineState) -> PipelineState:
         return state
 
     try:
-        # Step 1: Fork
-        fork_full_name = _fork_repo(repo_owner, repo_name_short)
-        logger.info("N6: Fork ready: %s", fork_full_name)
+        # Single classic-PAT session per submission (#398).
+        # Holds the campaign-scoped PAT (#397, public_repo only) in heap
+        # for the fork → clone → push → PR-create sequence. One pinentry
+        # prompt; one immutable-string copy in heap floating for GC.
+        with link_auditor_pat_session() as pat:
+            # Step 1: Fork
+            fork_full_name = _fork_repo(repo_owner, repo_name_short, pat)
+            logger.info("N6: Fork ready: %s", fork_full_name)
 
-        with tempfile.TemporaryDirectory(prefix="ghla-pr-") as tmp_dir:
-            work_dir = Path(tmp_dir)
+            with tempfile.TemporaryDirectory(prefix="ghla-pr-") as tmp_dir:
+                work_dir = Path(tmp_dir)
 
-            # Step 2: Clone fork
-            repo_dir = _clone_fork(fork_full_name, work_dir)
+                # Step 2: Clone fork
+                repo_dir = _clone_fork(fork_full_name, work_dir)
 
-            # Step 3: Create branch
-            branch_name = "fix/dead-links"
-            subprocess.run(
-                ["git", "checkout", "-b", branch_name],
-                cwd=str(repo_dir),
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                check=True,
-            )
+                # Step 3: Create branch
+                branch_name = "fix/dead-links"
+                subprocess.run(
+                    ["git", "checkout", "-b", branch_name],
+                    cwd=str(repo_dir),
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    check=True,
+                )
 
-            # Step 4: Apply fixes
-            modified = _apply_fixes(repo_dir, fixes)
-            if not modified:
-                logger.warning("N6: No files were modified after applying fixes")
-                return state
+                # Step 4: Apply fixes
+                modified = _apply_fixes(repo_dir, fixes)
+                if not modified:
+                    logger.warning("N6: No files were modified after applying fixes")
+                    return state
 
-            # Step 5: Commit
-            subprocess.run(
-                ["git", "add"] + modified,
-                cwd=str(repo_dir),
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                check=True,
-            )
-            commit_msg = _generate_commit_message(fixes)
-            subprocess.run(
-                ["git", "commit", "-m", commit_msg],
-                cwd=str(repo_dir),
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                check=True,
-            )
+                # Step 5: Commit
+                subprocess.run(
+                    ["git", "add"] + modified,
+                    cwd=str(repo_dir),
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    check=True,
+                )
+                commit_msg = _generate_commit_message(fixes)
+                subprocess.run(
+                    ["git", "commit", "-m", commit_msg],
+                    cwd=str(repo_dir),
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    check=True,
+                )
 
-            # Step 6: Push to fork
-            subprocess.run(
-                ["git", "push", "origin", branch_name],
-                cwd=str(repo_dir),
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                check=True,
-            )
+                # Step 6: Push to fork
+                subprocess.run(
+                    ["git", "push", "origin", branch_name],
+                    cwd=str(repo_dir),
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    check=True,
+                )
 
-            # Step 7: Generate PR title and body
-            from gh_link_auditor.pipeline.pr_message import (
-                generate_pr_body_from_fixes,
-                generate_pr_title_from_fixes,
-            )
+                # Step 7: Generate PR title and body
+                from gh_link_auditor.pipeline.pr_message import (
+                    generate_pr_body_from_fixes,
+                    generate_pr_title_from_fixes,
+                )
 
-            pr_title = generate_pr_title_from_fixes(fixes)
-            verdicts = state.get("reviewed_verdicts", [])
-            pr_body = generate_pr_body_from_fixes(fixes, verdicts)
+                pr_title = generate_pr_title_from_fixes(fixes)
+                verdicts = state.get("reviewed_verdicts", [])
+                pr_body = generate_pr_body_from_fixes(fixes, verdicts)
 
-            # Step 8: Create PR from fork → upstream (classic-PAT REST, #185)
-            default_branch = _get_default_branch(repo_owner, repo_name_short)
-            fork_owner = fork_full_name.split("/")[0]
+                # Step 8: Create PR (campaign PAT, #397/#398 — same `pat` as fork)
+                default_branch = _get_default_branch(repo_owner, repo_name_short)
+                fork_owner = fork_full_name.split("/")[0]
 
-            pr_url, pr_number = _create_pr(
-                upstream_owner=repo_owner,
-                upstream_repo=repo_name_short,
-                head=f"{fork_owner}:{branch_name}",
-                base=default_branch,
-                title=pr_title,
-                body=pr_body,
-            )
+                pr_url, pr_number = _create_pr(
+                    upstream_owner=repo_owner,
+                    upstream_repo=repo_name_short,
+                    head=f"{fork_owner}:{branch_name}",
+                    base=default_branch,
+                    title=pr_title,
+                    body=pr_body,
+                    pat=pat,
+                )
 
-            state["pr_url"] = pr_url
-            state["pr_number"] = pr_number
-            logger.info("N6: PR created: %s", pr_url)
+                state["pr_url"] = pr_url
+                state["pr_number"] = pr_number
+                logger.info("N6: PR created: %s", pr_url)
 
-            db_path = state.get("db_path")
-            if db_path:
-                from gh_link_auditor.pr_tracker import update_trust_on_submit
-                from gh_link_auditor.unified_db import UnifiedDatabase
+                db_path = state.get("db_path")
+                if db_path:
+                    from gh_link_auditor.pr_tracker import update_trust_on_submit
+                    from gh_link_auditor.unified_db import UnifiedDatabase
 
-                try:
-                    with UnifiedDatabase(db_path) as udb:
-                        update_trust_on_submit(udb, f"{repo_owner}/{repo_name_short}")
-                except Exception as trust_exc:
-                    logger.warning("N6: trust update skipped: %s", trust_exc)
+                    try:
+                        with UnifiedDatabase(db_path) as udb:
+                            update_trust_on_submit(udb, f"{repo_owner}/{repo_name_short}")
+                    except Exception as trust_exc:
+                        logger.warning("N6: trust update skipped: %s", trust_exc)
 
     except RuntimeError as exc:
         state["errors"] = state.get("errors", []) + [f"N6: {exc}"]

--- a/tests/unit/pipeline/test_n6.py
+++ b/tests/unit/pipeline/test_n6.py
@@ -36,6 +36,34 @@ def _make_fix(
     )
 
 
+@contextmanager
+def _fake_link_auditor_pat(token: str = "ghp_fake_campaign"):
+    """Module-level fake yielding a campaign-scoped token (#397/#398).
+
+    Used to mock ``link_auditor_pat_session`` in tests that invoke
+    ``n6_submit_pr`` — n6 opens this once per submission and passes the
+    yielded token down to ``_fork_repo`` and ``_create_pr``.
+    """
+    yield token
+
+
+class _SessionEntryCounter:
+    """Context-manager factory that counts entries (#398).
+
+    Used to assert ``n6_submit_pr`` enters the session exactly once and
+    that helper functions never open their own session.
+    """
+
+    def __init__(self, token: str = "ghp_fake_campaign") -> None:
+        self.entries = 0
+        self.token = token
+
+    @contextmanager
+    def __call__(self):
+        self.entries += 1
+        yield self.token
+
+
 class TestApplyFixes:
     """Tests for _apply_fixes()."""
 
@@ -214,6 +242,10 @@ class TestN6SubmitPr:
 
         with (
             patch(
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr.link_auditor_pat_session",
+                side_effect=_fake_link_auditor_pat,
+            ),
+            patch(
                 "gh_link_auditor.pipeline.nodes.n6_submit_pr._fork_repo",
                 return_value="testuser/repo",
             ),
@@ -254,6 +286,10 @@ class TestN6SubmitPr:
         readme.write_text("Check [link](https://old.example.com/page) here.\n")
 
         with (
+            patch(
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr.link_auditor_pat_session",
+                side_effect=_fake_link_auditor_pat,
+            ),
             patch(
                 "gh_link_auditor.pipeline.nodes.n6_submit_pr._fork_repo",
                 return_value="testuser/repo",
@@ -297,6 +333,10 @@ class TestN6SubmitPr:
 
         with (
             patch(
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr.link_auditor_pat_session",
+                side_effect=_fake_link_auditor_pat,
+            ),
+            patch(
                 "gh_link_auditor.pipeline.nodes.n6_submit_pr._fork_repo",
                 return_value="testuser/repo",
             ),
@@ -329,9 +369,15 @@ class TestN6SubmitPr:
         state["repo_name_short"] = "repo"
         state["fixes"] = [_make_fix()]
 
-        with patch(
-            "gh_link_auditor.pipeline.nodes.n6_submit_pr._fork_repo",
-            side_effect=RuntimeError("fork failed: permission denied"),
+        with (
+            patch(
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr.link_auditor_pat_session",
+                side_effect=_fake_link_auditor_pat,
+            ),
+            patch(
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr._fork_repo",
+                side_effect=RuntimeError("fork failed: permission denied"),
+            ),
         ):
             result = n6_submit_pr(state)
 
@@ -354,6 +400,10 @@ class TestN6SubmitPr:
 
         with (
             patch(
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr.link_auditor_pat_session",
+                side_effect=_fake_link_auditor_pat,
+            ),
+            patch(
                 "gh_link_auditor.pipeline.nodes.n6_submit_pr._fork_repo",
                 return_value="testuser/repo",
             ),
@@ -366,14 +416,85 @@ class TestN6SubmitPr:
 
         assert "pr_url" not in result
 
+    def test_enters_link_auditor_session_exactly_once(self, tmp_path: Path) -> None:
+        """#398: a successful submission must trigger exactly one pinentry.
+
+        Two `with link_auditor_pat_session()` blocks (the pre-refactor state)
+        would trigger pinentry twice and leave two PAT-byte copies in heap
+        for GC. One block is strictly better for both UX and security.
+        """
+        state = create_initial_state(target="https://github.com/org/repo")
+        state["target_type"] = "url"
+        state["repo_owner"] = "org"
+        state["repo_name_short"] = "repo"
+        state["fixes"] = [_make_fix()]
+        state["reviewed_verdicts"] = []
+
+        clone_dir = tmp_path / "repo"
+        clone_dir.mkdir()
+        readme = clone_dir / "README.md"
+        readme.write_text("Check [link](https://old.example.com/page) here.\n")
+
+        counter = _SessionEntryCounter()
+        with (
+            patch(
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr.link_auditor_pat_session",
+                side_effect=counter,
+            ),
+            patch(
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr._fork_repo",
+                return_value="testuser/repo",
+            ),
+            patch(
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr._clone_fork",
+                return_value=clone_dir,
+            ),
+            patch(
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr._get_default_branch",
+                return_value="main",
+            ),
+            patch(
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr._create_pr",
+                return_value=("https://github.com/org/repo/pull/42", 42),
+            ),
+            patch("subprocess.run", return_value=_mock_completed("")),
+        ):
+            result = n6_submit_pr(state)
+
+        assert counter.entries == 1, f"expected single decrypt, got {counter.entries}"
+        assert result.get("pr_url") == "https://github.com/org/repo/pull/42"
+
+    def test_propagates_link_auditor_session_failure_to_state_errors(self) -> None:
+        """#397/#398: a missing campaign PAT bubbles up as a state error.
+
+        When operator hasn't run the one-time gpg-encrypt for the
+        campaign PAT, link_auditor_pat_session raises. n6's existing
+        try/except surfaces it as a structured state["errors"] entry
+        — same shape as fork-failure / git-failure handling.
+        """
+        state = create_initial_state(target="https://github.com/org/repo")
+        state["target_type"] = "url"
+        state["repo_owner"] = "org"
+        state["repo_name_short"] = "repo"
+        state["fixes"] = [_make_fix()]
+
+        @contextmanager
+        def boom(*_a, **_kw):
+            raise RuntimeError("campaign PAT unavailable: file missing")
+            yield  # unreachable
+
+        with patch(
+            "gh_link_auditor.pipeline.nodes.n6_submit_pr.link_auditor_pat_session",
+            side_effect=boom,
+        ):
+            result = n6_submit_pr(state)
+
+        assert any("campaign PAT unavailable" in e for e in result.get("errors", []))
+        assert "pr_url" not in result
+
 
 class TestForkRepo:
-    """Tests for _fork_repo() — classic-PAT REST implementation (issue #185)."""
-
-    @staticmethod
-    @contextmanager
-    def _fake_classic_pat(token: str = "ghp_fake_classic"):
-        yield token
+    """Tests for _fork_repo() — caller-provides-PAT (issue #398)."""
 
     def test_returns_fork_full_name(self) -> None:
         from gh_link_auditor.pipeline.nodes.n6_submit_pr import _fork_repo
@@ -383,19 +504,13 @@ class TestForkRepo:
             status_code=202,
             body={"full_name": "martymcenroe/upstream-repo"},
         )
-        with (
-            patch(
-                "gh_link_auditor.classic_pat.classic_pat_session",
-                side_effect=self._fake_classic_pat,
-            ),
-            patch("httpx.post", return_value=fake_response) as mock_post,
-        ):
-            result = _fork_repo("upstream-org", "upstream-repo")
+        with patch("httpx.post", return_value=fake_response) as mock_post:
+            result = _fork_repo("upstream-org", "upstream-repo", "ghp_fake_campaign")
 
         assert result == "martymcenroe/upstream-repo"
         assert mock_post.call_args.args[0] == "https://api.github.com/repos/upstream-org/upstream-repo/forks"
         headers = mock_post.call_args.kwargs["headers"]
-        assert headers["Authorization"] == "Bearer ghp_fake_classic"
+        assert headers["Authorization"] == "Bearer ghp_fake_campaign"
         assert headers["Accept"] == "application/vnd.github+json"
 
     def test_raises_on_api_error(self) -> None:
@@ -403,39 +518,39 @@ class TestForkRepo:
         from tests.fakes.http import FakeHTTPResponse
 
         fake_response = FakeHTTPResponse(status_code=403, body={"message": "forbidden"})
+        with patch("httpx.post", return_value=fake_response):
+            with pytest.raises(Exception):
+                _fork_repo("org", "repo", "ghp_fake_campaign")
+
+    def test_does_not_open_session_internally(self) -> None:
+        """#398: _fork_repo must NOT open link_auditor_pat_session itself.
+
+        The caller (n6_submit_pr) owns the PAT context. Helpers receive
+        the decrypted token as a parameter so the whole submission lives
+        inside one with-block (single decrypt + single heap copy).
+        """
+        from gh_link_auditor.pipeline.nodes.n6_submit_pr import _fork_repo
+        from tests.fakes.http import FakeHTTPResponse
+
+        counter = _SessionEntryCounter()
+        fake_response = FakeHTTPResponse(
+            status_code=202,
+            body={"full_name": "martymcenroe/upstream-repo"},
+        )
         with (
             patch(
-                "gh_link_auditor.classic_pat.classic_pat_session",
-                side_effect=self._fake_classic_pat,
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr.link_auditor_pat_session",
+                side_effect=counter,
             ),
             patch("httpx.post", return_value=fake_response),
         ):
-            with pytest.raises(Exception):
-                _fork_repo("org", "repo")
+            _fork_repo("org", "repo", "ghp_fake_campaign")
 
-    def test_propagates_classic_pat_decryption_failure(self) -> None:
-        from gh_link_auditor.pipeline.nodes.n6_submit_pr import _fork_repo
-
-        @contextmanager
-        def boom(*_a, **_kw):
-            raise RuntimeError("classic PAT unavailable")
-            yield  # unreachable
-
-        with patch(
-            "gh_link_auditor.classic_pat.classic_pat_session",
-            side_effect=boom,
-        ):
-            with pytest.raises(RuntimeError, match="classic PAT"):
-                _fork_repo("org", "repo")
+        assert counter.entries == 0, "helper opened a session it should not own"
 
 
 class TestCreatePr:
-    """Tests for _create_pr() — classic-PAT REST implementation (issue #185)."""
-
-    @staticmethod
-    @contextmanager
-    def _fake_classic_pat(token: str = "ghp_fake_classic"):
-        yield token
+    """Tests for _create_pr() — caller-provides-PAT (issue #398)."""
 
     def test_returns_url_and_number(self) -> None:
         from gh_link_auditor.pipeline.nodes.n6_submit_pr import _create_pr
@@ -448,18 +563,14 @@ class TestCreatePr:
                 "number": 42,
             },
         )
-        with (
-            patch(
-                "gh_link_auditor.classic_pat.classic_pat_session",
-                side_effect=self._fake_classic_pat,
-            ),
-            patch("httpx.post", return_value=fake_response) as mock_post,
-        ):
-            url, number = _create_pr("org", "repo", "user:branch", "main", "title", "body")
+        with patch("httpx.post", return_value=fake_response) as mock_post:
+            url, number = _create_pr("org", "repo", "user:branch", "main", "title", "body", "ghp_fake_campaign")
 
         assert url == "https://github.com/org/repo/pull/42"
         assert number == 42
         assert mock_post.call_args.args[0] == "https://api.github.com/repos/org/repo/pulls"
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer ghp_fake_campaign"
         payload = mock_post.call_args.kwargs["json"]
         assert payload == {
             "title": "title",
@@ -473,15 +584,30 @@ class TestCreatePr:
         from tests.fakes.http import FakeHTTPResponse
 
         fake_response = FakeHTTPResponse(status_code=422, body={"message": "invalid"})
+        with patch("httpx.post", return_value=fake_response):
+            with pytest.raises(Exception):
+                _create_pr("org", "repo", "user:branch", "main", "t", "b", "ghp_fake_campaign")
+
+    def test_does_not_open_session_internally(self) -> None:
+        """#398: _create_pr must NOT open link_auditor_pat_session itself."""
+        from gh_link_auditor.pipeline.nodes.n6_submit_pr import _create_pr
+        from tests.fakes.http import FakeHTTPResponse
+
+        counter = _SessionEntryCounter()
+        fake_response = FakeHTTPResponse(
+            status_code=201,
+            body={"html_url": "https://github.com/org/repo/pull/42", "number": 42},
+        )
         with (
             patch(
-                "gh_link_auditor.classic_pat.classic_pat_session",
-                side_effect=self._fake_classic_pat,
+                "gh_link_auditor.pipeline.nodes.n6_submit_pr.link_auditor_pat_session",
+                side_effect=counter,
             ),
             patch("httpx.post", return_value=fake_response),
         ):
-            with pytest.raises(Exception):
-                _create_pr("org", "repo", "user:branch", "main", "t", "b")
+            _create_pr("org", "repo", "user:branch", "main", "t", "b", "ghp_fake_campaign")
+
+        assert counter.entries == 0, "helper opened a session it should not own"
 
 
 class TestCloneFork:

--- a/tests/unit/test_classic_pat.py
+++ b/tests/unit/test_classic_pat.py
@@ -1,0 +1,90 @@
+"""Tests for the gh_link_auditor.classic_pat shim module.
+
+See LLD-397-398 and AssemblyZero#1344 for the design rationale.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from gh_link_auditor.classic_pat import (
+    LINK_AUDITOR_PAT_PATH,
+    link_auditor_pat_session,
+)
+
+
+def test_link_auditor_pat_path_is_in_secrets_dir() -> None:
+    """The campaign PAT lives at ~/.secrets/link-auditor-pat.gpg.
+
+    Operators following the one-time setup in LLD-397-398 §5 will
+    gpg-encrypt to this exact path. Drift here breaks every submission.
+    """
+    assert LINK_AUDITOR_PAT_PATH == Path.home() / ".secrets" / "link-auditor-pat.gpg"
+
+
+def test_link_auditor_pat_path_is_separate_from_admin_classic_pat() -> None:
+    """#397: campaign PAT and admin PAT must NOT share a path.
+
+    Reusing ~/.secrets/classic-pat.gpg would re-introduce the asymmetric
+    blast radius the least-privilege design was created to avoid.
+    """
+    admin_classic_path = Path.home() / ".secrets" / "classic-pat.gpg"
+    assert LINK_AUDITOR_PAT_PATH != admin_classic_path
+
+
+def test_link_auditor_pat_session_is_callable() -> None:
+    """The shim is importable and callable without entering its context."""
+    assert callable(link_auditor_pat_session)
+
+
+def test_link_auditor_pat_session_raises_when_assemblyzero_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Missing AssemblyZero → RuntimeError naming both LLD-397-398 and AZ#1344.
+
+    Operators searching the chat for either reference should find the
+    error message and reach the setup runbook.
+    """
+    from gh_link_auditor import classic_pat
+
+    fake_missing = tmp_path / "definitely-not-here"
+    monkeypatch.setattr(classic_pat, "ASSEMBLYZERO_TOOLS", fake_missing)
+
+    with pytest.raises(RuntimeError, match="LLD-397-398"):
+        with classic_pat.link_auditor_pat_session():
+            pass
+
+
+def test_link_auditor_pat_session_forwards_path_to_underlying_real_session(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The shim must call _pat_session.classic_pat_session(pat_path=LINK_AUDITOR_PAT_PATH).
+
+    Passing the wrong path would silently decrypt the admin PAT,
+    silently re-introducing the asymmetric blast radius #397 fixed.
+    """
+    from gh_link_auditor import classic_pat
+
+    # Bypass the AssemblyZero existence gate without needing it installed.
+    monkeypatch.setattr(classic_pat, "ASSEMBLYZERO_TOOLS", tmp_path)
+
+    received_paths: list[Path | None] = []
+
+    @contextmanager
+    def fake_real_session(pat_path: Path | None = None):
+        received_paths.append(pat_path)
+        yield "ghp_fake_campaign_decrypted"
+
+    fake_module = types.ModuleType("_pat_session")
+    fake_module.classic_pat_session = fake_real_session  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "_pat_session", fake_module)
+
+    with classic_pat.link_auditor_pat_session() as pat:
+        assert pat == "ghp_fake_campaign_decrypted"
+
+    assert received_paths == [LINK_AUDITOR_PAT_PATH], f"shim called underlying with wrong path: {received_paths}"


### PR DESCRIPTION
## Summary

Two coupled fixes shipped together — both touch `n6_submit_pr.py` and `classic_pat.py`.

**#397 (least-privilege campaign PAT).** Adds `link_auditor_pat_session()` shim pointing at `~/.secrets/link-auditor-pat.gpg` (a NEW encrypted PAT with `public_repo` scope only). Removes the unused admin-scope `classic_pat_session()` shim from gh_link_auditor. Blast radius of a leaked campaign PAT drops from "admin everything across `martymcenroe/*`" to "spam PRs on public repos."

**#398 (single decrypt per submission).** Refactors `_fork_repo` and `_create_pr` to accept the decrypted PAT as a parameter; `n6_submit_pr` opens one `with link_auditor_pat_session() as pat:` block per submission instead of two. One pinentry prompt instead of two. One immutable-string PAT copy in heap floating for GC instead of two (per `_pat_session.py:14-18` — `del pat` does NOT zero bytes in CPython; fewer with-blocks is strictly safer).

Design and rationale in `docs/lld/active/LLD-397-398.md`.

## Operator post-merge action

**Required one-time setup** (per LLD-397-398 §5) before the next submission will work:

1. GitHub Settings → Developer settings → Personal access tokens → Tokens (classic) → Generate new token. Name: `gh-link-auditor-campaign`. Scope: `public_repo` ONLY. No admin/workflow.
2. Save PAT to clipboard, then:
   \`\`\`bash
   mkdir -p ~/.secrets
   cat /dev/clipboard | gpg -c -o ~/.secrets/link-auditor-pat.gpg
   \`\`\`
3. Clipboard / browser-history hygiene per ADR-0216 surface checklist.

Until step 2 runs, `n6_submit_pr` will fail fast with a `FileNotFoundError` whose message includes the gpg-encrypt command (same shape as the existing admin-PAT shim).

## Companion ADR update

[martymcenroe/AssemblyZero#1344](https://github.com/martymcenroe/AssemblyZero/issues/1344) — ADR-0216 update adding (a) least-privilege PAT guidance, (b) Python string-immutability honesty. Separate PR; can ship in either order.

## Test plan

- [x] `tests/unit/test_classic_pat.py` — new file, 5 tests, 100% coverage on `src/gh_link_auditor/classic_pat.py`
- [x] `tests/unit/pipeline/test_n6.py` — updated `TestForkRepo`/`TestCreatePr` for `pat` parameter; added `test_enters_link_auditor_session_exactly_once` + `test_propagates_link_auditor_session_failure_to_state_errors` + `_does_not_open_session_internally` for both helpers
- [x] `poetry run pytest` — 2625 passed, 2 skipped
- [x] `poetry run ruff check .` — clean
- [x] `poetry run ruff format .` — clean
- [ ] **Operator post-merge:** complete one-time setup above; run a real submission against a fresh test repo (or repeat the OasisLMF flow) to confirm one pinentry prompt and successful PR creation

Closes #397
Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)