### PR TITLE
chore(GEMINI.md): remove blocking session-handshake/ACK

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -13,17 +13,6 @@ That file contains core rules that apply to ALL projects and ALL agents:
 
 ---
 
-## 1. Session Initialization (The Handshake)
-
-**CRITICAL:** When a session begins:
-1. **Analyze:** Silently parse the provided `git status` or issue context.
-2. **Halt & Ask:** Your **FIRST** output must be exactly:
-   > "ACK. State determination complete. Please identify my model version."
-3. **Wait:** Do not proceed until the user replies (e.g., "3.0 Pro").
-4. **Update Identity:** Incorporate the version into your Metadata Tag for all future turns.
-
----
-
 ## 2. Execution Rules
 
 - **Authority:** `AssemblyZero:standards/0002-coding-standards` is the law for Git workflows.


### PR DESCRIPTION
Removes the `## Session Initialization (The Handshake)` section from GEMINI.md. It instructs the agent to emit an `ACK` and HALT until the user replies, which blocks the Antigravity CLI (`agy`) on auto-load. Operator-confirmed by direct test.

No-Issue: remove the blocking Gemini session-handshake/ACK from GEMINI.md -- it halts Antigravity CLI (agy) on auto-load. Operator-confirmed by direct test that agy prompts the ACK in repos that still carry it. Fleet consistency cleanup.