### PR TITLE
chore(classic_pat): rename PAT path to link-auditor-classic-pat.gpg

### DIFF
--- a/docs/lld/active/LLD-397-398.md
+++ b/docs/lld/active/LLD-397-398.md
@@ -15,7 +15,7 @@ Both issues are independent but their fixes touch the same two files, share the 
 
 ## 2. Solution
 
-**Add a second encrypted PAT** scoped to `public_repo` only, at `~/.secrets/link-auditor-pat.gpg`. Add a new shim `link_auditor_pat_session()` in `src/gh_link_auditor/classic_pat.py` that wraps the existing parameterized `_pat_session.classic_pat_session(pat_path=...)` (already pat_path-aware at `AssemblyZero/tools/_pat_session.py:67`).
+**Add a second encrypted PAT** scoped to `public_repo` only, at `~/.secrets/link-auditor-classic-pat.gpg`. Add a new shim `link_auditor_pat_session()` in `src/gh_link_auditor/classic_pat.py` that wraps the existing parameterized `_pat_session.classic_pat_session(pat_path=...)` (already pat_path-aware at `AssemblyZero/tools/_pat_session.py:67`).
 
 **Refactor `n6_submit_pr`** to open exactly one `with link_auditor_pat_session() as pat:` block per submission, wrapping the fork-API call, the gh-CLI clone/edit/push work, and the PR-API call. The two private helpers `_fork_repo` and `_create_pr` accept the decrypted `pat` as a parameter and use it in the `Authorization: Bearer` header.
 
@@ -26,7 +26,7 @@ The admin-scope `classic_pat_session()` shim is **removed** from `src/gh_link_au
 ### 3.1 New constant + shim in `src/gh_link_auditor/classic_pat.py`
 
 ```python
-LINK_AUDITOR_PAT_PATH = Path.home() / ".secrets" / "link-auditor-pat.gpg"
+LINK_AUDITOR_PAT_PATH = Path.home() / ".secrets" / "link-auditor-classic-pat.gpg"
 
 @contextmanager
 def link_auditor_pat_session() -> Iterator[str]:
@@ -130,7 +130,7 @@ The campaign PAT lives in heap for the duration of the `with` block (~3-10s) ins
 
 ### 4.1 New (`tests/unit/test_classic_pat.py`)
 
-- `test_link_auditor_pat_path_constant_value`: `LINK_AUDITOR_PAT_PATH` equals `Path.home() / ".secrets" / "link-auditor-pat.gpg"`.
+- `test_link_auditor_pat_path_constant_value`: `LINK_AUDITOR_PAT_PATH` equals `Path.home() / ".secrets" / "link-auditor-classic-pat.gpg"`.
 - `test_link_auditor_pat_session_is_context_manager`: callable, returns a context manager.
 - `test_link_auditor_pat_session_yields_token_when_underlying_succeeds`: with `_pat_session.classic_pat_session` mocked to yield "ghp_fake_campaign", `link_auditor_pat_session()` yields the same.
 - `test_link_auditor_pat_session_passes_pat_path_to_underlying`: assert the underlying `_real_session` is invoked with `pat_path=LINK_AUDITOR_PAT_PATH`.
@@ -158,7 +158,7 @@ After the PR merges, the operator must do a **one-time setup** before the next s
 2. Save to clipboard, then in terminal:
    ```bash
    mkdir -p ~/.secrets
-   cat /dev/clipboard | gpg -c -o ~/.secrets/link-auditor-pat.gpg
+   cat /dev/clipboard | gpg -c -o ~/.secrets/link-auditor-classic-pat.gpg
    ```
 3. Per ADR-0216 surface checklist: clear clipboard (`Set-Clipboard -Value $null` PowerShell, or `echo -n "" | clip`); clear browser download history; verify no editor caches the PAT page.
 
@@ -185,6 +185,6 @@ Until the operator does this, `link_auditor_pat_session()` raises `FileNotFoundE
 
 ## 8. Risk
 
-- **Operator setup gap.** Until the operator gpg-encrypts the new PAT to `~/.secrets/link-auditor-pat.gpg`, the next submission errors out with `FileNotFoundError`. Mitigation: the error message includes the exact gpg-encrypt command, mirroring the existing admin-PAT pattern.
+- **Operator setup gap.** Until the operator gpg-encrypts the new PAT to `~/.secrets/link-auditor-classic-pat.gpg`, the next submission errors out with `FileNotFoundError`. Mitigation: the error message includes the exact gpg-encrypt command, mirroring the existing admin-PAT pattern.
 - **Wrong PAT scope chosen.** If the operator accidentally grants `repo` or `workflow` scope to the new PAT, the least-privilege benefit is partly lost. Mitigation: LLD step 1 explicitly says `public_repo` only.
 - **Test coverage gap during refactor.** Existing tests that mocked `classic_pat_session` need to mock `link_auditor_pat_session` instead. Missing one means the test hits the real `~/.secrets` file, which doesn't exist in CI/dev → fails. Mitigation: §4.2 enumerates every test needing the update; the lint+test gate catches any missed mock.

--- a/src/gh_link_auditor/classic_pat.py
+++ b/src/gh_link_auditor/classic_pat.py
@@ -5,7 +5,7 @@ PAT cannot perform: forking arbitrary public repos and opening cross-fork
 PRs (see issue #185). It is least-privilege by design: ``public_repo`` scope
 only, no admin or workflow rights (see LLD-397-398, issue #397).
 
-The encrypted PAT lives at ``~/.secrets/link-auditor-pat.gpg`` and is
+The encrypted PAT lives at ``~/.secrets/link-auditor-classic-pat.gpg`` and is
 decrypted in-process by ``AssemblyZero/tools/_pat_session.py`` (ADR-0216).
 This module does NOT import from AssemblyZero at module-load time. The
 sys.path manipulation and underlying import are deferred until the
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Iterator
 
 ASSEMBLYZERO_TOOLS = Path.home() / "Projects" / "AssemblyZero" / "tools"
-LINK_AUDITOR_PAT_PATH = Path.home() / ".secrets" / "link-auditor-pat.gpg"
+LINK_AUDITOR_PAT_PATH = Path.home() / ".secrets" / "link-auditor-classic-pat.gpg"
 
 
 @contextmanager

--- a/tests/unit/test_classic_pat.py
+++ b/tests/unit/test_classic_pat.py
@@ -19,12 +19,12 @@ from gh_link_auditor.classic_pat import (
 
 
 def test_link_auditor_pat_path_is_in_secrets_dir() -> None:
-    """The campaign PAT lives at ~/.secrets/link-auditor-pat.gpg.
+    """The campaign PAT lives at ~/.secrets/link-auditor-classic-pat.gpg.
 
     Operators following the one-time setup in LLD-397-398 §5 will
     gpg-encrypt to this exact path. Drift here breaks every submission.
     """
-    assert LINK_AUDITOR_PAT_PATH == Path.home() / ".secrets" / "link-auditor-pat.gpg"
+    assert LINK_AUDITOR_PAT_PATH == Path.home() / ".secrets" / "link-auditor-classic-pat.gpg"
 
 
 def test_link_auditor_pat_path_is_separate_from_admin_classic_pat() -> None:


### PR DESCRIPTION
## Summary

- Updates `LINK_AUDITOR_PAT_PATH` from `~/.secrets/link-auditor-pat.gpg` → `~/.secrets/link-auditor-classic-pat.gpg` to match the operator's chosen filename.
- Constant name stays `LINK_AUDITOR_PAT_PATH` (not `LINK_AUDITOR_CLASSIC_PAT_PATH`) so a future fine-grained swap only needs the file-path change, not a constant rename + call-site sweep.
- Updates `LLD-397-398.md`, the test assertion, and the module docstring to reflect the canonical filename.
- No behavioral change. Tests + lint clean.

## Test plan

- [x] `tests/unit/test_classic_pat.py::test_link_auditor_pat_path_is_in_secrets_dir` asserts the new path
- [x] Full pytest suite green (42 targeted + everything else)
- [x] `ruff check .` clean; `ruff format --check .` clean

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)