### PR TITLE
feat(preflight-C5): tune subagent prompt to recognize trivial-difference URL pairs

### DIFF
--- a/docs/lld/active/LLD-349.md
+++ b/docs/lld/active/LLD-349.md
@@ -1,0 +1,118 @@
+# LLD-349: tune C5 subagent prompt for trivial-difference URL pairs
+
+**Issue:** #349
+**Status:** Active
+
+## 1. Problem
+
+The C5 "content equivalence" subagent (`prompts/preflight/content_equiv.txt`) too readily returns `unrelated` for URL pairs that share the same destination but differ in surface form (org-rename, query-string ordering, fragment differences, http→https, www↔non-www, etc.).
+
+Concrete evidence from `bulk-20260526T031148Z` preflight pass (2026-05-26):
+
+- **`act-now-coalition/covid-data-model`** — dead `https://github.com/covid-projections/covid-data-model/blob/main/Makefile` redirects (GitHub org-rename) to `https://github.com/act-now-coalition/covid-data-model/blob/main/Makefile`. All 10 hard gates PASS. Correctness score: 75/75 except C5 = 0/15. Subagent returned `unrelated` for a pair that GitHub itself treats as one canonical resource. Final score 65 (threshold 90) → `score_too_low` verdict → not surfaced for PR.
+
+The fast-path in `scores.py` (#340) already short-circuits the patterns we had hard evidence for (escape-only diff, `index.html` canonical, stray trailing chars, truncation, same-final-url redirect, percent-encoding equivalence). The subagent fall-through is the layer that needs the broader semantic guidance.
+
+## 2. Solution
+
+Rewrite `prompts/preflight/content_equiv.txt` with:
+
+1. An **URL-normalization instruction** that tells the subagent to compare normalized forms (lowercase host, strip default ports, normalize trailing-slash, sort query parameters, drop fragments-on-equal-path) before deciding.
+2. An **explicit "fix patterns" framing** so the subagent recognizes that the dead URL is by definition the broken form and the candidate is by definition the proposed correction — a healthy bias toward `clean` when the candidate page renders the same content.
+3. An **examples block** showing 5-7 concrete patterns (org-rename, query-string ordering, http→https, www↔non-www, fragment-only, trailing-slash) that should be classified `clean` so the subagent has anchors for the rule.
+4. Tighter `unrelated` boundary: reserve for genuinely different content (different page, different concept, different service / landing / login).
+
+No code changes outside the prompt + the matching golden file + any required test additions. The subagent invocation in `gates.py` already passes all the context (dead_url, candidate_url, link_text, candidate_page) needed.
+
+## 3. Design
+
+### 3.1 New prompt structure
+
+Headed sections:
+
+```
+You are evaluating ... [unchanged purpose]
+
+Context provided: [unchanged]
+
+STEP 1 — Normalize before judging
+  - Lowercase the host
+  - Strip default ports (:80 for http, :443 for https)
+  - Normalize trailing slashes on paths (treat /foo and /foo/ as equal)
+  - Drop URL fragments (#anchor) when comparing
+  - Sort query parameters when comparing
+  - Recognize that http and https serving the same content are equivalent
+  - Recognize that www. and non-www. serving the same content are equivalent
+
+STEP 2 — Recognize "fix patterns"
+  Default bias: candidate is the proposed CORRECTION to a known-broken
+  dead URL. When the candidate page renders content related to the link
+  text, prefer `clean` even if the URL surface forms differ.
+
+STEP 3 — Choose the verdict
+
+  - `clean` — candidate is the same conceptual content as the link text
+    suggests, OR a normalized-equivalent URL serving the same content.
+    Examples:
+      - github.com/old-org/repo/blob/main/X → github.com/new-org/repo/blob/main/X
+        (GitHub repo rename — same content, new canonical URL)
+      - example.com/page?b=2&a=1 → example.com/page?a=1&b=2
+        (query reorder — same page)
+      - http://docs.example.com/ → https://docs.example.com/
+        (HTTPS upgrade — same site)
+      - example.com/page#section → example.com/page
+        (fragment difference — same page)
+      - example.com/page → www.example.com/page
+        (www variant — same page)
+
+  - `partial` — candidate is related but a different specific resource.
+    Example: link text says "installation page" but candidate is the
+    project home page that mentions installation in passing.
+
+  - `unrelated` — candidate is about a completely different topic, or is
+    a landing/login/sales page with no relation to the link text.
+
+Return EXACTLY ONE token ... [unchanged grammar]
+```
+
+### 3.2 Golden file
+
+`tests/golden/preflight/content_equiv.txt` mirror-updates to match the new prompt verbatim (`test_preflight_prompts.py::TestContentEquivPromptRender` asserts byte equality).
+
+### 3.3 No code change
+
+The subagent invocation in `gates.py` (where C5 is computed, around line 689 — `score_c5_content_equivalence`) doesn't change. It already reads `prompts/preflight/content_equiv.txt` at runtime; the new content takes effect on the next preflight invocation.
+
+## 4. Tests
+
+### 4.1 Updated
+
+- `tests/integration/test_preflight_prompts.py::TestContentEquivPromptRender` — keep the byte-match assertion. Update the golden via `--update-goldens` (per the test docstring).
+
+### 4.2 New
+
+Two unit tests asserting the new prompt content carries the load-bearing instructions (so a future "simplify the prompt" PR can't silently regress the normalization layer):
+
+- `test_content_equiv_prompt_has_normalization_step` — substring assertion for "Normalize before judging" + "trailing slashes" + "query parameters."
+- `test_content_equiv_prompt_has_org_rename_example` — substring assertion for "GitHub repo rename" so the org-rename example specifically is pinned.
+
+Both placed in `test_preflight_prompts.py`.
+
+### 4.3 Out of scope for this LLD
+
+- `@pytest.mark.live` integration test that actually calls a real subagent against a near-equivalent pair. The issue acceptance lists this as a goal but it's a separate test-infrastructure concern (live tests need credentials + flake budget). File as follow-up if needed.
+- Re-running the #314 audit. Will run preflight against the `bulk-20260526T031148Z` candidates after merge to demonstrate the `act-now-coalition` case now passes; report findings in the issue.
+
+## 5. Acceptance
+
+- `prompts/preflight/content_equiv.txt` carries the new structure described in §3.1.
+- `tests/golden/preflight/content_equiv.txt` matches byte-for-byte.
+- Two new substring tests in `test_preflight_prompts.py` assert load-bearing prompt content.
+- Full pytest suite passes; lint + format clean.
+- After merge: re-run preflight against `act-now-coalition/covid-data-model` from the `bulk-20260526T031148Z` run; verify the C5 verdict flips from `unrelated` to `clean` and the total score exceeds 90 → `pass` verdict.
+
+## 6. Risk
+
+- **Subagent over-rotates to `clean`.** If the new examples are too aggressive, the subagent might start classifying genuinely-different pages as `clean`. Mitigation: the examples explicitly contrast `clean` (same content under different URL form) against `partial` and `unrelated` (different content). Plus the hard gates (gate 1 anti-AI, gate 5 dead-URL-still-dead, gate 6 candidate-URL-alive, etc.) all stay in place — C5 over-rotation alone cannot push a bad candidate through.
+- **Existing `clean` cases regress.** Negligible — the new prompt is a superset of the old guidance (the old `clean`/`partial`/`unrelated` definitions remain; the new content adds normalization rules + examples).
+- **Golden-file regen is forgotten.** Caught by `test_preflight_prompts.py::TestContentEquivPromptRender` which is in the unit suite and runs on every push.

--- a/prompts/preflight/content_equiv.txt
+++ b/prompts/preflight/content_equiv.txt
@@ -10,15 +10,60 @@ The context below contains:
 - ``candidate_page``: an object with ``title``, ``h1``, ``body_snippet``
   (first ~200 chars) of the candidate URL's rendered page.
 
-Verdict rules:
+STEP 1 — Normalize before judging
 
-- ``clean`` — candidate page is clearly the same conceptual content as the
-  link text suggests. The user clicking the link gets what they expected.
-- ``partial`` — candidate page is related but not the same specific
+Two URLs that differ only in the following dimensions point to the same
+resource and should be treated as equivalent:
+
+- Host casing (``Example.com`` vs ``example.com``)
+- Default ports (``http://host:80`` vs ``http://host``;
+  ``https://host:443`` vs ``https://host``)
+- Trailing slash on a path (``/foo`` vs ``/foo/``)
+- URL fragment (``/page#section`` vs ``/page`` when the path is equal)
+- Query-parameter ordering (``?a=1&b=2`` vs ``?b=2&a=1``)
+- Protocol upgrade when the same server serves both (``http://docs.x.com``
+  vs ``https://docs.x.com``)
+- WWW prefix when both forms serve the same site (``example.com`` vs
+  ``www.example.com``)
+
+If after normalization the two URLs point to the same content, return
+``clean`` even if the surface forms differ.
+
+STEP 2 — Recognize "fix" patterns
+
+The dead URL is by definition the broken / stale form. The candidate URL
+is by definition the proposed correction. When the candidate page renders
+content related to the link text, bias toward ``clean``. The verdict
+``unrelated`` is reserved for genuine topical mismatch, not for "the URL
+looks different."
+
+STEP 3 — Choose the verdict
+
+- ``clean`` — candidate page is the same conceptual content as the link
+  text suggests, OR a normalized-equivalent URL serving the same content.
+  Concrete patterns that are ``clean``:
+    - ``https://github.com/old-org/repo/blob/main/X`` →
+      ``https://github.com/new-org/repo/blob/main/X``
+      (GitHub repo rename — same content, new canonical URL)
+    - ``https://example.com/page?b=2&a=1`` →
+      ``https://example.com/page?a=1&b=2``
+      (query reorder — same page)
+    - ``http://docs.example.com/`` → ``https://docs.example.com/``
+      (HTTPS upgrade — same site)
+    - ``https://example.com/page#section`` → ``https://example.com/page``
+      (fragment difference — same page)
+    - ``https://example.com/page`` → ``https://www.example.com/page``
+      (www variant — same page)
+    - ``https://example.com/Docs/Foo`` → ``https://example.com/docs/foo``
+      (case-only host difference on case-insensitive servers — same page)
+
+- ``partial`` — candidate page is related but a different specific
   resource. Example: link text says "installation page" but candidate is
   the project home page that mentions installation in passing.
+
 - ``unrelated`` — candidate page is about a completely different topic,
-  or is a landing/login/sales page with no relation to the link text.
+  or is a landing / login / sales page with no relation to the link
+  text. The verdict is about *content*, not URL form.
 
 Return EXACTLY ONE of the following tokens on the first line of your
 response, with no other output:

--- a/tests/golden/preflight/content_equiv.txt
+++ b/tests/golden/preflight/content_equiv.txt
@@ -10,15 +10,60 @@ The context below contains:
 - ``candidate_page``: an object with ``title``, ``h1``, ``body_snippet``
   (first ~200 chars) of the candidate URL's rendered page.
 
-Verdict rules:
+STEP 1 — Normalize before judging
 
-- ``clean`` — candidate page is clearly the same conceptual content as the
-  link text suggests. The user clicking the link gets what they expected.
-- ``partial`` — candidate page is related but not the same specific
+Two URLs that differ only in the following dimensions point to the same
+resource and should be treated as equivalent:
+
+- Host casing (``Example.com`` vs ``example.com``)
+- Default ports (``http://host:80`` vs ``http://host``;
+  ``https://host:443`` vs ``https://host``)
+- Trailing slash on a path (``/foo`` vs ``/foo/``)
+- URL fragment (``/page#section`` vs ``/page`` when the path is equal)
+- Query-parameter ordering (``?a=1&b=2`` vs ``?b=2&a=1``)
+- Protocol upgrade when the same server serves both (``http://docs.x.com``
+  vs ``https://docs.x.com``)
+- WWW prefix when both forms serve the same site (``example.com`` vs
+  ``www.example.com``)
+
+If after normalization the two URLs point to the same content, return
+``clean`` even if the surface forms differ.
+
+STEP 2 — Recognize "fix" patterns
+
+The dead URL is by definition the broken / stale form. The candidate URL
+is by definition the proposed correction. When the candidate page renders
+content related to the link text, bias toward ``clean``. The verdict
+``unrelated`` is reserved for genuine topical mismatch, not for "the URL
+looks different."
+
+STEP 3 — Choose the verdict
+
+- ``clean`` — candidate page is the same conceptual content as the link
+  text suggests, OR a normalized-equivalent URL serving the same content.
+  Concrete patterns that are ``clean``:
+    - ``https://github.com/old-org/repo/blob/main/X`` →
+      ``https://github.com/new-org/repo/blob/main/X``
+      (GitHub repo rename — same content, new canonical URL)
+    - ``https://example.com/page?b=2&a=1`` →
+      ``https://example.com/page?a=1&b=2``
+      (query reorder — same page)
+    - ``http://docs.example.com/`` → ``https://docs.example.com/``
+      (HTTPS upgrade — same site)
+    - ``https://example.com/page#section`` → ``https://example.com/page``
+      (fragment difference — same page)
+    - ``https://example.com/page`` → ``https://www.example.com/page``
+      (www variant — same page)
+    - ``https://example.com/Docs/Foo`` → ``https://example.com/docs/foo``
+      (case-only host difference on case-insensitive servers — same page)
+
+- ``partial`` — candidate page is related but a different specific
   resource. Example: link text says "installation page" but candidate is
   the project home page that mentions installation in passing.
+
 - ``unrelated`` — candidate page is about a completely different topic,
-  or is a landing/login/sales page with no relation to the link text.
+  or is a landing / login / sales page with no relation to the link
+  text. The verdict is about *content*, not URL form.
 
 Return EXACTLY ONE of the following tokens on the first line of your
 response, with no other output:

--- a/tests/integration/test_preflight_prompts.py
+++ b/tests/integration/test_preflight_prompts.py
@@ -54,6 +54,29 @@ class TestContentEquivPromptRender:
         assert content == golden
         assert "single token" in content.lower() or "exactly one" in content.lower()
 
+    def test_prompt_has_url_normalization_step(self):
+        """#349: subagent must be told to normalize before judging.
+
+        Pinning the normalization-step header + two of its load-bearing
+        dimensions (trailing-slash, query-parameter ordering) catches a
+        future "simplify the prompt" PR that drops the section entirely.
+        """
+        content = Path("prompts/preflight/content_equiv.txt").read_text(encoding="utf-8")
+        assert "Normalize before judging" in content
+        assert "trailing slash" in content.lower()
+        assert "query-parameter" in content.lower() or "query parameter" in content.lower()
+
+    def test_prompt_has_github_org_rename_example(self):
+        """#349: explicit GitHub-org-rename example anchors the C5 verdict.
+
+        The 2026-05-26 act-now-coalition/covid-data-model preflight was
+        rejected because the subagent classified an org-rename redirect
+        as `unrelated`. The example is the regression test against that.
+        """
+        content = Path("prompts/preflight/content_equiv.txt").read_text(encoding="utf-8")
+        assert "GitHub repo rename" in content
+        assert "old-org" in content and "new-org" in content
+
 
 class TestRedirectTargetPromptRender:
     def test_prompt_file_exists_and_has_grammar_instructions(self, update_goldens):


### PR DESCRIPTION
## Summary

Rewrites `prompts/preflight/content_equiv.txt` with three new sections (Normalize, Recognize fix patterns, Verdict block with 6 concrete `clean` examples). The motivating case is the 2026-05-26 `act-now-coalition/covid-data-model` preflight — a GitHub-canonical org-rename redirect was classified `unrelated` by the subagent, scoring 65/100 (threshold 90) and failing as `score_too_low`. New prompt explicitly anchors the GitHub-org-rename pattern as `clean`.

Design + rationale: `docs/lld/active/LLD-349.md`.

## Test plan

- [x] Golden file (`tests/golden/preflight/content_equiv.txt`) mirror-updated; byte-match test passes
- [x] Two new substring tests pin the load-bearing prompt content (Normalize header + GitHub-rename example) against future "simplify the prompt" regressions
- [x] Full pytest suite green (2627 passed +2 from this PR)
- [x] `ruff check .` clean; `ruff format --check .` clean
- [ ] **Post-merge verification** (operator runs): re-run preflight against `bulk-20260526T031148Z` candidates; confirm `act-now-coalition/covid-data-model` flips from `score_too_low` (65) to `pass` (≥90)

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)